### PR TITLE
Fix breaking newline

### DIFF
--- a/nerdfont/install.ps1
+++ b/nerdfont/install.ps1
@@ -6,9 +6,7 @@ $my_fontdir = "$Env:UserProfile\AppData\Local\Microsoft\Windows\Fonts"
 New-Item -Path "$my_fontdir" -ItemType Directory -Force | out-null
 IF (!(Test-Path -Path "$my_fontdir\$my_nerdfont_otf"))
 {
-
-    & curl.exe -fsSLo "$my_nerdfont_otf" 'https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/DroidSansMono/complete
-/Droid%20Sans%20Mono%20Nerd%20Font%20Complete%20Windows%20Compatible.otf'
+    & curl.exe -fsSLo "$my_nerdfont_otf" 'https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/DroidSansMono/complete/Droid%20Sans%20Mono%20Nerd%20Font%20Complete%20Windows%20Compatible.otf'
     & move "$my_nerdfont_otf" "$my_fontdir"
 }
 


### PR DESCRIPTION
New line causes the command to throw an exception instead of correctly installing font