### PR TITLE
fix brew on clean macos, remove group expansion

### DIFF
--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{
+function __bootstrap_webi() {
 
 set -e
 set -u
@@ -284,11 +284,13 @@ echo "Have a problem? Experience a bug? Please let us know:"
 echo "        https://github.com/webinstall/packages/issues"
 echo ""
 
-{
+function __init_installer() {
 
 {{ installer }}
 
 }
+
+__init_installer
 
 ##
 ##
@@ -354,3 +356,5 @@ rm -rf "$WEBI_TMP"
 # See? No magic. Just downloading and moving files.
 
 }
+
+__bootstrap_webi

--- a/brew/install.sh
+++ b/brew/install.sh
@@ -3,9 +3,23 @@
 set -e
 set -u
 
-{
+function _install_brew() {
     # Straight from https://brew.sh
     #/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+
+    needs_xcode="$(/usr/bin/xcode-select -p >/dev/null 2> /dev/null || echo "true")"
+    if [[ -n "${needs_xcode}" ]]
+    then
+        echo ""
+        echo ""
+        echo "ERROR: Run this command to install XCode Command Line Tools first:"
+        echo ""
+        echo "    xcode-select --install"
+        echo ""
+        echo "After the install, close this terminal, open a new one, and try again."
+        echo ""
+        exit 1
+    fi
 
     # From Straight from https://brew.sh
     if ! [ -d "$HOME/.local/opt/brew" ]; then
@@ -35,3 +49,5 @@ set -u
     echo '        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"'
     echo ""
 }
+
+_install_brew


### PR DESCRIPTION
# Test for XCode before installing Brew

Re: https://github.com/webinstall/webi-installers/issues/141

`brew` requires `git` and such. We can easily test for that before attempting to install (and we may want to copy that over to anything that needs git).

# Remove Group Expansion

We're switching from

```bash
{
  dostuff ...
}
```

to

```bash
function __dostuff() {
  dostuff ...
}
__dostuff()
```

Originally I introduced the grouping because it will cause an error if a script is not completely downloaded before it is run. However, it introduced some bad expansions in certain cases.

Using a function has the same benefits, but no known downsides (yet).