### PR TITLE
vim-nerdtree config ignores anything that starts with .git node_modules dist etc

### DIFF
--- a/vim-nerdtree/nerdtree.vim
+++ b/vim-nerdtree/nerdtree.vim
@@ -12,7 +12,7 @@ nnoremap <leader>f :NERDTreeFind<CR>
 let NERDTreeShowHidden=1
 
 " keep ignoring .git, node_modules, vendor, and dist
-let NERDTreeIgnore=["\.git", "node_modules", "vendor", "dist"]
+let NERDTreeIgnore=["\.git/", "node_modules/", "vendor/", "dist/"]
 
 " Start NERDTree when Vim is started without file arguments.
 autocmd StdinReadPre * let s:std_in=1


### PR DESCRIPTION
Ignore dirs with those names, not anything that starts with those strings.