### PR TITLE
Added k9s installer

### DIFF
--- a/k9s/README.md
+++ b/k9s/README.md
@@ -1,0 +1,56 @@
+---
+title: K9s
+homepage: https://github.com/derailed/k9s
+tagline: |
+  K9s provides a terminal UI to interact with your Kubernetes clusters
+---
+
+### Updating `k9s`
+
+`webi k9s@stable`
+
+Use the `@beta` tag for pre-releases.
+
+## Cheat Sheet
+
+> `k9s` aim is to make it easier to navigate, observe and manage your applications in the wild. K9s continually watches Kubernetes for changes and offers subsequent commands to interact with your observed resources.
+
+### Preflight check
+
+K9s uses 256 colors terminal mode. On `Nix system make sure TERM is set accordingly.
+
+```bash
+export TERM=xterm-256color
+```
+
+To run k9s:
+```bash
+k9s
+```
+
+### Command line arguments
+
+List all available CLI options
+```bash
+k9s help
+```
+
+To get info about K9s runtime (logs, configs, etc..)
+```bash
+k9s info
+```
+
+To run K9s in a given namespace
+```bash
+k9s -n mycoolns
+```
+
+Start K9s in an existing KubeConfig context
+```bash
+k9s --context coolCtx
+```
+
+Start K9s in readonly mode - with all cluster modification commands disabled
+```bash
+k9s --readonly
+```

--- a/k9s/install.ps1
+++ b/k9s/install.ps1
@@ -1,0 +1,58 @@
+#!/usr/bin/env pwsh
+
+###############
+# Install k9s #
+###############
+
+# Every package should define these variables
+$pkg_cmd_name = "k9s"
+
+$pkg_dst_cmd = "$Env:USERPROFILE\.local\bin\k9s.exe"
+$pkg_dst = "$pkg_dst_cmd"
+
+$pkg_src_cmd = "$Env:USERPROFILE\.local\opt\k9s-v$Env:WEBI_VERSION\bin\k9s.exe"
+$pkg_src_bin = "$Env:USERPROFILE\.local\opt\k9s-v$Env:WEBI_VERSION\bin"
+$pkg_src_dir = "$Env:USERPROFILE\.local\opt\k9s-v$Env:WEBI_VERSION"
+$pkg_src = "$pkg_src_cmd"
+
+$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+
+# Fetch archive
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+{
+    # TODO: arch detection
+    echo "Downloading k9s from $Env:WEBI_PKG_URL to $pkg_download"
+    & curl.exe -A -L "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
+    & move "$pkg_download.part" "$pkg_download"
+}
+
+IF (!(Test-Path -Path "$pkg_src_cmd"))
+{
+    echo "Installing k9s"
+
+    # TODO: create package-specific temp directory
+    # Enter tmp
+    pushd .local\tmp
+
+        # Remove any leftover tmp cruft
+        Remove-Item -Path ".\k9s-v*" -Recurse -ErrorAction Ignore
+        Remove-Item -Path ".\k9s.exe" -Recurse -ErrorAction Ignore
+
+        # Unpack archive file into this temporary directory
+        # Windows BSD-tar handles zip. Imagine that.
+        echo "Unpacking $pkg_download"
+        & tar xf "$pkg_download"
+
+        # Settle unpacked archive into place
+        echo "Install Location: $pkg_src_cmd"
+        New-Item "$pkg_src_bin" -ItemType Directory -Force        
+        Move-Item -Path "k9s.exe" -Destination "$pkg_src_bin"
+
+    # Exit tmp
+    popd
+}
+
+echo "Copying into '$pkg_dst_cmd' from '$pkg_src_cmd'"
+Remove-Item -Path "$pkg_dst_cmd" -Recurse -ErrorAction Ignore
+Copy-Item -Path "$pkg_src" -Destination "$pkg_dst" -Recurse
+Remove-Item -Path "$pkg_src" -Recurse -ErrorAction Ignore

--- a/k9s/install.sh
+++ b/k9s/install.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+{
+    set -e
+    set -u
+
+    ##################
+    # Install k9s #
+    ##################
+
+    # Every package should define these 6 variables
+    pkg_cmd_name="k9s"
+
+    pkg_dst_cmd="$HOME/.local/bin/k9s"
+    pkg_dst="$pkg_dst_cmd"
+
+    pkg_src_cmd="$HOME/.local/opt/k9s-v$WEBI_VERSION/bin/k9s"
+    pkg_src_dir="$HOME/.local/opt/k9s-v$WEBI_VERSION"
+    pkg_src="$pkg_src_cmd"
+
+    # pkg_install must be defined by every package
+    pkg_install() {
+        # ~/.local/opt/k9s-v0.99.9/bin
+        mkdir -p "$(dirname $pkg_src_cmd)"
+
+        # mv ./k9s-*/k9s ~/.local/opt/k9s-v0.99.9/bin/k9s
+        mv k9s "$pkg_src_cmd"
+    }
+
+    # pkg_get_current_version is recommended, but (soon) not required
+    pkg_get_current_version() {
+        # 'k9s version' has output in this format:
+
+        # Version:    v0.24.2
+        # Commit:     f929114ae4679c89ca06b2833d8a0fca5f1ec69d
+        # Date:       2020-12-04T17:42:10Z
+
+        # This trims it down to just the version number:
+        # 0.24.2
+        echo $(k9s version 2>/dev/null | grep Version: | cut -d 'v' -f 2)
+    }
+
+}

--- a/k9s/releases.js
+++ b/k9s/releases.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var github = require('../_common/github.js');
+var owner = 'derailed';
+var repo = 'k9s';
+
+module.exports = function (request) {
+  return github(request, owner, repo).then(function (all) {
+    return all;
+  });
+};
+
+if (module === require.main) {
+  module.exports(require('@root/request')).then(function (all) {
+    all = require('../_webi/normalize.js')(all);
+    // just select the first 5 for demonstration
+    all.releases = all.releases.slice(0, 5);
+    console.info(JSON.stringify(all, null, 2));
+  });
+}


### PR DESCRIPTION
This is with reference to issue #170. I have created the install scripts and tested if the installation works. It worked without any errors on my system (Ubuntu 20.04). 

Added required preflight checks according to K9s documentation and some common command-line parameter options in the cheat sheet section. 

Adjusted `pkg_get_current_version` to work with the k9s version output. 