### PR TITLE
doc: correct readlink usage

### DIFF
--- a/caddy/README.md
+++ b/caddy/README.md
@@ -100,7 +100,7 @@ Using a user named `app` to run your services is common industry convention.
 You can use `setcap` to allow Caddy to use privileged ports.
 
 ```bash
-sudo setcap cap_net_bind_service=+ep $(readlink $(command -v caddy))
+sudo setcap cap_net_bind_service=+ep $(readlink -f $(command -v caddy))
 ```
 
 **systemd config**


### PR DESCRIPTION
Should use `readlink -f` which is correct whether or not the target is a link