### PR TITLE
WIP less magic, more pkg_install

### DIFF
--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{
+_webi_run() {
 
 set -e
 set -u
@@ -75,7 +75,7 @@ webi_check() {
     set -e
 
     my_canonical_name="'$pkg_cmd_name' v$WEBI_VERSION"
-    if [ -n "$my_current_cmd" ] &&  "$my_current_cmd" != "$pkg_dst_cmd" ]; then
+    if [ -n "$my_current_cmd" ] && [ "$my_current_cmd" != "$pkg_dst_cmd" ]; then
         >&2 echo "WARN: possible conflict between $my_canonical_name and $pkg_current_version at $my_current_cmd"
         echo ""
     fi
@@ -290,3 +290,5 @@ rm -rf "$WEBI_TMP"
 # See? No magic. Just downloading and moving files.
 
 }
+
+_webi_run

--- a/golang/install.sh
+++ b/golang/install.sh
@@ -1,78 +1,93 @@
-set -e
-set -u
+#!/bin/bash
 
-GOBIN="${HOME}/go"
-GOBIN_REAL="${HOME}/.local/opt/go-bin-v${WEBI_VERSION}"
+# The custom install functions and variables are here.
+# The generic functions - version checks, download, extract, etc - are here:
+#   - https://github.com/webinstall/packages/branches/master/_webi/template.sh
 
-# The package is 'golang', but the command is 'go'
-pkg_cmd_name="go"
+{
+    set -e
+    set -u
 
-# NOTE: pkg_* variables can be defined here
-#       pkg_cmd_name
-#       pkg_src, pkg_src_bin, pkg_src_cmd
-#       pkg_dst, pkg_dst_bin, pkg_dst_cmd
-#
-# Their defaults are defined in _webi/template.sh at https://github.com/webinstall/packages
+    # These variables are special to the Go installer
+    GOBIN="${HOME}/go"
+    GOBIN_REAL="${HOME}/.local/opt/go-bin-v${WEBI_VERSION}"
 
-pkg_get_current_version() {
-    # 'go version' has output in this format:
-    #       go version go1.14.2 darwin/amd64
-    # This trims it down to just the version number:
-    #       1.14.2
-    echo "$(go version 2>/dev/null | head -n 1 | cut -d' ' -f3 | sed 's:go::')"
-}
+    # Every package should define these 6 variables
 
-pkg_format_cmd_version() {
-    # 'go v1.14.0' will be 'go1.14'
-    my_version=$(echo "$1" | sed 's:\.0::g')
-    echo "${pkg_cmd_name}${my_version}"
-}
+    # The package is 'golang', but the command is 'go'
+    pkg_cmd_name="go"
 
-pkg_link() {
-    # 'pkg_dst' will default to $HOME/.local/opt/go
-    # 'pkg_src' will be the installed version, such as to $HOME/.local/opt/go-v1.14.2
-    rm -rf "$pkg_dst"
-    ln -s "$pkg_src" "$pkg_dst"
+    # ~/.local/opt/go
+    pkg_dst_cmd="$WEBI_PREFIX/opt/go/bin/go"
+    pkg_dst="$WEBI_PREFIX/opt/go"
 
-    # Go has a special $GOBIN
+    # ~/.local/opt/go-v1.14.6/bin/go
+    pkg_src_cmd="$WEBI_PREFIX/opt/go-v$WEBI_VERSION/bin/go"
+    pkg_src_dir="$WEBI_PREFIX/opt/go-v$WEBI_VERSION"
+    pkg_src="$pkg_src_dir"
 
-    # 'GOBIN' is set above to "${HOME}/go"
-    # 'GOBIN_REAL' will be "${HOME}/.local/opt/go-bin-v${WEBI_VERSION}"
-    rm -rf "$GOBIN"
-    mkdir -p "$GOBIN_REAL/bin"
-    ln -s "$GOBIN_REAL" "$GOBIN"
-}
+    pkg_install() {
+        # mkdir -p ~/.local/opt
+        mkdir -p "$(dirname $pkg_src)"
 
-pkg_post_install() {
-    pkg_link
+        # mv ./go* ~/.local/opt/go-v1.14.6
+        mv ./go* "$pkg_src"
+    }
 
-    # web_path_add is defined in _webi/template.sh at https://github.com/webinstall/packages
-    # Updates PATH with
-    #       "$HOME/.local/opt/go"
-    webi_path_add "$pkg_dst_bin"
-    webi_path_add "$GOBIN/bin"
+    pkg_link() {
+        # 'pkg_dst' will default to $HOME/.local/opt/go
+        # 'pkg_src' will be the installed version, such as to $HOME/.local/opt/go-v1.14.6
+        rm -rf "$pkg_dst"
+        ln -s "$pkg_src" "$pkg_dst"
 
-    # Install x go
-    echo "Building go language tools..."
-    echo gopls
-    "$pkg_dst_cmd" get golang.org/x/tools/gopls > /dev/null #2>/dev/null
-    echo golint
-    "$pkg_dst_cmd" get golang.org/x/lint/golint > /dev/null #2>/dev/null
-    echo errcheck
-    "$pkg_dst_cmd" get github.com/kisielk/errcheck > /dev/null #2>/dev/null
-    echo gotags
-    "$pkg_dst_cmd" get github.com/jstemmer/gotags > /dev/null #2>/dev/null
-    echo goimports
-    "$pkg_dst_cmd" get golang.org/x/tools/cmd/goimports > /dev/null #2>/dev/null
-    echo gorename
-    "$pkg_dst_cmd" get golang.org/x/tools/cmd/gorename > /dev/null #2>/dev/null
-    echo gotype
-    "$pkg_dst_cmd" get golang.org/x/tools/cmd/gotype > /dev/null #2>/dev/null
-    echo stringer
-    "$pkg_dst_cmd" get golang.org/x/tools/cmd/stringer > /dev/null #2>/dev/null
-}
+        # Go has a special $GOBIN
 
-pkg_done_message() {
-    echo "Installed 'go' v$WEBI_VERSION to ~/.local/opt/go"
-    echo "Installed go 'x' tools to GOBIN=\$HOME/go/bin"
+        # 'GOBIN' is set above to "${HOME}/go"
+        # 'GOBIN_REAL' will be "${HOME}/.local/opt/go-bin-v${WEBI_VERSION}"
+        rm -rf "$GOBIN"
+        mkdir -p "$GOBIN_REAL/bin"
+        ln -s "$GOBIN_REAL" "$GOBIN"
+    }
+
+    pkg_post_install() {
+        pkg_link
+
+        # web_path_add is defined in _webi/template.sh at https://github.com/webinstall/packages
+        # Updates PATH with
+        #       "$HOME/.local/opt/go"
+        webi_path_add "$pkg_dst_bin"
+        webi_path_add "$GOBIN/bin"
+
+        # Install x go
+        echo "Building go language tools..."
+        echo gopls
+        "$pkg_dst_cmd" get golang.org/x/tools/gopls > /dev/null #2>/dev/null
+        echo golint
+        "$pkg_dst_cmd" get golang.org/x/lint/golint > /dev/null #2>/dev/null
+        echo errcheck
+        "$pkg_dst_cmd" get github.com/kisielk/errcheck > /dev/null #2>/dev/null
+        echo gotags
+        "$pkg_dst_cmd" get github.com/jstemmer/gotags > /dev/null #2>/dev/null
+        echo goimports
+        "$pkg_dst_cmd" get golang.org/x/tools/cmd/goimports > /dev/null #2>/dev/null
+        echo gorename
+        "$pkg_dst_cmd" get golang.org/x/tools/cmd/gorename > /dev/null #2>/dev/null
+        echo gotype
+        "$pkg_dst_cmd" get golang.org/x/tools/cmd/gotype > /dev/null #2>/dev/null
+        echo stringer
+        "$pkg_dst_cmd" get golang.org/x/tools/cmd/stringer > /dev/null #2>/dev/null
+    }
+
+    pkg_done_message() {
+        echo "Installed 'go' v$WEBI_VERSION to ~/.local/opt/go"
+        echo "Installed go 'x' tools to GOBIN=\$HOME/go/bin"
+    }
+
+    pkg_get_current_version() {
+        # 'go version' has output in this format:
+        #       go version go1.14.6 darwin/amd64
+        # This trims it down to just the version number:
+        #       1.14.6
+        echo "$(go version 2>/dev/null | head -n 1 | cut -d' ' -f3 | sed 's:go::')"
+    }
 }

--- a/hexyl/install.sh
+++ b/hexyl/install.sh
@@ -1,31 +1,45 @@
 #!/bin/bash
 
+# The custom install functions and variables are here.
+# The generic functions - version checks, download, extract, etc - are here:
+#   - https://github.com/webinstall/packages/branches/master/_webi/template.sh
+
 {
     set -e
     set -u
 
-    ###############
+    #################
     # Install hexyl #
-    ###############
+    #################
 
-    WEBI_SINGLE=true
+    # All 6 of these variables must be defined for every package
+    pkg_cmd_name="hexyl"
 
-    pkg_get_current_version() {
-      # 'hexyl --version' has output in this format:
-      #       hexyl 0.8.0
-      # This trims it down to just the version number:
-      #       0.8.0
-      echo $(hexyl --version 2>/dev/null | head -n 1 | cut -d' ' -f 2)
-    }
+    pkg_dst_cmd="$WEBI_PREFIX/bin/hexyl"
+    pkg_dst="$pkg_dst_cmd"
 
+    pkg_src_cmd="$WEBI_PREFIX/opt/hexyl-v$WEBI_VERSION/bin/hexyl"
+    pkg_src_dir="$WEBI_PREFIX/opt/hexyl-v$WEBI_VERSION"
+    pkg_src="$pkg_src_cmd"
+
+    # pkg_install must be defined for every package
     pkg_install() {
-        # ~/.local/
-        mkdir -p "$pkg_src_bin"
+        # mkdir -p ~/.local/opt/hexyl-v0.8.0/bin
+        mkdir -p "$(dirname "$pkg_src_cmd")"
 
         # mv ./hexyl-*/hexyl ~/.local/opt/hexyl-v0.8.0/bin/hexyl
         mv ./hexyl-*/hexyl "$pkg_src_cmd"
 
         # chmod a+x ~/.local/opt/hexyl-v0.8.0/bin/hexyl
         chmod a+x "$pkg_src_cmd"
+    }
+
+    # pkg_get_current_version is recommended, but (soon) not required
+    pkg_get_current_version() {
+      # 'hexyl --version' has output in this format:
+      #       hexyl 0.8.0
+      # This trims it down to just the version number:
+      #       0.8.0
+      echo $(hexyl --version 2>/dev/null | head -n 1 | cut -d' ' -f 2)
     }
 }

--- a/node/install.sh
+++ b/node/install.sh
@@ -1,44 +1,54 @@
 #!/bin/bash
 
-# "This is too simple" you say! "Where is the magic!?" you ask.
-# There is no magic!
-# The custom functions for node are here.
+# The custom install functions and variables are here.
 # The generic functions - version checks, download, extract, etc - are here:
 #   - https://github.com/webinstall/packages/branches/master/_webi/template.sh
 
-set -e
-set -u
+{
+    set -e
+    set -u
 
-pkg_cmd_name="node"
-#WEBI_SINGLE=""
+    # Every package should define these 6 variables
+    pkg_cmd_name="node"
 
-pkg_get_current_version() {
-    # 'node --version' has output in this format:
-    #       v12.8.0
-    # This trims it down to just the version number:
-    #       12.8.0
-    echo "$(node --version 2>/dev/null | head -n 1 | cut -d' ' -f1 | sed 's:^v::')"
-}
+    # ~/.local/opt/node
+    pkg_dst_cmd="$WEBI_PREFIX/opt/node/bin/node"
+    pkg_dst="$WEBI_PREFIX/opt/node"
 
-pkg_install() {
-    # mkdir -p $HOME/.local/opt
-    mkdir -p "$(dirname $pkg_src)"
+    # ~/.local/opt/node-v14.7.0/bin/node
+    pkg_src_cmd="$WEBI_PREFIX/opt/node-v$WEBI_VERSION/bin/node"
+    pkg_src_dir="$WEBI_PREFIX/opt/node-v$WEBI_VERSION"
+    pkg_src="$pkg_src_dir"
 
-    # mv ./node* "$HOME/.local/opt/node-v14.4.0"
-    mv ./"$pkg_cmd_name"* "$pkg_src"
-}
+    # pkg_install must be defined by each package
+    pkg_install() {
+        # mkdir -p ~/.local/opt
+        mkdir -p "$(dirname $pkg_src)"
 
-pkg_link() {
-    # rm -f "$HOME/.local/opt/node"
-    rm -f "$pkg_dst"
+        # mv ./node* ~/.local/opt/node-v14.7.0
+        mv ./node* "$pkg_src"
+    }
 
-    # ln -s "$HOME/.local/opt/node-v14.4.0" "$HOME/.local/opt/node"
-    ln -s "$pkg_src" "$pkg_dst"
+    pkg_link() {
+        # rm -f ~/.local/opt/node
+        rm -f "$pkg_dst"
 
-    # Node bugfix: use the correct version of node, even if PATH has a conflict
-    "$pkg_src"/bin/node "$pkg_src"/bin/npm config set scripts-prepend-node-path=true
-}
+        # ln -s ~/.local/opt/node-v14.7.0 ~/.local/opt/node
+        ln -s "$pkg_src" "$pkg_dst"
 
-pkg_done_message() {
-    echo "Installed 'node' and 'npm' at $pkg_dst"
+        # Node bugfix: use the correct version of node, even if PATH has a conflict
+        "$pkg_src"/bin/node "$pkg_src"/bin/npm config set scripts-prepend-node-path=true
+    }
+
+    pkg_done_message() {
+        echo "Installed 'node' and 'npm' at $pkg_dst"
+    }
+
+    pkg_get_current_version() {
+        # 'node --version' has output in this format:
+        #       v12.8.0
+        # This trims it down to just the version number:
+        #       12.8.0
+        echo "$(node --version 2>/dev/null | head -n 1 | cut -d' ' -f1 | sed 's:^v::')"
+    }
 }

--- a/rg/install.sh
+++ b/rg/install.sh
@@ -1,3 +1,9 @@
+#!/bin/bash
+
+# The custom install functions and variables are here.
+# The generic functions - version checks, download, extract, etc - are here:
+#   - https://github.com/webinstall/packages/branches/master/_webi/template.sh
+
 {
     set -e
     set -u
@@ -9,20 +15,39 @@
     # Every package should define these 6 variables
     pkg_cmd_name="rg"
 
-    pkg_dst_cmd="$HOME/.local/bin/rg"
+    # ~/.local/bin/rg
+    pkg_dst_cmd="$WEBI_PREFIX/bin/rg"
     pkg_dst="$pkg_dst_cmd"
 
-    pkg_src_cmd="$HOME/.local/opt/rg-v$WEBI_VERSION/bin/rg"
-    pkg_src_dir="$HOME/.local/opt/rg-v$WEBI_VERSION"
+    # ~/.local/opt/ripgrep-v12.1.1/bin/rg
+    pkg_src_cmd="$WEBI_PREFIX/opt/ripgrep-v$WEBI_VERSION/rg"
+    pkg_src_dir="$WEBI_PREFIX/opt/ripgrep-v$WEBI_VERSION"
     pkg_src="$pkg_src_cmd"
 
     # pkg_install must be defined by every package
     pkg_install() {
-        # ~/.local/opt/rg-v12.1.1/bin
-        mkdir -p "$(dirname $pkg_src_cmd)"
+        # mv ./ripgrep-*/rg ~/.local/opt/rg-v12.1.1
+        mv ./ripgrep-* "$pkg_src_dir"
+    }
 
-        # mv ./ripgrep-*/rg ~/.local/opt/rg-v12.1.1/bin/rg
-        mv ./ripgrep-*/rg "$pkg_src_cmd"
+    pkg_link() {
+        # 'pkg_dst' should be $HOME/.local/opt/<pkg> or $HOME/.local/bin/<cmd>
+        rm -rf "$pkg_dst"
+
+        # 'pkg_src' will be the installed version, such as to $HOME/.local/opt/<pkg>-v<version>
+        ln -s "$pkg_src" "$pkg_dst"
+
+        # update bash completions
+        # See https://serverfault.com/a/1013395/93930
+        rm -rf ~/.local/share/bash-completion/completions/rg.bash
+        mkdir -p ~/.local/share/bash-completion/completions/
+        ln -s "$pkg_src_dir/complete/rg.bash" ~/.local/share/bash-completion/completions/
+
+        # update fish completions
+        # See https://stackoverflow.com/a/20839388/151312
+        rm -rf ~/.config/fish/completions/rg.fish
+        mkdir -p ~/.config/fish/completions/
+        ln -s "$pkg_src_dir/complete/rg.fish" ~/.config/fish/completions/
     }
 
     # pkg_get_current_version is recommended, but (soon) not required


### PR DESCRIPTION
I think that the general patterns are well-established enough that it makes sense to move some of the installer code back into the `install.sh`

The upside is that the `install.sh` will be (hopefully) be easier to intuit without opening `template.sh`.

The downside is that `install.sh` will have more lines of bash.

- [ ] we don't actually need ` pkg_get_current_version` (we can use the file system install path)
- [ ] the most important and potentially unique commands are in `pkg_install`
    - (the `mv` from the extracted folder to the install path)
