### PR TITLE
namespace downloads to ~/Downloads/webi

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ WEBI_SINGLE=""
 
 ```bash
 webi_check              # Checks to see if the selected version is already installed (and re-links if so)
-webi_download           # Downloads the selected release to $HOME/Downloads/<package-name>.tar.gz
+webi_download           # Downloads the selected release to $HOME/Downloads/webi/<package-name>.tar.gz
 webi_extract            # Extracts the download to /tmp/<package-name>-<random>/
 webi_path_add /new/path # Adds /new/path to PATH for bash, zsh, and fish
 webi_pre_install        # Runs webi_check, webi_download, and webi_extract

--- a/_example/install.ps1
+++ b/_example/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\foobar-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\foobar-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/_example/install.ps1
+++ b/_example/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\foobar-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\foobar-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading foobar from $Env:WEBI_PKG_URL to $pkg_download"

--- a/_webi/bootstrap.sh
+++ b/_webi/bootstrap.sh
@@ -9,13 +9,14 @@ function __install_webi() {
     export WEBI_HOST
 
     echo ""
-    echo -e "Thanks for using webi to install '\e[32m${WEBI_PKG:-}\e[0m' on '\e[31m$(uname -s)/$(uname -m)\e[0m'."
+    printf "Thanks for using webi to install '\e[32m${WEBI_PKG:-}\e[0m' on '\e[31m$(uname -s)/$(uname -m)\e[0m'.\n"
     echo "Have a problem? Experience a bug? Please let us know:"
     echo "        https://github.com/webinstall/webi-installers/issues"
     echo ""
-    echo -e "\e[31mLovin'\e[0m it? Say thanks with a \e[34mStar on GitHub\e[0m:"
-    echo -e "        \e[32mhttps://github.com/webinstall/webi-installers\e[0m"
+    printf "\e[31mLovin'\e[0m it? Say thanks with a \e[34mStar on GitHub\e[0m:\n"
+    printf "        \e[32mhttps://github.com/webinstall/webi-installers\e[0m\n"
     echo ""
+
     WEBI_WELCOME=true
     export WEBI_WELCOME
 

--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -45,7 +45,7 @@ function __bootstrap_webi() {
     WEBI_TMP=${WEBI_TMP:-"$(mktemp -d -t webinstall-"${WEBI_PKG:-}".XXXXXXXX)"}
     export _webi_tmp="${_webi_tmp:-"$HOME/.local/opt/webi-tmp.d"}"
 
-    mkdir -p "$HOME/Downloads"
+    mkdir -p "$HOME/Downloads/webi"
     mkdir -p "$HOME/.local/bin"
     mkdir -p "$HOME/.local/opt"
 
@@ -150,7 +150,7 @@ function __bootstrap_webi() {
         if [ -n "${2:-}" ]; then
             my_dl="$2"
         else
-            my_dl="$HOME/Downloads/$WEBI_PKG_FILE"
+            my_dl="$HOME/Downloads/webi/$WEBI_PKG_FILE"
         fi
 
         WEBI_PKG_DOWNLOAD="${my_dl}"
@@ -200,20 +200,20 @@ function __bootstrap_webi() {
     webi_extract() {
         pushd "$WEBI_TMP" > /dev/null 2>&1
         if [ "tar" == "$WEBI_EXT" ]; then
-            echo "Extracting $HOME/Downloads/$WEBI_PKG_FILE"
-            tar xf "$HOME/Downloads/$WEBI_PKG_FILE"
+            echo "Extracting $HOME/Downloads/webi/$WEBI_PKG_FILE"
+            tar xf "$HOME/Downloads/webi/$WEBI_PKG_FILE"
         elif [ "zip" == "$WEBI_EXT" ]; then
-            echo "Extracting $HOME/Downloads/$WEBI_PKG_FILE"
-            unzip "$HOME/Downloads/$WEBI_PKG_FILE" > __unzip__.log
+            echo "Extracting $HOME/Downloads/webi/$WEBI_PKG_FILE"
+            unzip "$HOME/Downloads/webi/$WEBI_PKG_FILE" > __unzip__.log
         elif [ "exe" == "$WEBI_EXT" ]; then
-            echo "Moving $HOME/Downloads/$WEBI_PKG_FILE"
-            mv "$HOME/Downloads/$WEBI_PKG_FILE" .
+            echo "Moving $HOME/Downloads/webi/$WEBI_PKG_FILE"
+            mv "$HOME/Downloads/webi/$WEBI_PKG_FILE" .
         elif [ "xz" == "$WEBI_EXT" ]; then
-            echo "Inflating $HOME/Downloads/$WEBI_PKG_FILE"
-            unxz -c "$HOME/Downloads/$WEBI_PKG_FILE" > "$(basename "$WEBI_PKG_FILE")"
+            echo "Inflating $HOME/Downloads/webi/$WEBI_PKG_FILE"
+            unxz -c "$HOME/Downloads/webi/$WEBI_PKG_FILE" > "$(basename "$WEBI_PKG_FILE")"
         else
             # do nothing
-            echo "Failed to extract $HOME/Downloads/$WEBI_PKG_FILE"
+            echo "Failed to extract $HOME/Downloads/webi/$WEBI_PKG_FILE"
             exit 1
         fi
         popd > /dev/null 2>&1

--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -36,6 +36,7 @@ function __bootstrap_webi() {
     #PKG_FORMATS=
     WEBI_UA="$(uname -a)"
     WEBI_PKG_DOWNLOAD=""
+    WEBI_PKG_PATH="${HOME}/Downloads/webi/${PKG_NAME:-error}/${WEBI_VERSION:-latest}"
     export WEBI_HOST
 
     ##
@@ -45,7 +46,7 @@ function __bootstrap_webi() {
     WEBI_TMP=${WEBI_TMP:-"$(mktemp -d -t webinstall-"${WEBI_PKG:-}".XXXXXXXX)"}
     export _webi_tmp="${_webi_tmp:-"$HOME/.local/opt/webi-tmp.d"}"
 
-    mkdir -p "$HOME/Downloads/webi"
+    mkdir -p "${WEBI_PKG_PATH}"
     mkdir -p "$HOME/.local/bin"
     mkdir -p "$HOME/.local/opt"
 
@@ -106,7 +107,14 @@ function __bootstrap_webi() {
         my_current_cmd="$(command -v "$pkg_cmd_name")"
         set -e
         if [ -n "$my_current_cmd" ]; then
-            pkg_current_version="$(pkg_get_current_version 2> /dev/null | head -n 1)"
+            # TODO get version from symlink?
+            pkg_current_version=""
+            if [ -n "$(command -v pkg_get_current_version)" ]; then
+                pkg_current_version="$(
+                    pkg_get_current_version 2> /dev/null |
+                        head -n 1
+                )"
+            fi
             # remove trailing '.0's for golang's sake
             my_current_version="$(echo "$pkg_current_version" | sed 's:\.0::g')"
             my_src_version="$(echo "$WEBI_VERSION" | sed 's:\.0::g')"
@@ -150,7 +158,7 @@ function __bootstrap_webi() {
         if [ -n "${2:-}" ]; then
             my_dl="$2"
         else
-            my_dl="$HOME/Downloads/webi/$WEBI_PKG_FILE"
+            my_dl="${WEBI_PKG_PATH}/$WEBI_PKG_FILE"
         fi
 
         WEBI_PKG_DOWNLOAD="${my_dl}"
@@ -200,20 +208,20 @@ function __bootstrap_webi() {
     webi_extract() {
         pushd "$WEBI_TMP" > /dev/null 2>&1
         if [ "tar" == "$WEBI_EXT" ]; then
-            echo "Extracting $HOME/Downloads/webi/$WEBI_PKG_FILE"
-            tar xf "$HOME/Downloads/webi/$WEBI_PKG_FILE"
+            echo "Extracting ${WEBI_PKG_PATH}/$WEBI_PKG_FILE"
+            tar xf "${WEBI_PKG_PATH}/$WEBI_PKG_FILE"
         elif [ "zip" == "$WEBI_EXT" ]; then
-            echo "Extracting $HOME/Downloads/webi/$WEBI_PKG_FILE"
-            unzip "$HOME/Downloads/webi/$WEBI_PKG_FILE" > __unzip__.log
+            echo "Extracting ${WEBI_PKG_PATH}/$WEBI_PKG_FILE"
+            unzip "${WEBI_PKG_PATH}/$WEBI_PKG_FILE" > __unzip__.log
         elif [ "exe" == "$WEBI_EXT" ]; then
-            echo "Moving $HOME/Downloads/webi/$WEBI_PKG_FILE"
-            mv "$HOME/Downloads/webi/$WEBI_PKG_FILE" .
+            echo "Moving ${WEBI_PKG_PATH}/$WEBI_PKG_FILE"
+            mv "${WEBI_PKG_PATH}/$WEBI_PKG_FILE" .
         elif [ "xz" == "$WEBI_EXT" ]; then
-            echo "Inflating $HOME/Downloads/webi/$WEBI_PKG_FILE"
-            unxz -c "$HOME/Downloads/webi/$WEBI_PKG_FILE" > "$(basename "$WEBI_PKG_FILE")"
+            echo "Inflating ${WEBI_PKG_PATH}/$WEBI_PKG_FILE"
+            unxz -c "${WEBI_PKG_PATH}/$WEBI_PKG_FILE" > "$(basename "$WEBI_PKG_FILE")"
         else
             # do nothing
-            echo "Failed to extract $HOME/Downloads/webi/$WEBI_PKG_FILE"
+            echo "Failed to extract ${WEBI_PKG_PATH}/$WEBI_PKG_FILE"
             exit 1
         fi
         popd > /dev/null 2>&1

--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -305,12 +305,12 @@ function __bootstrap_webi() {
 
     if [[ -z ${WEBI_WELCOME:-} ]]; then
         echo ""
-        echo -e "Thanks for using webi to install '\e[32m${WEBI_PKG:-}\e[0m' on '\e[31m$(uname -s)/$(uname -m)\e[0m'."
+        printf "Thanks for using webi to install '\e[32m${WEBI_PKG:-}\e[0m' on '\e[31m$(uname -s)/$(uname -m)\e[0m'.\n"
         echo "Have a problem? Experience a bug? Please let us know:"
         echo "        https://github.com/webinstall/webi-installers/issues"
         echo ""
-        echo -e "\e[31mLovin'\e[0m it? Say thanks with a \e[34mStar on GitHub\e[0m:"
-        echo -e "        \e[32mhttps://github.com/webinstall/webi-installers\e[0m"
+        printf "\e[31mLovin'\e[0m it? Say thanks with a \e[34mStar on GitHub\e[0m:\n"
+        printf "        \e[32mhttps://github.com/webinstall/webi-installers\e[0m\n"
         echo ""
     fi
 

--- a/arc/install.ps1
+++ b/arc/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\archiver-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\archiver-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading archiver from $Env:WEBI_PKG_URL to $pkg_download"
@@ -40,7 +40,7 @@ IF (!(Test-Path -Path "$pkg_src_cmd"))
         Remove-Item -Path ".\arc.exe" -Recurse -ErrorAction Ignore
 
         # Move single binary into root of temporary folder
-        & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE" "arc.exe"
+        & move "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE" "arc.exe"
 
         # Settle unpacked archive into place
         echo "Install Location: $pkg_src_cmd"

--- a/arc/install.ps1
+++ b/arc/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\archiver-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\archiver-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/awless/install.ps1
+++ b/awless/install.ps1
@@ -16,6 +16,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\awless-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\awless-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/awless/install.ps1
+++ b/awless/install.ps1
@@ -16,11 +16,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\awless-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\awless-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE")) {
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
     # TODO: arch detection
     echo "Downloading awless from $Env:WEBI_PKG_URL to $pkg_download"
     & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"

--- a/bat/install.ps1
+++ b/bat/install.ps1
@@ -3,12 +3,12 @@
 $VERNAME = "$Env:PKG_NAME-v$Env:WEBI_VERSION.exe"
 $EXENAME = "$Env:PKG_NAME.exe"
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
-    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
-    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part"
-    & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part"
+    & move "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 }
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME"))
@@ -24,8 +24,8 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME"))
 
         # Unpack archive
         # Windows BSD-tar handles zip. Imagine that.
-        echo "Unpacking $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
-        & tar xf "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+        echo "Unpacking $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+        & tar xf "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
         # Move single binary into root of temporary folder
         & move "bat-*\$EXENAME" "$VERNAME"
 

--- a/caddy/install.ps1
+++ b/caddy/install.ps1
@@ -16,6 +16,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\caddy-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\caddy-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/caddy/install.ps1
+++ b/caddy/install.ps1
@@ -16,11 +16,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\caddy-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\caddy-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE")) {
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
     # TODO: arch detection
     echo "Downloading caddy from $Env:WEBI_PKG_URL to $pkg_download"
     & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"

--- a/chromedriver/install.ps1
+++ b/chromedriver/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\chromedriver-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\chromedriver-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/chromedriver/install.ps1
+++ b/chromedriver/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\chromedriver-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\chromedriver-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading chromedriver from $Env:WEBI_PKG_URL to $pkg_download"

--- a/comrak/install.ps1
+++ b/comrak/install.ps1
@@ -3,12 +3,12 @@
 $VERNAME = "$Env:PKG_NAME-v$Env:WEBI_VERSION.exe"
 $EXENAME = "$Env:PKG_NAME.exe"
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
-    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
-    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part"
-    & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part"
+    & move "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 }
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\.local\opt\$Env:PKG_NAME-v$Env:WEBI_VERSION\bin\$VERNAME"))
@@ -23,7 +23,7 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\opt\$Env:PKG_NAME-v$Env:WEBI_VERS
         Remove-Item -Path "$Env:PKG_NAME-v*" -Recurse -ErrorAction Ignore
 
         # Move single binary into root of temporary folder
-        & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE" "$VERNAME"
+        & move "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE" "$VERNAME"
 
         # Settle unpacked archive into place
         echo "New Name: $VERNAME"

--- a/curlie/install.ps1
+++ b/curlie/install.ps1
@@ -3,12 +3,12 @@
 $VERNAME = "$Env:PKG_NAME-v$Env:WEBI_VERSION.exe"
 $EXENAME = "$Env:PKG_NAME.exe"
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
-    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
-    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part"
-    & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part"
+    & move "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 }
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME"))
@@ -24,8 +24,8 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME"))
 
         # Unpack archive
         # Windows BSD-tar handles zip. Imagine that.
-        echo "Unpacking $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
-        & tar xf "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+        echo "Unpacking $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+        & tar xf "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
         # Move single binary into root of temporary folder
         & move "$EXENAME" "$VERNAME"
 

--- a/deno/install.ps1
+++ b/deno/install.ps1
@@ -1,13 +1,13 @@
 #!/usr/bin/env pwsh
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
-    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
     #Invoke-WebRequest https://nodejs.org/dist/v12.16.2/node-v12.16.2-win-x64.zip -OutFile node-v12.16.2-win-x64.zip
-    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part"
-    & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part"
+    & move "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 }
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\.local\opt\$Env:PKG_NAME-v$Env:WEBI_VERSION"))
@@ -23,8 +23,8 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\opt\$Env:PKG_NAME-v$Env:WEBI_VERS
 
         # Unpack archive
         # Windows BSD-tar handles zip. Imagine that.
-        echo "Unpacking $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
-        & tar xf "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+        echo "Unpacking $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+        & tar xf "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
         # Settle unpacked archive into place
         echo "New Name: $Env:PKG_NAME-v$Env:WEBI_VERSION"

--- a/dotenv-linter/install.ps1
+++ b/dotenv-linter/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\dotenv-linter-v$Env:WEBI_VERSION\bin
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\dotenv-linter-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading dotenv-linter from $Env:WEBI_PKG_URL to $pkg_download"

--- a/dotenv-linter/install.ps1
+++ b/dotenv-linter/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\dotenv-linter-v$Env:WEBI_VERSION\bin
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\dotenv-linter-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/dotenv/install.ps1
+++ b/dotenv/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\dotenv-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\dotenv-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading dotenv from $Env:WEBI_PKG_URL to $pkg_download"

--- a/dotenv/install.ps1
+++ b/dotenv/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\dotenv-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\dotenv-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/fd/install.ps1
+++ b/fd/install.ps1
@@ -3,12 +3,12 @@
 $VERNAME = "$Env:PKG_NAME-v$Env:WEBI_VERSION.exe"
 $EXENAME = "$Env:PKG_NAME.exe"
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
-    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
-    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part"
-    & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part"
+    & move "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 }
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME"))
@@ -24,8 +24,8 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME"))
 
         # Unpack archive
         # Windows BSD-tar handles zip. Imagine that.
-        echo "Unpacking $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
-        & tar xf "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+        echo "Unpacking $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+        & tar xf "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
         # Move single binary into root of temporary folder
         & move "$EXENAME" "$VERNAME"
 

--- a/ffmpeg/install.ps1
+++ b/ffmpeg/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\ffmpeg-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\ffmpeg-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/ffmpeg/install.ps1
+++ b/ffmpeg/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\ffmpeg-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\ffmpeg-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading ffmpeg from $Env:WEBI_PKG_URL to $pkg_download"

--- a/fzf/install.ps1
+++ b/fzf/install.ps1
@@ -3,12 +3,12 @@
 $VERNAME = "$Env:PKG_NAME-v$Env:WEBI_VERSION.exe"
 $EXENAME = "$Env:PKG_NAME.exe"
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
-    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
-    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part"
-    & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part"
+    & move "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 }
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME"))
@@ -24,8 +24,8 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME"))
 
         # Unpack archive
         # Windows BSD-tar handles zip. Imagine that.
-        echo "Unpacking $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
-        & tar xf "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+        echo "Unpacking $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+        & tar xf "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
         # Move single binary into root of temporary folder
         & move "$EXENAME" "$VERNAME"
 

--- a/gh/install.ps1
+++ b/gh/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\gh-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\gh-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading gh from $Env:WEBI_PKG_URL to $pkg_download"

--- a/gh/install.ps1
+++ b/gh/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\gh-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\gh-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/git/install.ps1
+++ b/git/install.ps1
@@ -1,8 +1,8 @@
 #!/usr/bin/env pwsh
 
 $pkg_cmd_name = "git"
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 $pkg_src = "$Env:USERPROFILE\.local\opt\$pkg_cmd_name-v$Env:WEBI_VERSION"
 

--- a/git/install.ps1
+++ b/git/install.ps1
@@ -1,6 +1,7 @@
 #!/usr/bin/env pwsh
 
 $pkg_cmd_name = "git"
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 $pkg_src = "$Env:USERPROFILE\.local\opt\$pkg_cmd_name-v$Env:WEBI_VERSION"

--- a/gitdeploy/install.ps1
+++ b/gitdeploy/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\gitdeploy-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\gitdeploy-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/gitdeploy/install.ps1
+++ b/gitdeploy/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\gitdeploy-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\gitdeploy-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading gitdeploy from $Env:WEBI_PKG_URL to $pkg_download"

--- a/gitea/install.ps1
+++ b/gitea/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\gitea-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\gitea-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading gitea from $Env:WEBI_PKG_URL to $pkg_download"
@@ -40,7 +40,7 @@ IF (!(Test-Path -Path "$pkg_src_cmd"))
         Remove-Item -Path ".\gitea.exe" -Recurse -ErrorAction Ignore
 
         # Move single binary into root of temporary folder
-        & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE" "gitea.exe"
+        & move "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE" "gitea.exe"
 
         # Settle unpacked archive into place
         echo "Install Location: $pkg_src_cmd"

--- a/gitea/install.ps1
+++ b/gitea/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\gitea-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\gitea-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/golang/install.ps1
+++ b/golang/install.ps1
@@ -1,6 +1,7 @@
 #!/usr/bin/env pwsh
 
 $pkg_cmd_name = "go"
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 $pkg_src = "$Env:USERPROFILE\.local\opt\$pkg_cmd_name-v$Env:WEBI_VERSION"

--- a/golang/install.ps1
+++ b/golang/install.ps1
@@ -1,8 +1,8 @@
 #!/usr/bin/env pwsh
 
 $pkg_cmd_name = "go"
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 $pkg_src = "$Env:USERPROFILE\.local\opt\$pkg_cmd_name-v$Env:WEBI_VERSION"
 

--- a/golang/install.sh
+++ b/golang/install.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 set -u
 
@@ -19,7 +20,10 @@ pkg_get_current_version() {
     #       go version go1.14.2 darwin/amd64
     # This trims it down to just the version number:
     #       1.14.2
-    echo "$(go version 2> /dev/null | head -n 1 | cut -d' ' -f3 | sed 's:go::')"
+    go version 2> /dev/null |
+        head -n 1 |
+        cut -d' ' -f3 |
+        sed 's:go::'
 }
 
 pkg_format_cmd_version() {
@@ -58,46 +62,55 @@ pkg_post_install() {
 
     # See https://pkg.go.dev/mod/golang.org/x/tools?tab=packages
 
+    my_install="install"
+    # note: we intend a lexical comparison, so this is correct
+    #shellcheck disable=SC2072
+    if [[ ${WEBI_VERSION} < "1.16" ]]; then
+        my_install="get"
+    fi
+
     echo ""
     echo godoc
-    "$pkg_dst_cmd" get golang.org/x/tools/cmd/godoc@latest > /dev/null #2>/dev/null
+    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/godoc@latest > /dev/null #2>/dev/null
 
     echo ""
     echo gopls
-    "$pkg_dst_cmd" get golang.org/x/tools/gopls@latest > /dev/null #2>/dev/null
+    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/gopls@latest > /dev/null #2>/dev/null
 
     echo ""
     echo guru
-    "$pkg_dst_cmd" get golang.org/x/tools/cmd/guru@latest > /dev/null #2>/dev/null
+    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/guru@latest > /dev/null #2>/dev/null
 
     echo ""
     echo golint
-    "$pkg_dst_cmd" get golang.org/x/lint/golint@latest > /dev/null #2>/dev/null
+    "$pkg_dst_cmd" "${my_install}" golang.org/x/lint/golint@latest > /dev/null #2>/dev/null
 
     echo ""
     echo goimports
-    "$pkg_dst_cmd" get golang.org/x/tools/cmd/goimports@latest > /dev/null #2>/dev/null
+    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/goimports@latest > /dev/null #2>/dev/null
 
     echo ""
     echo gomvpkg
-    "$pkg_dst_cmd" get golang.org/x/tools/cmd/gomvpkg@latest > /dev/null #2>/dev/null
+    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/gomvpkg@latest > /dev/null #2>/dev/null
 
     echo ""
     echo gorename
-    "$pkg_dst_cmd" get golang.org/x/tools/cmd/gorename@latest > /dev/null #2>/dev/null
+    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/gorename@latest > /dev/null #2>/dev/null
 
     echo ""
     echo gotype
-    "$pkg_dst_cmd" get golang.org/x/tools/cmd/gotype@latest > /dev/null #2>/dev/null
+    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/gotype@latest > /dev/null #2>/dev/null
 
     echo ""
     echo stringer
-    "$pkg_dst_cmd" get golang.org/x/tools/cmd/stringer@latest > /dev/null #2>/dev/null
+    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/stringer@latest > /dev/null #2>/dev/null
 
     echo ""
 }
 
 pkg_done_message() {
-    echo "Installed 'go' v$WEBI_VERSION to ~/.local/opt/go"
-    echo "Installed go 'x' tools to GOBIN=\$HOME/go/bin"
+    echo "Installed 'go v$WEBI_VERSION' to ~/.local/opt/go"
+    # note: literal $HOME on purpose
+    #shellcheck disable=SC2016
+    echo 'Installed go "x" tools to GOBIN=$HOME/go/bin'
 }

--- a/goreleaser/install.ps1
+++ b/goreleaser/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\goreleaser-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\goreleaser-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/goreleaser/install.ps1
+++ b/goreleaser/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\goreleaser-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\goreleaser-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading goreleaser from $Env:WEBI_PKG_URL to $pkg_download"

--- a/gpg/install.sh
+++ b/gpg/install.sh
@@ -11,7 +11,7 @@ function _install_gpg() {
     fi
 
     # Download the latest LTS
-    #curl -fsSL -o ~/Downloads/GnuPG-2.2.32.dmg 'https://sourceforge.net/projects/gpgosx/files/GnuPG-2.2.32.dmg/download'
+    #curl -fsSL -o ~/Downloads/webi/GnuPG-2.2.32.dmg 'https://sourceforge.net/projects/gpgosx/files/GnuPG-2.2.32.dmg/download'
     webi_download
     chmod a-w "${WEBI_PKG_DOWNLOAD}"
 
@@ -19,15 +19,15 @@ function _install_gpg() {
     hdiutil detach -quiet /Volumes/GnuPG* 2> /dev/null || true
     hdiutil attach -quiet -readonly "${WEBI_PKG_DOWNLOAD}"
 
-    # Extract (completely) to ~/Downloads/GnuGP-VERSION.d
+    # Extract (completely) to ~/Downloads/webi/GnuGP-VERSION.d
     # (and detach the DMG)
-    rm -rf ~/Downloads/GnuPG-"${WEBI_VERSION}".d
-    pkgutil --expand-full /Volumes/GnuPG*/*.pkg ~/Downloads/GnuPG-"${WEBI_VERSION}".d
+    rm -rf ~/Downloads/webi/GnuPG-"${WEBI_VERSION}".d
+    pkgutil --expand-full /Volumes/GnuPG*/*.pkg ~/Downloads/webi/GnuPG-"${WEBI_VERSION}".d
     hdiutil detach -quiet /Volumes/GnuPG*
 
     # Move to ~/.local/opt/gnugp (where it belongs!)
     if [[ ! -e ~/.local/opt/gnupg-"${WEBI_VERSION}" ]]; then
-        mv ~/Downloads/GnuPG-"${WEBI_VERSION}".d/GnuPG.pkg/Payload/ ~/.local/opt/gnupg-"${WEBI_VERSION}"
+        mv ~/Downloads/webi/GnuPG-"${WEBI_VERSION}".d/GnuPG.pkg/Payload/ ~/.local/opt/gnupg-"${WEBI_VERSION}"
     fi
 
     # Update symlink to latest

--- a/gprox/install.ps1
+++ b/gprox/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\gprox-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\gprox-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/gprox/install.ps1
+++ b/gprox/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\gprox-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\gprox-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading gprox from $Env:WEBI_PKG_URL to $pkg_download"

--- a/hugo/install.ps1
+++ b/hugo/install.ps1
@@ -16,11 +16,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\hugo-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\hugo-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE")) {
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
     # TODO: arch detection
     echo "Downloading hugo from $Env:WEBI_PKG_URL to $pkg_download"
     & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"

--- a/hugo/install.ps1
+++ b/hugo/install.ps1
@@ -16,6 +16,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\hugo-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\hugo-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/jq/install.ps1
+++ b/jq/install.ps1
@@ -3,12 +3,12 @@
 $VERNAME = "$Env:PKG_NAME-v$Env:WEBI_VERSION.exe"
 $EXENAME = "$Env:PKG_NAME.exe"
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
-    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
-    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part"
-    & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part"
+    & move "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 }
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME"))
@@ -23,8 +23,8 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME"))
         Remove-Item -Path "$Env:PKG_NAME-v*" -Recurse -ErrorAction Ignore
 
         # Move single binary into temporary folder
-        echo "Moving $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
-        & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE" "$VERNAME"
+        echo "Moving $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+        & move "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE" "$VERNAME"
 
         # Settle unpacked archive into place
         echo "New Name: $VERNAME"

--- a/k9s/install.ps1
+++ b/k9s/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\k9s-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\k9s-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/k9s/install.ps1
+++ b/k9s/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\k9s-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\k9s-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading k9s from $Env:WEBI_PKG_URL to $pkg_download"

--- a/keypairs/install.ps1
+++ b/keypairs/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\keypairs-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\keypairs-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading keypairs from $Env:WEBI_PKG_URL to $pkg_download"

--- a/keypairs/install.ps1
+++ b/keypairs/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\keypairs-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\keypairs-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/kind/install.ps1
+++ b/kind/install.ps1
@@ -14,6 +14,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\kind-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\kind-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))

--- a/kind/install.ps1
+++ b/kind/install.ps1
@@ -14,10 +14,10 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\kind-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\kind-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     echo "Downloading kind from $Env:WEBI_PKG_URL to $pkg_download"
     & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"

--- a/kubectx/install.ps1
+++ b/kubectx/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\kubectx-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\kubectx-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading kubectx from $Env:WEBI_PKG_URL to $pkg_download"

--- a/kubectx/install.ps1
+++ b/kubectx/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\kubectx-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\kubectx-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/kubens/install.ps1
+++ b/kubens/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\kubens-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\kubens-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading kubens from $Env:WEBI_PKG_URL to $pkg_download"

--- a/kubens/install.ps1
+++ b/kubens/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\kubens-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\kubens-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/lf/install.ps1
+++ b/lf/install.ps1
@@ -14,6 +14,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\lf-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\lf-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))

--- a/lf/install.ps1
+++ b/lf/install.ps1
@@ -14,10 +14,10 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\lf-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\lf-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     echo "Downloading lf from $Env:WEBI_PKG_URL to $pkg_download"
     & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"

--- a/lsd/install.ps1
+++ b/lsd/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\lsd-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\lsd-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading lsd from $Env:WEBI_PKG_URL to $pkg_download"

--- a/lsd/install.ps1
+++ b/lsd/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\lsd-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\lsd-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
-
 set -e
 set -u
 
 webi_download
 
-pushd ~/Downloads 2>&1 > /dev/null
+pushd ~/Downloads/webi 2>&1 > /dev/null
 
 if [ "Darwin" == "$(uname -s)" ]; then
-    curl -fsSL 'https://gist.githubusercontent.com/solderjs/8c36d132250163011c83bad8284975ee/raw/5a291955813743c20c12ca2d35c7b1bb34f8aecc/create-bootable-installer-for-os-x-el-capitan.sh' -o create-bootable-installer-for-os-x-el-capitan.sh
+    curl -fsSL 'https://gist.githubusercontent.com/coolaj86/8c36d132250163011c83bad8284975ee/raw/5a291955813743c20c12ca2d35c7b1bb34f8aecc/create-bootable-installer-for-os-x-el-capitan.sh' -o create-bootable-installer-for-os-x-el-capitan.sh
     bash create-bootable-installer-for-os-x-el-capitan.sh
 else
-    curl -fsSL 'https://gist.githubusercontent.com/solderjs/9834a45a6c21a41e8882698a00b55787/raw/c43061cd0c53ec675996f5cb66c7077e666aabd4/install-mac-tools.sh' -o install-mac-tools.sh
+    curl -fsSL 'https://gist.githubusercontent.com/coolaj86/9834a45a6c21a41e8882698a00b55787/raw/c43061cd0c53ec675996f5cb66c7077e666aabd4/install-mac-tools.sh' -o install-mac-tools.sh
     # TODO add xar to webinstall.dev
     sudo apt install libz-dev # needed for xar
     bash install-mac-tools.sh
     echo "WARN: may need a restart for hfsplus to be recognized by the kernel"
 
-    curl -fsSL 'https://gist.github.com/solderjs/04fd06560a8465a695337eb502f5b0e9/raw/0a06fb4dce91399d374d9a12958dabb48a9bd42a/empty.7400m.img.bz2' -o empty.7400m.img.bz2
+    curl -fsSL 'https://gist.github.com/coolaj86/04fd06560a8465a695337eb502f5b0e9/raw/0a06fb4dce91399d374d9a12958dabb48a9bd42a/empty.7400m.img.bz2' -o empty.7400m.img.bz2
 
-    curl -fsSL 'https://gist.githubusercontent.com/solderjs/9834a45a6c21a41e8882698a00b55787/raw/c43061cd0c53ec675996f5cb66c7077e666aabd4/linux-create-bootable-macos-recovery-image.sh' -o linux-create-bootable-macos-recovery-image.sh
+    curl -fsSL 'https://gist.githubusercontent.com/coolaj86/9834a45a6c21a41e8882698a00b55787/raw/c43061cd0c53ec675996f5cb66c7077e666aabd4/linux-create-bootable-macos-recovery-image.sh' -o linux-create-bootable-macos-recovery-image.sh
     bash linux-create-bootable-macos-recovery-image.sh
 fi
 
+mv ~/Downloads/webi/el-capitan.iso ~/Downloads/
 echo ""
-echo "Created $HOME/Downloads/el-capitan.iso"
+echo "Created ~/Downloads/el-capitan.iso"
 echo ""
 
 popd 2>&1 > /dev/null

--- a/mutagen/install.ps1
+++ b/mutagen/install.ps1
@@ -14,6 +14,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\mutagen-v$Env:WEBI_VERSION"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\mutagen-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))

--- a/mutagen/install.ps1
+++ b/mutagen/install.ps1
@@ -14,10 +14,10 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\mutagen-v$Env:WEBI_VERSION"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\mutagen-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     echo "Downloading mutagen from $Env:WEBI_PKG_URL to $pkg_download"
     & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"

--- a/node/install.ps1
+++ b/node/install.ps1
@@ -1,13 +1,13 @@
 #!/usr/bin/env pwsh
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
-    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
     #Invoke-WebRequest https://nodejs.org/dist/v12.16.2/node-v12.16.2-win-x64.zip -OutFile node-v12.16.2-win-x64.zip
-    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part"
-    & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part"
+    & move "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 }
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\.local\opt\$Env:PKG_NAME-v$Env:WEBI_VERSION"))
@@ -23,8 +23,8 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\opt\$Env:PKG_NAME-v$Env:WEBI_VERS
 
         # Unpack archive
         # Windows BSD-tar handles zip. Imagine that.
-        echo "Unpacking $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
-        & tar xf "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+        echo "Unpacking $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+        & tar xf "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
         # Settle unpacked archive into place
         echo "New Name: $Env:PKG_NAME-v$Env:WEBI_VERSION"

--- a/node/install.sh
+++ b/node/install.sh
@@ -17,7 +17,10 @@ pkg_get_current_version() {
     #       v12.8.0
     # This trims it down to just the version number:
     #       12.8.0
-    echo "$(node --version 2> /dev/null | head -n 1 | cut -d' ' -f1 | sed 's:^v::')"
+    node --version 2> /dev/null |
+        head -n 1 |
+        cut -d' ' -f1 |
+        sed 's:^v::'
 }
 
 pkg_install() {

--- a/pandoc/install.ps1
+++ b/pandoc/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\pandoc-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\pandoc-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/pandoc/install.ps1
+++ b/pandoc/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\pandoc-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\pandoc-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading pandoc from $Env:WEBI_PKG_URL to $pkg_download"

--- a/rclone/install.ps1
+++ b/rclone/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\rclone-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\rclone-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading rclone from $Env:WEBI_PKG_URL to $pkg_download"

--- a/rclone/install.ps1
+++ b/rclone/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\rclone-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\rclone-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/rg/install.ps1
+++ b/rg/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\ripgrep-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\ripgrep-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading ripgrep from $Env:WEBI_PKG_URL to $pkg_download"

--- a/rg/install.ps1
+++ b/rg/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\ripgrep-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\ripgrep-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/sass/install.ps1
+++ b/sass/install.ps1
@@ -17,6 +17,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\dart-sass-v$Env:WEBI_VERSION"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\dart-sass-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_dir"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))

--- a/sass/install.ps1
+++ b/sass/install.ps1
@@ -17,10 +17,10 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\dart-sass-v$Env:WEBI_VERSION"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\dart-sass-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_dir"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading sass (dart-sass) from $Env:WEBI_PKG_URL to $pkg_download"

--- a/sclient/install.ps1
+++ b/sclient/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\sclient-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\sclient-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading sclient from $Env:WEBI_PKG_URL to $pkg_download"

--- a/sclient/install.ps1
+++ b/sclient/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\sclient-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\sclient-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/sd/install.ps1
+++ b/sd/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\sd-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\sd-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/sd/install.ps1
+++ b/sd/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\sd-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\sd-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading sd from $Env:WEBI_PKG_URL to $pkg_download"

--- a/serviceman/install.ps1
+++ b/serviceman/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\serviceman-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\serviceman-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/serviceman/install.ps1
+++ b/serviceman/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\serviceman-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\serviceman-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading serviceman from $Env:WEBI_PKG_URL to $pkg_download"

--- a/shellcheck/install.ps1
+++ b/shellcheck/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\shellcheck-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\shellcheck-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/shellcheck/install.ps1
+++ b/shellcheck/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\shellcheck-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\shellcheck-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading shellcheck from $Env:WEBI_PKG_URL to $pkg_download"

--- a/shfmt/install.ps1
+++ b/shfmt/install.ps1
@@ -14,10 +14,10 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\shfmt-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\shfmt-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     echo "Downloading shfmt from $Env:WEBI_PKG_URL to $pkg_download"
     & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"

--- a/shfmt/install.ps1
+++ b/shfmt/install.ps1
@@ -14,6 +14,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\shfmt-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\shfmt-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))

--- a/syncthing/install.ps1
+++ b/syncthing/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\syncthing-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\syncthing-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading syncthing from $Env:WEBI_PKG_URL to $pkg_download"

--- a/syncthing/install.ps1
+++ b/syncthing/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\syncthing-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\syncthing-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/watchexec/install.ps1
+++ b/watchexec/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\watchexec-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\watchexec-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/watchexec/install.ps1
+++ b/watchexec/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\watchexec-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\watchexec-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading watchexec from $Env:WEBI_PKG_URL to $pkg_download"

--- a/wsl.bak/install.ps1
+++ b/wsl.bak/install.ps1
@@ -1,7 +1,7 @@
 #!/usr/bin/env pwsh
 
-curl.exe -s "https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi" -o "$Env:USERPROFILE\Downloads\wsl_update_x64.msi"
-msiexec /a "$Env:USERPROFILE\Downloads\wsl_update_x64.msi" /qb TARGETDIR="C:\temp"
+curl.exe -s "https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi" -o "$Env:USERPROFILE\Downloads\webi\wsl_update_x64.msi"
+msiexec /a "$Env:USERPROFILE\Downloads\webi\wsl_update_x64.msi" /qb TARGETDIR="C:\temp"
 copy C:\temp\System32\lxss\tools\kernel C:\Windows\System32\lxss\tools\
 
 dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart

--- a/wsl/install.ps1
+++ b/wsl/install.ps1
@@ -28,13 +28,13 @@ IF(!(Test-CommandExists wsl))
 }
 
 echo ""
-IF ((Test-Path -Path "$Env:UserProfile\Downloads\Ubuntu_2004_x64.appx" )) {
+IF ((Test-Path -Path "$Env:UserProfile\Downloads\webi\Ubuntu_2004_x64.appx" )) {
     echo "Skipping 4 of 5: Ubuntu Linux 20.04 already installed"
 } ELSE {
     echo "Installing 4 of 5 Ubuntu Linux 20.04 (for WSL 1 and WSL 2) ..."
-    curl.exe -fL -o "$Env:UserProfile\Downloads\Ubuntu_2004_x64.appx.part" https://aka.ms/wslubuntu2004
-    & move "$Env:UserProfile\Downloads\Ubuntu_2004_x64.appx.part" "$Env:UserProfile\Downloads\Ubuntu_2004_x64.appx"
-    Add-AppxPackage "$Env:UserProfile\Downloads\Ubuntu_2004_x64.appx"
+    curl.exe -fL -o "$Env:UserProfile\Downloads\webi\Ubuntu_2004_x64.appx.part" https://aka.ms/wslubuntu2004
+    & move "$Env:UserProfile\Downloads\webi\Ubuntu_2004_x64.appx.part" "$Env:UserProfile\Downloads\webi\Ubuntu_2004_x64.appx"
+    Add-AppxPackage "$Env:UserProfile\Downloads\webi\Ubuntu_2004_x64.appx"
 }
 
 echo ""

--- a/xz/install.ps1
+++ b/xz/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\xz-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\xz-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading xz from $Env:WEBI_PKG_URL to $pkg_download"

--- a/xz/install.ps1
+++ b/xz/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\xz-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\xz-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive

--- a/yq/install.ps1
+++ b/yq/install.ps1
@@ -10,6 +10,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\yq-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\yq-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))

--- a/yq/install.ps1
+++ b/yq/install.ps1
@@ -10,10 +10,10 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\yq-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\yq-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     echo "Downloading yq from $Env:WEBI_PKG_URL to $pkg_download"
     & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"

--- a/zoxide/install.ps1
+++ b/zoxide/install.ps1
@@ -15,11 +15,11 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\zoxide-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\zoxide-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
-New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
-$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE")) {
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
     # TODO: arch detection
     Write-Output "Downloading zoxide from $Env:WEBI_PKG_URL to $pkg_download"
     & curl.exe -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"

--- a/zoxide/install.ps1
+++ b/zoxide/install.ps1
@@ -15,6 +15,7 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\zoxide-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\zoxide-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_cmd"
 
+New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
 $pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
 
 # Fetch archive


### PR DESCRIPTION
Currently live on https://beta.webinstall.dev.

Tested decently well on Mac, Linux, and Windows.

Re: https://github.com/webinstall/webi-installers/issues/220

# for reference

How I used `sd` for this refactor (on the Windows side):

```bash
#!/bin/bash

sd -s '$pkg_download =' 'New-Item "$Env:USERPROFILE\Downloads" -ItemType Directory -Force | out-null
$pkg_download =' */install.ps1

sd -s '\Downloads\' '\Downloads\webi\' */install.ps1
sd -s '\Downloads"' '\Downloads\webi"' */install.ps1
```