### PR TITLE
Use the default webi_install method for gprox

### DIFF
--- a/gprox/install.sh
+++ b/gprox/install.sh
@@ -18,15 +18,6 @@
     pkg_src_dir="$HOME/.local/opt/gprox-v$WEBI_VERSION"
     pkg_src="$pkg_src_cmd"
 
-    # pkg_install must be defined by every package
-    pkg_install() {
-        # ~/.local/opt/gprox-v0.99.9/bin
-        mkdir -p "$(dirname $pkg_src_cmd)"
-
-        # mv ./gprox-*/gprox ~/.local/opt/gprox-v0.99.9/bin/gprox
-        mv ./gprox-*/gprox "$pkg_src_cmd"
-    }
-
     # pkg_get_current_version is recommended, but (soon) not required
     pkg_get_current_version() {
         # 'gprox --version' has output in this format:
@@ -35,5 +26,4 @@
         #       0.99.9
         echo $(gprox --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
     }
-
 }


### PR DESCRIPTION
This is just removing the `pkg_install` method and using the default, which seems to work. Fixes #264 