### PR TITLE
security: also check for UsePAM

### DIFF
--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -35,6 +35,7 @@ function __bootstrap_webi() {
     #PKG_ARCHES=
     #PKG_FORMATS=
     WEBI_UA="$(uname -a)"
+    WEBI_PKG_DOWNLOAD=""
     export WEBI_HOST
 
     ##
@@ -151,6 +152,9 @@ function __bootstrap_webi() {
         else
             my_dl="$HOME/Downloads/$WEBI_PKG_FILE"
         fi
+
+        WEBI_PKG_DOWNLOAD="${my_dl}"
+        export WEBI_PKG_DOWNLOAD
 
         if [ -e "$my_dl" ]; then
             echo "Found $my_dl"

--- a/fish/install.sh
+++ b/fish/install.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 set -u
 
@@ -12,13 +13,17 @@ fi
 ################
 
 # Every package should define these 6 variables
+# shellcheck disable=2034
 pkg_cmd_name="fish"
 
 pkg_dst_cmd="$HOME/.local/bin/fish"
+# shellcheck disable=2034
 pkg_dst="$pkg_dst_cmd"
 
 pkg_src_cmd="$HOME/.local/opt/fish-v$WEBI_VERSION/bin/fish"
+# shellcheck disable=2034
 pkg_src_dir="$HOME/.local/opt/fish-v$WEBI_VERSION"
+# shellcheck disable=2034
 pkg_src="$pkg_src_cmd"
 
 # pkg_install must be defined by every package
@@ -45,10 +50,10 @@ function _macos_post_install() {
     if [ -e "$HOME/Library/Preferences/com.googlecode.iterm2.plist" ]; then
         /usr/libexec/PlistBuddy \
             -c "SET ':New Bookmarks:0:Custom Command' 'Custom Shell'" \
-            $HOME/Library/Preferences/com.googlecode.iterm2.plist
+            "$HOME/Library/Preferences/com.googlecode.iterm2.plist"
         /usr/libexec/PlistBuddy \
             -c "SET ':New Bookmarks:0:Command' $HOME/.local/bin/fish" \
-            $HOME/Library/Preferences/com.googlecode.iterm2.plist
+            "$HOME/Library/Preferences/com.googlecode.iterm2.plist"
         echo "To set 'fish' as the default iTerm2 shell:"
         echo "    iTerm2 > Preferences > Profiles > General > Command >"
         echo "    Custom Shell: $HOME/.local/bin/fish"
@@ -80,5 +85,5 @@ function pkg_get_current_version() {
     #       fish, version 3.1.2
     # This trims it down to just the version number:
     #       3.1.2
-    echo $(fish --version 2> /dev/null | head -n 1 | cut -d ' ' -f 3)
+    fish --version 2> /dev/null | head -n 1 | cut -d ' ' -f 3
 }

--- a/gh/README.md
+++ b/gh/README.md
@@ -1,0 +1,31 @@
+---
+title: GitHub CLI
+homepage: https://github.com/cli/cli
+tagline: |
+  `gh` is GitHub on the command line.
+---
+
+## Updating and Switch versions
+
+```bash
+webi gh
+```
+
+## Cheat Sheet
+
+> `gh` doesn't exist and this text should have been replaced. It doesn't do
+> anything, but what it does is useful because it is; everybody knows it.
+
+To run gh:
+
+```bash
+gh
+```
+
+### Add Baz Highlighting
+
+To run gh with both bar and baz highlighting turned on:
+
+```bash
+gh --bar=baz
+```

--- a/gh/README.md
+++ b/gh/README.md
@@ -9,19 +9,77 @@ To update or switch versions, run `webi gh@stable` (or `@v1`, `@beta`, etc).
 
 ## Cheat Sheet
 
-> `gh` doesn't exist and this text should have been replaced. It doesn't do
-> anything, but what it does is useful because it is; everybody knows it.
+> `gh` is cross-platform Github command-line. You can perform pull requests
+> create-repo, isssues, fork and other GitHub functionalities right from your
+> terminal while Working with Git and your code.
 
-To run gh:
+Installation:
+
+- For macOS and Windows [macOS/Windows](https://github.com/cli/cli/blob/trunk/README.md)
+- For linux Installation on specific distribution [linux](https://github.com/cli/cli/blob/trunk/docs/install_linux.md)
+
+### Authentication
+
+Authenticate with your Github account.
 
 ```bash
-gh
+gh auth login
 ```
 
-### Add Baz Highlighting
+### Pull Request
 
-To run gh with both bar and baz highlighting turned on:
+Create a pull request.
 
 ```bash
-gh --bar=baz
+gh pr create -t <title> -b <body>
+```
+
+Check out pull requests locally.
+
+```bash
+gh pr checkout
+```
+
+Check the status of yout pull requests.
+
+```bash
+gh pr status
+```
+
+View Your pull requests' checks.
+
+```bash
+gh pr check
+```
+
+### Issues
+
+View and filter a repository's open issues.
+
+```bash
+gh issue list
+```
+
+### Release
+
+Create a new release.
+
+```bash
+gh release create 0.1
+```
+
+### Repo
+
+View repository READMEs.
+
+```bash
+gh repo view
+```
+
+### Create Shortcut
+
+Create Shortcut for a gh command.
+
+```bash
+gh alias set bugs 'issue list --label="bugs"'
 ```

--- a/gh/README.md
+++ b/gh/README.md
@@ -5,11 +5,7 @@ tagline: |
   `gh` is GitHub on the command line.
 ---
 
-## Updating and Switch versions
-
-```bash
-webi gh
-```
+To update or switch versions, run `webi gh@stable` (or `@v1`, `@beta`, etc).
 
 ## Cheat Sheet
 

--- a/gh/install.ps1
+++ b/gh/install.ps1
@@ -1,0 +1,61 @@
+#!/usr/bin/env pwsh
+
+##############
+# Install gh #
+##############
+
+# Every package should define these variables
+$pkg_cmd_name = "gh"
+
+$pkg_dst_cmd = "$Env:USERPROFILE\.local\bin\gh.exe"
+$pkg_dst = "$pkg_dst_cmd"
+
+$pkg_src_cmd = "$Env:USERPROFILE\.local\opt\gh-v$Env:WEBI_VERSION\bin\gh.exe"
+$pkg_src_bin = "$Env:USERPROFILE\.local\opt\gh-v$Env:WEBI_VERSION\bin"
+$pkg_src_dir = "$Env:USERPROFILE\.local\opt\gh-v$Env:WEBI_VERSION"
+$pkg_src = "$pkg_src_cmd"
+
+$pkg_download = "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+
+# Fetch archive
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+{
+    # TODO: arch detection
+    echo "Downloading gh from $Env:WEBI_PKG_URL to $pkg_download"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
+    & move "$pkg_download.part" "$pkg_download"
+}
+
+IF (!(Test-Path -Path "$pkg_src_cmd"))
+{
+    echo "Installing gh"
+
+    # TODO: create package-specific temp directory
+    # Enter tmp
+    pushd .local\tmp
+
+        # Remove any leftover tmp cruft
+        Remove-Item -Path ".\gh-v*" -Recurse -ErrorAction Ignore
+        Remove-Item -Path ".\gh.exe" -Recurse -ErrorAction Ignore
+
+        # NOTE: DELETE THIS COMMENT IF NOT USED
+        # Move single binary into root of temporary folder
+        #& move "$pkg_download" "gh.exe"
+
+        # Unpack archive file into this temporary directory
+        # Windows BSD-tar handles zip. Imagine that.
+        echo "Unpacking $pkg_download"
+        & tar xf "$pkg_download"
+
+        # Settle unpacked archive into place
+        echo "Install Location: $pkg_src_cmd"
+        New-Item "$pkg_src_bin" -ItemType Directory -Force | out-null
+        Move-Item -Path ".\bin\gh.exe" -Destination "$pkg_src_bin"
+
+    # Exit tmp
+    popd
+}
+
+echo "Copying into '$pkg_dst_cmd' from '$pkg_src_cmd'"
+Remove-Item -Path "$pkg_dst_cmd" -Recurse -ErrorAction Ignore | out-null
+Copy-Item -Path "$pkg_src" -Destination "$pkg_dst" -Recurse

--- a/gh/install.sh
+++ b/gh/install.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+function __init_gh() {
+    set -e
+    set -u
+
+    ##############
+    # Install gh #
+    ##############
+
+    # Every package should define these 6 variables
+    pkg_cmd_name="gh"
+
+    pkg_dst_cmd="$HOME/.local/bin/gh"
+    pkg_dst="$pkg_dst_cmd"
+
+    pkg_src_cmd="$HOME/.local/opt/gh-v$WEBI_VERSION/bin/gh"
+    pkg_src_dir="$HOME/.local/opt/gh-v$WEBI_VERSION"
+    pkg_src="$pkg_src_cmd"
+
+    # pkg_install must be defined by every package
+    pkg_install() {
+        # ~/.local/opt/gh-v0.99.9/bin
+        mkdir -p "$(dirname $pkg_src_cmd)"
+
+        # mv ./gh-*/gh ~/.local/opt/gh-v0.99.9/bin/gh
+        mv ./"$pkg_cmd_name"*/bin/gh "$pkg_src_cmd"
+    }
+
+    # pkg_get_current_version is recommended, but (soon) not required
+    pkg_get_current_version() {
+        # 'gh --version' has output in this format:
+        #       gh 0.99.9 (rev abcdef0123)
+        # This trims it down to just the version number:
+        #       0.99.9
+        echo $(gh --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
+    }
+
+}
+
+__init_gh

--- a/gh/releases.js
+++ b/gh/releases.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var github = require('../_common/github.js');
+var owner = 'cli';
+var repo = 'cli';
+
+module.exports = function (request) {
+  return github(request, owner, repo).then(function (all) {
+    return all;
+  });
+};
+
+if (module === require.main) {
+  module.exports(require('@root/request')).then(function (all) {
+    all = require('../_webi/normalize.js')(all);
+    // just select the first 5 for demonstration
+    all.releases = all.releases.slice(0, 5);
+    console.info(JSON.stringify(all, null, 2));
+  });
+}

--- a/git-gpg-init/README.md
+++ b/git-gpg-init/README.md
@@ -1,0 +1,192 @@
+---
+title: git-gpg-init
+homepage: https://webinstall.dev/git-gpg-init
+tagline: |
+  Get your GnuPG Public Key.
+---
+
+## Cheat Sheet
+
+> Although the latest git release allows you to sign with SSH Keys (and GitHub
+> will implement this shortly if it hasn't already), most systems do not have
+> the latest git release, and most verification systems are not updated with the
+> newest verification techniques, so you may wish to sign your commits with GPG,
+> as has been done for the last 20 years...
+
+Here we'll cover
+
+- How to [add a GPG key to Github](https://github.com/settings/gpg/new)
+- How to cache the passphrase longer
+- How to [create a GPG key](./gpg-pubkey)
+- How to configure git with GPG signing
+- Troubleshooting 'gpg failed to sign the data'
+
+Usage:
+
+```bash
+git-gpg-init
+```
+
+Example output:
+
+```txt
+GnuPG Public Key ID: CA025BC42F00BBBE
+
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQGNBGGQtKIBDAChxTT375fetQawLkyyDcz07uIEZVa9pvuip8goMqev7PkOIHi+
+j6PDtFmxgv8ZOFe8+1RfMC7eL5fYah0/OBxNm7pPvAPDWOX38FfUzoq9CALW2xPD
+...
+Yee+eokiC2mWIEkMwbqlnNmkX/wphS0zcCsEiHirmDxgY6YY9QRjlzUMY68OqjfJ
+IFjFWv3R7eckM957wyR5BvdQNfGrW7cWefWhdZOzLEE7
+=GXEK
+-----END PGP PUBLIC KEY BLOCK-----
+
+Successfully updated ~/.gitconfig for gpg commit signing
+
+How to verify signed commits on GitHub:
+
+    1. Go to 'Add GPG Key': https://github.com/settings/gpg/new
+    2. Copy and paste the key above from the first ---- to the last ----
+```
+
+### Files
+
+These are the files / directories that are created and/or modified with this
+install:
+
+```txt
+~/.config/envman/PATH.env
+~/.local/bin/git-gpg-init
+~/Downloads/YOU.KEY_ID.gpg.asc
+```
+
+### How to add your GPG Public Key to GitHub
+
+1. Go to your GitHub Profile (<https://github.com/settings/profile>)
+2. Go to the SSH and GPG Keys (<https://github.com/settings/keys>)
+3. Add GPG Key (<https://github.com/settings/gpg/new>)
+4. Paste the output of `gpg-pubkey` into the form
+
+### How to cache the Passphrase longer
+
+If you'd like the passphrase to be cached until your login session ends, just
+set it to 400 days and call it good.
+
+`~/.gnupg/gpg-agent.conf`:
+
+```txt
+default-cache-ttl 34560000
+max-cache-ttl 34560000
+```
+
+You'll need to reload `gpg-agent` for this to take effect, or just logout and
+login again.
+
+```bash
+# kill gpg-agent dead
+killall gpg-agent
+gpgconf killall gpg-agent
+
+# start gpg-agent again (yes, 'bye' to start)
+gpg-connect-agent --agent-program ~/.local/opt/gnupg/bin/gpg-agent /bye
+```
+
+Note: You may need to change or omit `--agent-program`, depending on how you
+installed `gpg` (if you installed it with Webi, run it as shown above).
+
+### How to create a GPG Key
+
+See:
+
+- [gpg-pubkey](./gpg-pubkey)
+- and [gpg](./gpg), if you want to do it "the hard way"
+
+### How to manually set up git commit gpg signing
+
+(this is what `git-gpg-init` does)
+
+Run [gpg-pubkey-id](./gpg-pubkey) to get your GnuPG Public Key ID and then
+update your `~/.gitconfig` to sign with it by default:
+
+```bash
+#!/bin/bash
+
+MY_KEY_ID="$(
+  gpg-pubkey-id
+)"
+
+git config --global user.signingkey "${MY_KEY_ID}"
+git config --global commit.gpgsign true
+git config --global log.showSignature true
+```
+
+Or, for Windows users:
+
+```bash
+#!/usr/bin/env pwsh
+
+$my_key_id = gpg-pubkey-id
+
+git config --global user.signingkey "$my_key_id"
+git config --global commit.gpgsign true
+git config --global log.showSignature true
+```
+
+Or, if you prefer to edit the text file directly:
+
+`~/.gitconfig`
+
+```txt
+[user]
+  signingkey = CA025BC42F00BBBE
+[commit]
+  gpgsign = true
+[log]
+  showSignature = true
+```
+
+In some cases you may also want to prevent conflicts between different installed
+versions of gpg, like so:
+
+```bash
+git config --global gpg.program ~/.local/opt/gnupg/bin/gpg
+```
+
+```txt
+[gpg]
+  program = /Users/me/.local/opt/gnupg/bin/gpg
+```
+
+### Troubleshooting 'gpg failed to sign the data'
+
+`gpg` is generally expected to be used with a Desktop client. On Linux servers
+you may get this error:
+
+```txt
+error: gpg failed to sign the data
+fatal: failed to write commit object
+```
+
+Try to load the `gpg-agent`, set `GPG_TTY`, and then run a clearsign test.
+
+```bash
+gpg-connect-agent /bye
+export GPG_TTY=$(tty)
+echo "test" | gpg --clearsign
+```
+
+If that works, update your `~/.bashrc`, `~/.zshrc`, and/or
+`~/.config/fish/config.fish` to include the following:
+
+```bash
+gpg-connect-agent /bye
+export GPG_TTY=$(tty)
+```
+
+If this is failing on Mac or Windows, then `gpg-agent` is not starting as
+expected on login (for Mac the above may work), and/or the `pinentry` command is
+not in the PATH.
+
+If you just installed `gpg`, try closing and reopening your Terminal, or
+possibly rebooting.

--- a/git-gpg-init/git-gpg-init.sh
+++ b/git-gpg-init/git-gpg-init.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+set -u
+
+export PATH="$HOME/.local/opt/gnupg/bin:$PATH"
+export PATH="$HOME/.local/opt/gnupg/bin/pinentry-mac.app/Contents/MacOS:$PATH"
+
+# TODO check for public key without gpg-pubkey?
+if ! command -v gpg-pubkey; then
+    webi gpg-pubkey
+else
+    gpg-pubkey
+fi
+
+MY_KEY_ID="$(
+    gpg-pubkey-id
+)"
+
+echo -n "Enabling automatic git commit signing...
+    git config --global user.signingkey ${MY_KEY_ID}
+    git config --global commit.gpgsign true
+    git config --global log.showSignature true
+"
+
+git config --global user.signingkey "${MY_KEY_ID}"
+git config --global commit.gpgsign true
+git config --global log.showSignature true
+
+echo ""
+echo "Successfully updated ~/.gitconfig"
+echo ""
+echo "How to verify signed commits on GitHub:"
+echo ""
+echo "    1. Go to 'Add GPG Key': https://github.com/settings/gpg/new"
+echo "    2. Copy and paste the key above from the first ---- to the last ----"
+echo ""

--- a/git-gpg-init/install.sh
+++ b/git-gpg-init/install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+set -u
+
+function __install_git_gpg_init() {
+    MY_CMD="git-gpg-init"
+
+    rm -f "$HOME/.local/bin/$MY_CMD"
+    webi_download "$WEBI_HOST/packages/$MY_CMD/$MY_CMD.sh" "$HOME/.local/bin/$MY_CMD"
+    chmod a+x "$HOME/.local/bin/$MY_CMD"
+}
+
+function __check_gpg_pubkey_exists() {
+    if ! command -v gpg; then
+        webi gpg-pubkey
+        export PATH="$HOME/.local/opt/gnupg/bin:$PATH"
+        export PATH="$HOME/.local/opt/gnupg/bin/pinentry-mac.app/Contents/MacOS:$PATH"
+    fi
+}
+
+function __check_gpg_exists() {
+    if ! command -v gpg; then
+        webi gpg
+        export PATH="$HOME/.local/opt/gnupg/bin:$PATH"
+        export PATH="$HOME/.local/opt/gnupg/bin/pinentry-mac.app/Contents/MacOS:$PATH"
+    fi
+}
+
+__install_git_gpg_init
+__check_gpg_pubkey_exists
+__check_gpg_exists
+
+# run the command
+"$HOME/.local/bin/$MY_CMD"

--- a/gnupg/install.sh
+++ b/gnupg/install.sh
@@ -1,0 +1,10 @@
+# title: GnuPG (gpg alias)
+# homepage: https://webinstall.dev/gpg
+# tagline: Alias for https://webinstall.dev/gpg
+# alias: gpg
+# description: |
+#   See https://webinstall.dev/gpg
+
+echo "'gnupg@${WEBI_TAG:-stable}' is an alias for 'gpg@${WEBI_VERSION:-}'"
+WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
+curl -fsSL "$WEBI_HOST/gpg@${WEBI_VERSION:-}" | bash

--- a/gpg-pubkey/README.md
+++ b/gpg-pubkey/README.md
@@ -1,0 +1,239 @@
+---
+title: GnuPG Pub Key
+homepage: https://webinstall.dev/gpg-pubkey
+tagline: |
+  Get your GnuPG Public Key.
+---
+
+## Cheat Sheet
+
+> Your GnuPG Public Key can be used for signing git commits and email, among
+> other things. The file public key ends in `.asc`.
+
+This installs two commands.
+
+- `gpg-pubkey` will:
+  1.  Create a new gpg keypair if you don’t already have one \
+      (uses `~/.gitconfig` for name and email)
+  2.  Copy your new or existing GnuPG Public Key to your `Downloads` folder
+  3.  Print the location of the copied key, and its contents, to the screen
+- `gpg-pubkey-id` will output the id of your public key.
+
+The easiest way to get your GnuPG Public Key:
+
+```bash
+curl https://webinstall.dev/gpg-pubkey | bash
+```
+
+This is what the output of `gpg-pubkey` looks like (except much longer):
+
+```txt
+GnuPG Public Key ID: CA025BC42F00BBBE
+
+~/Downloads/john@example.com.gpg.asc:
+
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBGGLrUIBEAC+k1rHvi4xbCiN/cnh3Zi4rbKeJdPIWDP0wDhZcYzIN4/ZWVAm
+... (several lines omitted for brevity)
+nZH7UhxDx6Gu4w1+uef0E/cjz2BuEn/LN9UBGWwI5dLp5p03FeXYzzAwt6sh
+=rRiF
+-----END PGP PUBLIC KEY BLOCK-----
+```
+
+Note: Your public key is the _entire_ section starting with and including
+`-----BEGIN` all the way to and including `BLOCK-----`
+
+### Files
+
+These are the files / directories that are created and/or modified with this
+install:
+
+```txt
+~/.config/envman/PATH.env
+~/.local/bin/gpg-pubkey
+~/.local/bin/gpg-pubkey-id
+~/.gnupg/
+~/Downloads/YOU.KEY_ID.gpg.asc
+```
+
+## How to add your GPG Public Key to GitHub
+
+1. Go to your GitHub Profile (<https://github.com/settings/profile>)
+2. Go to the SSH and GPG Keys (<https://github.com/settings/keys>)
+3. Add GPG Key (<https://github.com/settings/gpg/new>)
+4. Paste the output of `gpg-pubkey` into the form
+
+## How to automatically sign your git commits
+
+Run `gpg-pubkey-id` to get your GnuPG Public Key ID and then update your
+`~/.gitconfig` to sign with it by default:
+
+```bash
+#!/bin/bash
+
+MY_KEY_ID="$(
+  gpg-pubkey-id
+)"
+
+git config --global user.signingkey "${MY_KEY_ID}"
+git config --global commit.gpgsign true
+git config --global log.showSignature true
+```
+
+Or, for Windows users:
+
+```bash
+#!/usr/bin/env pwsh
+
+$my_key_id = gpg-pubkey-id
+
+git config --global user.signingkey "$my_key_id"
+git config --global commit.gpgsign true
+git config --global log.showSignature true
+```
+
+## How to use `gpg` manually
+
+- How to get your Public Key ID
+- How to export your Public Key
+- How to create a Private Key
+
+### How to get your GnuPG Public Key ID
+
+All _Secret Keys_ have _Public IDs_ (and corresponding _Public Keys_).
+
+Here's a command to list your secret key(s) and get the Public ID (of the first
+one, if you have many):
+
+```bash
+#!/bin/bash
+
+MY_KEY_ID="$(
+    gpg --list-secret-keys --keyid-format LONG |
+        grep sec |
+        cut -d'/' -f2 |
+        cut -d' ' -f1
+)"
+echo "$MY_KEY_ID"
+```
+
+Or, for Windows users:
+
+```pwsh
+#!/usr/bin/env pwsh
+
+$my_key_id = (
+    gpg --list-secret-keys --keyid-format LONG |
+        Select-String -Pattern '\.*sec.*\/' |
+        Select-Object Line |
+        ForEach-Object {
+            $_.Line.split('/')[1].split(' ')[0]
+        }
+)
+echo "$my_key_id"
+```
+
+Let's break that down, for good measure:
+
+All secret keys have a Public Key and a Public ID, which can be viewed in _LONG_
+format:
+
+```bash
+gpg --list-secret-keys --keyid-format LONG
+```
+
+```txt
+/Users/me/.gnupg/pubring.kbx
+----------------------------
+sec   rsa3072/CA025BC42F00BBBE 2021-11-10 [SCEA]
+      6F848282295B19123748D36BCA025BC42F00BBBE
+uid                 [ultimate] John Doe (mac.local) <john@example.com>
+ssb   rsa3072/674124162BF19A32 2021-11-10 [SEA]
+```
+
+The line with the Public Key ID is the one that starts with `sec`:
+
+```txt
+sec   rsa3072/CA025BC42F00BBBE 2021-11-10 [SCEA]
+```
+
+Specifically, it's the part just after the `/` - **CA025BC42F00BBBE**, in this
+case.
+
+Note: It's important that you list the Secret Keys, because listing Public Keys
+will show all keys that you trust in your gpg keychain (co-workers, for
+example), not just keys that you own.
+
+### How to export your GnuPG Public Key:
+
+Here's how to copy your Public Key into your Downloads folder:
+
+```bash
+gpg --armor --export "${MY_KEY_ID}" > ~/Downloads/"${MY_EMAIL}".gpg.asc
+```
+
+Or, if you just want to print it to your console, run this:
+
+```bash
+gpg --armor --export "${MY_KEY_ID}"
+```
+
+### How to create an GnuPG Private Key:
+
+Generally speaking you'll want to use the same name and email for `git` and
+`gpg`.
+
+Here's how you can automate creating a key using the same info as what's in your
+`~/.gitconfig`:
+
+```bash
+#!/bin/bash
+
+MY_NAME="$( git config --global user.name )"
+MY_HOST="$( hostname )"
+MY_EMAIL="$( git config --global user.email )"
+
+gpg --batch --generate-key << EOF
+ %echo Generating RSA 3072 key
+ Key-Type: RSA
+ Key-Length: 3072
+ Subkey-Type: RSA
+ Subkey-Length: 3072
+ Name-Real: ${MY_NAME}
+ Name-Comment: ${MY_HOST}
+ Name-Email: ${MY_EMAIL}
+ Expire-Date: 0
+ %commit
+EOF
+```
+
+Or, for the Windows folk...
+
+```bash
+#!/usr/bin/env pwsh
+
+$my_name = git config --global user.name
+$my_host = hostname
+$my_email = git config --global user.email
+
+echo "
+ %echo Generating RSA 3072 key
+ Key-Type: RSA
+ Key-Length: 3072
+ Subkey-Type: RSA
+ Subkey-Length: 3072
+ Name-Real: $my_name
+ Name-Comment: $my_host
+ Name-Email: $my_email
+ Expire-Date: 0
+ %commit
+" | gpg --batch --generate-key
+```
+
+Note: if you want to create a key without a passphrase, add
+`--pinentry=loopback --passphrase=''` to the arguments.
+
+(though typically it's better to create a random passphrase and just let macOS
+store it in your user Keychain and forget it - just so it doesn't get backed up
+unencrypted, etc)

--- a/gpg-pubkey/gpg-pubkey-id.ps1
+++ b/gpg-pubkey/gpg-pubkey-id.ps1
@@ -1,0 +1,8 @@
+#!/usr/bin/env pwsh
+
+gpg --list-secret-keys --keyid-format LONG |
+    Select-String -Pattern '\.*sec.*\/' |
+    Select-Object Line |
+    ForEach-Object {
+        $_.Line.split('/')[1].split(' ')[0]
+    }

--- a/gpg-pubkey/gpg-pubkey-id.sh
+++ b/gpg-pubkey/gpg-pubkey-id.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+set -u
+
+gpg --list-secret-keys --keyid-format LONG |
+    grep sec |
+    cut -d'/' -f2 |
+    cut -d' ' -f1

--- a/gpg-pubkey/gpg-pubkey.ps1
+++ b/gpg-pubkey/gpg-pubkey.ps1
@@ -1,0 +1,41 @@
+#!/usr/bin/env pwsh
+
+$my_key_id = gpg --list-secret-keys --keyid-format LONG |
+    Select-String -Pattern '\.*sec.*\/' |
+    Select-Object Line |
+    ForEach-Object {
+        $_.Line.split('/')[1].split(' ')[0]
+    }
+
+if (!$my_key_id)
+{
+    $my_name = git config --global user.name
+    $my_email = git config --global user.email
+    $my_host = hostname
+
+    echo "
+     %echo Generating RSA 3072 key
+     Key-Type: RSA
+     Key-Length: 3072
+     Subkey-Type: RSA
+     Subkey-Length: 3072
+     Name-Real: $my_name
+     Name-Comment: $my_host
+     Name-Email: $my_email
+     Expire-Date: 0
+     %commit
+    " | gpg --batch --generate-key
+}
+
+$my_asc_relpath = "Downloads/$my_email.$my_key_id.gpg.asc"
+& gpg --armor --export $my_key_id > "$Env:USERPROFILE/$my_asc_relpath"
+
+# TODO use the comment (if any) for the name of the file
+$my_email = git config --global user.email
+echo ""
+echo "GnuPG Public Key ID: $MY_KEY_ID"
+echo ""
+echo "~/$my_asc_relpath":
+echo ""
+& type "$Env:USERPROFILE/$my_asc_relpath"
+echo ""

--- a/gpg-pubkey/gpg-pubkey.sh
+++ b/gpg-pubkey/gpg-pubkey.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+set -e
+set -u
+
+function __get_git_email() {
+    grep 'email\s*=.*@' ~/.gitconfig |
+        tr -d '\t ' | head -n 1 |
+        cut -d'=' -f2
+}
+
+function __get_pubkey_id() {
+    gpg --list-secret-keys --keyid-format LONG |
+        grep sec |
+        cut -d'/' -f2 |
+        cut -d' ' -f1
+}
+
+function _create_gpg_key() {
+    if [[ ! -e ~/.gitconfig ]]; then
+        return 1
+    fi
+
+    MY_NAME="$(
+        grep 'name\s*=' ~/.gitconfig |
+            head -n 1 |
+            cut -d'=' -f2 |
+            sed -e 's/^[\t ]*//'
+    )"
+    if [[ -z ${MY_NAME} ]]; then
+        return 1
+    fi
+
+    MY_EMAIL="$(
+        __get_git_email
+    )"
+    if [[ -z ${MY_EMAIL} ]]; then
+        return 1
+    fi
+
+    MY_HOST="$(hostname)"
+
+    # Without passphrase:
+    #gpg --batch --generate-key --pinentry=loopback --passphrase=''
+
+    # With passphrase via macOS Keychain
+    gpg_opts="
+     %echo Generating RSA 3072 key...
+     %echo Warning: It may take several minutes to gather enough entropy,
+     %echo          especially on a linux VPS if haveged isn't installed.
+     %echo          (try moving the mouse, downloading large files, etc)
+     Key-Type: RSA
+     Key-Length: 3072
+     Subkey-Type: RSA
+     Subkey-Length: 3072
+     Name-Real: ${MY_NAME}
+     Name-Comment: ${MY_HOST}
+     Name-Email: ${MY_EMAIL}
+     Expire-Date: 0
+     %commit
+    "
+    if ! echo "$gpg_opts" | gpg --batch --generate-key 2> /dev/null; then
+        echo >&2 ""
+        echo >&2 ""
+        echo >&2 ""
+        echo >&2 "== STOP! CHOOSE A PASSPHRASE =="
+        echo >&2 ""
+        echo >&2 "Choose a passphrase for this GPG Key."
+        echo >&2 "(the passphrase will not be shown as you type)"
+        echo >&2 ""
+        echo >&2 -n "Passphrase: "
+        read -r -s
+        echo >&2 ""
+        echo "
+         %echo Generating RSA 3072 key...
+         %echo Warning: It may take several minutes to gather enough entropy,
+         %echo          especially on a linux VPS if haveged isn't installed.
+         %echo          (try moving the mouse, downloading large files, etc)
+         Key-Type: RSA
+         Key-Length: 3072
+         Subkey-Type: RSA
+         Subkey-Length: 3072
+         Name-Real: ${MY_NAME}
+         Name-Comment: ${MY_HOST}
+         Name-Email: ${MY_EMAIL}
+         Passphrase: ${REPLY}
+         Expire-Date: 0
+         %commit
+        " --batch --generate-key > gpg
+    fi
+    echo >&2 "Done"
+}
+
+# (maybe) Create first key
+if ! gpg --list-secret-keys | grep -q sec; then
+    if ! _create_gpg_key; then
+        echo >&2 ""
+        echo >&2 "Please set your name and email, and then try again:"
+        echo >&2 ""
+        echo >&2 "    git config --global user.name 'John Doe'"
+        echo >&2 "    git config --global user.email johndoe@example.com"
+        echo >&2 "    gpg-pubkey"
+        echo >&2 ""
+        echo >&2 "(or manually create a private key first)"
+        echo >&2 ""
+        exit 1
+    fi
+fi
+
+MY_KEY_ID="$(
+    __get_pubkey_id
+)"
+
+MY_EMAIL="$(
+    __get_git_email
+)"
+
+#gpg --send-keys "${MY_KEY_ID}"
+
+MY_ASC_RELPATH="Downloads/${MY_EMAIL}.${MY_KEY_ID}.gpg.asc"
+mkdir -p ~/Downloads/
+rm -f ~/"${MY_ASC_RELPATH}"
+gpg --armor --export "${MY_KEY_ID}" > ~/"${MY_ASC_RELPATH}"
+
+echo >&2 ""
+echo >&2 "GnuPG Public Key ID: ${MY_KEY_ID}"
+echo >&2 ""
+#shellcheck disable=SC2088
+echo >&2 "~/${MY_ASC_RELPATH}":
+echo >&2 ""
+cat ~/"${MY_ASC_RELPATH}"
+echo >&2 ""

--- a/gpg-pubkey/install.ps1
+++ b/gpg-pubkey/install.ps1
@@ -1,0 +1,43 @@
+#!/usr/bin/env pwsh
+
+#
+# gpg-pubkey-id
+#
+$MY_CMD = "gpg-pubkey"
+$MY_SUBCMD = "gpg-pubkey-id"
+
+& curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_HOST/packages/$MY_CMD/$MY_SUBCMD.ps1" -o "$Env:USERPROFILE\.local\bin\$MY_SUBCMD.ps1.part"
+Remove-Item -Path "$Env:USERPROFILE\.local\bin\$MY_SUBCMD.ps1" -Recurse -ErrorAction Ignore
+& move "$Env:USERPROFILE\.local\bin\$MY_SUBCMD.ps1.part" "$Env:USERPROFILE\.local\bin\$MY_SUBCMD.ps1"
+Set-Content -Path "$Env:USERPROFILE\.local\bin\$MY_SUBCMD.bat" -Value "@echo off`r`npushd %USERPROFILE%`r`npowershell -ExecutionPolicy Bypass .local\bin\$MY_SUBCMD.ps1 %1`r`npopd"
+
+#
+# gpg-pubkey
+#
+$MY_CMD = "gpg-pubkey"
+
+& curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_HOST/packages/$MY_CMD/$MY_CMD.ps1" -o "$Env:USERPROFILE\.local\bin\$MY_CMD.ps1.part"
+Remove-Item -Path "$Env:USERPROFILE\.local\bin\$MY_CMD.ps1" -Recurse -ErrorAction Ignore
+& move "$Env:USERPROFILE\.local\bin\$MY_CMD.ps1.part" "$Env:USERPROFILE\.local\bin\$MY_CMD.ps1"
+Set-Content -Path "$Env:USERPROFILE\.local\bin\$MY_CMD.bat" -Value "@echo off`r`npushd %USERPROFILE%`r`npowershell -ExecutionPolicy Bypass .local\bin\$MY_CMD.ps1 %1`r`npopd"
+
+#
+# Check the gpg exists
+#
+
+$gpg_exists = Get-Command gpg 2> $null
+if (!$gpg_exists) {
+    curl.exe "$Env:WEBI_HOST/gpg" | powershell
+    $gpg_exists = Get-Command gpg 2> $null
+    if (!$gpg_exists) {
+        echo ""
+        echo "(exited because gpg is not existalled)"
+        echo ""
+        Exit 1
+    }
+}
+
+#
+# run gpg-pubkey
+#
+& "$Env:USERPROFILE\.local\bin\$MY_CMD.bat"

--- a/gpg-pubkey/install.sh
+++ b/gpg-pubkey/install.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+set -u
+
+function __install_gpg_pubkey() {
+    MY_CMD="gpg-pubkey"
+
+    rm -f "$HOME/.local/bin/$MY_CMD"
+    webi_download "$WEBI_HOST/packages/$MY_CMD/$MY_CMD.sh" "$HOME/.local/bin/$MY_CMD"
+    chmod a+x "$HOME/.local/bin/$MY_CMD"
+}
+
+function __install_gpg_pubkey_id() {
+    MY_CMD="gpg-pubkey"
+    MY_SUBCMD="gpg-pubkey-id"
+
+    rm -f "$HOME/.local/bin/$MY_SUBCMD"
+    webi_download "$WEBI_HOST/packages/$MY_CMD/$MY_SUBCMD.sh" "$HOME/.local/bin/$MY_SUBCMD"
+    chmod a+x "$HOME/.local/bin/$MY_SUBCMD"
+}
+
+function __check_gpg_exists() {
+    if ! command -v gpg; then
+        webi gpg
+        export PATH="$HOME/.local/opt/gnupg/bin:$PATH"
+        export PATH="$HOME/.local/opt/gnupg/bin/pinentry-mac.app/Contents/MacOS:$PATH"
+    fi
+}
+
+__install_gpg_pubkey_id
+__install_gpg_pubkey
+__check_gpg_exists
+
+# run the command
+"$HOME/.local/bin/$MY_CMD"

--- a/gpg/README.md
+++ b/gpg/README.md
@@ -1,0 +1,152 @@
+---
+title: Gnu Privacy Guard
+homepage: https://gnupg.org/
+tagline: |
+  GnuPG: a complete implementation of OpenPGP (RFC4880), also known as **P**retty **G**ood **P**rivacy.
+---
+
+### Before you start
+
+If `~/.gitconfig` exists and has both `name` and `email` fields, then a new gpg
+key will be created after the install. Otherwise, you'll have to create one
+yourself.
+
+## Cheat Sheet
+
+> Among other things, gpg is particularly useful for signing and verifying git
+> commits (and emails too).
+
+Here we'll cover:
+
+- Important GPG Files & Directories
+- Creating New Keys
+- Listing Keys
+- Signing Git Commits
+- Exporting GPG Keys for GitHub
+- Publishing GPG Keys to "the Blockchain"
+- Running GPG Agent with launchd
+
+### Files
+
+These are the files / directories that are created and/or modified with this
+install:
+
+```txt
+~/.config/envman/PATH.env
+~/.local/opt/gnupg/bin/gpg
+~/.local/opt/gnupg/bin/gpg-agent
+~/.local/opt/gnupg/bin/pinentry-mac.app/Contents/MacOS/pinentry-mac
+~/.gnupg/gpg-agent.conf
+~/Library/LaunchAgent/gpg-agent.plist
+```
+
+### How to create a new GPG key
+
+See the [Cheat Sheet](./gpg-pubkey) at [gpg-pubkey](./gpg-pubkey).
+
+### How to List GPG Key(s)
+
+```bash
+gpg --list-secret-keys --keyid-format LONG
+```
+
+### How to configure git to sign commits
+
+See the [Cheat Sheet](./git-gpg-init) at [gpg-pubkey](./git-gpg-init).
+
+### How to Export GPG Key for GitHub
+
+See the [Cheat Sheet](./gpg-pubkey) at [gpg-pubkey](./gpg-pubkey).
+
+### How to Publish GPG Keys
+
+GPG is the OG "blockchain", as it were.
+
+If you'd like to publish your (public) key(s) to the public Key Servers for time
+and all eternity, you can:
+
+```bash
+gpg --send-keys "${MY_KEY_ID}"
+```
+
+(no IPFS needed 😉)
+
+### How to start gpg-agent with launchd
+
+(**Note**: this is **done for you** on install, but provided here for reference)
+
+It's a trick question: You can't.
+
+You need to use `gpg-connect-agent` instead.
+
+`~/Library/LaunchAgents/gpg-agent.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>gpg-agent</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>MY_HOME/.local/opt/gpg/bin/gpg-connect-agent</string>
+		<string>--agent-program</string>
+		<string>MY_HOME/.local/opt/gnupg/bin/gpg-agent</string>
+		<string>--homedir</string>
+		<string>MY_HOME/.gnupg/</string>
+		<string>/bye</string>
+	</array>
+
+	<key>RunAtLoad</key>
+	<true/>
+
+	<key>WorkingDirectory</key>
+	<string>MY_HOME</string>
+
+	<key>StandardErrorPath</key>
+	<string>MY_HOME/.local/share/gpg-agent/var/log/gpg-agent.log</string>
+	<key>StandardOutPath</key>
+	<string>MY_HOME/.local/share/gpg-agent/var/log/gpg-agent.log</string>
+</dict>
+</plist>
+```
+
+And then start it with launchctl:
+
+```bash
+launchctl load -w ~/Library/LaunchAgents/gpg-agent.plist
+```
+
+### Troubleshooting 'gpg failed to sign the data'
+
+`gpg` is generally expected to be used with a Desktop client. On Linux servers
+you may get this error:
+
+```txt
+error: gpg failed to sign the data
+fatal: failed to write commit object
+```
+
+Try to load the `gpg-agent`, set `GPG_TTY`, and then run a clearsign test.
+
+```bash
+gpg-connect-agent /bye
+export GPG_TTY=$(tty)
+echo "test" | gpg --clearsign
+```
+
+If that works, update your `~/.bashrc`, `~/.zshrc`, and/or
+`~/.config/fish/config.fish` to include the following:
+
+```bash
+gpg-connect-agent /bye
+export GPG_TTY=$(tty)
+```
+
+If this is failing on Mac or Windows, then `gpg-agent` is not starting as
+expected on login (for Mac the above may work), and/or the `pinentry` command is
+not in the PATH.
+
+If you just installed `gpg`, try closing and reopening your Terminal, or
+possibly rebooting.

--- a/gpg/install.ps1
+++ b/gpg/install.ps1
@@ -1,0 +1,6 @@
+#!/usr/bin/env pwsh
+
+echo "We don't yet have a way to automate the GnuPG Tools installer at the user level. In the meantime, try this:"
+echo ""
+echo "    https://gnupg.org/download/#binary"
+echo ""

--- a/gpg/install.sh
+++ b/gpg/install.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+set -e
+set -u
+
+function _install_gpg() {
+    if ! (uname -a | grep -i "darwin" > /dev/null); then
+        echo "No gpg installer for Linux yet. Try this instead:"
+        echo "    sudo apt install -y gpg gnupg"
+        exit 1
+    fi
+
+    # Download the latest LTS
+    #curl -fsSL -o ~/Downloads/GnuPG-2.2.32.dmg 'https://sourceforge.net/projects/gpgosx/files/GnuPG-2.2.32.dmg/download'
+    webi_download
+    chmod a-w "${WEBI_PKG_DOWNLOAD}"
+
+    # Mount the DMG in /Volumes
+    hdiutil detach -quiet /Volumes/GnuPG* 2> /dev/null || true
+    hdiutil attach -quiet -readonly "${WEBI_PKG_DOWNLOAD}"
+
+    # Extract (completely) to ~/Downloads/GnuGP-VERSION.d
+    # (and detach the DMG)
+    rm -rf ~/Downloads/GnuPG-"${WEBI_VERSION}".d
+    pkgutil --expand-full /Volumes/GnuPG*/*.pkg ~/Downloads/GnuPG-"${WEBI_VERSION}".d
+    hdiutil detach -quiet /Volumes/GnuPG*
+
+    # Move to ~/.local/opt/gnugp (where it belongs!)
+    if [[ ! -e ~/.local/opt/gnupg-"${WEBI_VERSION}" ]]; then
+        mv ~/Downloads/GnuPG-"${WEBI_VERSION}".d/GnuPG.pkg/Payload/ ~/.local/opt/gnupg-"${WEBI_VERSION}"
+    fi
+
+    # Update symlink to latest
+    rm -rf ~/.local/opt/gnupg
+    ln -s gnupg-"${WEBI_VERSION}" ~/.local/opt/gnupg
+
+    pathman add ~/.local/opt/gnupg/bin
+    export PATH="$HOME/.local/opt/gnupg/bin/:$PATH"
+
+    # Prep for first use
+    mkdir -p ~/.gnupg/
+    chmod 0700 ~/.gnupg/
+    if [[ ! -e ~/.gnupg/gpg-agent.conf ]] || ! grep 'pinentry-program' ~/.gnupg/gpg-agent.conf; then
+        echo "pinentry-program $HOME/.local/opt/gnupg/bin/pinentry-mac.app/Contents/MacOS/pinentry-mac" >> ~/.gnupg/gpg-agent.conf
+    fi
+
+    # Start with launchd
+    mkdir -p ~/Library/LaunchAgents/
+    launchctl unload -w ~/Library/LaunchAgents/gpg-agent.plist 2> /dev/null || true
+    # TODO download and use sed to replace
+    echo '<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>gpg-agent</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>'"${HOME}"'/.local/opt/gpg/bin/gpg-connect-agent</string>
+		<string>--agent-program</string>
+		<string>'"${HOME}"'/.local/opt/gnupg/bin/gpg-agent</string>
+		<string>--homedir</string>
+		<string>'"${HOME}"'/.gnupg/</string>
+		<string>/bye</string>
+	</array>
+
+	<key>RunAtLoad</key>
+	<true/>
+
+	<key>WorkingDirectory</key>
+	<string>'"${HOME}"'</string>
+
+	<key>StandardErrorPath</key>
+	<string>'"${HOME}"'/.local/share/gpg-agent/var/log/gpg-agent.log</string>
+	<key>StandardOutPath</key>
+	<string>'"${HOME}"'/.local/share/gpg-agent/var/log/gpg-agent.log</string>
+</dict>
+</plist>' > ~/Library/LaunchAgents/gpg-agent.plist
+    launchctl load -w ~/Library/LaunchAgents/gpg-agent.plist
+    sleep 3
+
+    # (maybe) Create first key
+    if ! gpg --list-secret-keys | grep -q sec; then
+        _create_gpg_key
+    fi
+}
+
+function _create_gpg_key() {
+    if [[ ! -e ~/.gitconfig ]]; then
+        return 0
+    fi
+
+    MY_NAME="$(
+        grep 'name\s*=' ~/.gitconfig |
+            head -n 1 |
+            cut -d'=' -f2 |
+            sed -e 's/^[\t ]*//'
+    )"
+    if [[ -z ${MY_NAME} ]]; then
+        return 0
+    fi
+
+    MY_EMAIL="$(
+        grep 'email\s*=.*@' ~/.gitconfig |
+            tr -d '\t ' | head -n 1 |
+            cut -d'=' -f2
+    )"
+    if [[ -z ${MY_EMAIL} ]]; then
+        return 0
+    fi
+
+    MY_HOST="$(hostname)"
+
+    # Without passphrase:
+    #gpg --batch --generate-key --pinentry=loopback --passphrase=''
+
+    # With passphrase via macOS Keychain
+    gpg --batch --yes --generate-key << EOF
+     %echo Generating RSA 3072 key
+     Key-Type: RSA
+     Key-Length: 3072
+     Subkey-Type: RSA
+     Subkey-Length: 3072
+     Name-Real: ${MY_NAME}
+     Name-Comment: ${MY_HOST}
+     Name-Email: ${MY_EMAIL}
+     Expire-Date: 0
+     %commit
+EOF
+
+}
+
+_install_gpg

--- a/gpg/releases.js
+++ b/gpg/releases.js
@@ -1,0 +1,91 @@
+'use strict';
+
+let ltsRe = /GnuPG-(2\.2\.[\d\.]+)/;
+
+function createRssMatcher() {
+  return new RegExp(
+    '<link>(https://sourceforge\\.net/projects/gpgosx/files/GnuPG-([\\d\\.]+)\\.dmg/download)</link>',
+    'g'
+  );
+}
+
+function createUrlMatcher() {
+  return new RegExp(
+    'https://sourceforge\\.net/projects/gpgosx/files/(GnuPG-([\\d\\.]+)\\.dmg)/download',
+    ''
+  );
+}
+
+async function getRawReleases(request) {
+  let matcher = createRssMatcher();
+
+  let resp = await request({
+    url: 'https://sourceforge.net/projects/gpgosx/rss?path=/'
+  });
+  let links = [];
+  for (;;) {
+    let m = matcher.exec(resp.body);
+    if (!m) {
+      break;
+    }
+    links.push(m[1]);
+  }
+  return links;
+}
+
+function transformReleases(links) {
+  //console.log(JSON.stringify(links, null, 2));
+  //console.log(links.length);
+
+  let matcher = createUrlMatcher();
+
+  let releases = links
+    .map(function (link) {
+      // strip 'go' prefix, standardize version
+      let isLts = ltsRe.test(link);
+      let parts = link.match(matcher);
+      if (!parts || !parts[2]) {
+        return null;
+      }
+      let segs = parts[2].split('.');
+      let version = segs.slice(0, 3).join('.');
+      if (segs.length > 3) {
+        version += '+' + segs.slice(3);
+      }
+
+      return {
+        name: parts[1],
+        version: version,
+        // all go versions >= 1.0.0 are effectively LTS
+        lts: isLts,
+        channel: 'stable',
+        // TODO <pubDate>Sat, 19 Nov 2016 16:17:33 UT</pubDate>
+        date: '1970-01-01', // the world may never know
+        os: 'macos',
+        arch: 'amd64',
+        ext: 'dmg',
+        download: link
+      };
+    })
+    .filter(Boolean);
+
+  return {
+    releases: releases
+  };
+}
+
+async function getAllReleases(request) {
+  let releases = await getRawReleases(request);
+  let all = transformReleases(releases);
+  return all;
+}
+
+module.exports = getAllReleases;
+
+if (module === require.main) {
+  getAllReleases(require('@root/request')).then(function (all) {
+    all = require('../_webi/normalize.js')(all);
+    all.releases = all.releases.slice(0, 10000);
+    console.info(JSON.stringify(all, null, 2));
+  });
+}

--- a/iterm2/install.sh
+++ b/iterm2/install.sh
@@ -26,7 +26,7 @@ function _install_iterm2() {
     fi
 
     if [[ -d ~/Applications/iTerm.app ]]; then
-        mv ~/Applications/iTerm.app ${WEBI_TMP}/iTerm.app-webi.bak
+        mv ~/Applications/iTerm.app "${WEBI_TMP}/iTerm.app-webi.bak"
     fi
     mv "${WEBI_TMP}/iTerm.app" ~/Applications/
 }

--- a/macos/releases.js
+++ b/macos/releases.js
@@ -72,10 +72,10 @@ module.exports = function (request) {
       if ('10.11.6' === a.version) {
         return -1;
       }
-      if (a.date > a.date) {
+      if (a.date > b.date) {
         return 1;
       }
-      if (a.date < a.date) {
+      if (a.date < b.date) {
         return -1;
       }
     });

--- a/ssh-pubkey/install.sh
+++ b/ssh-pubkey/install.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
+set -e
+set -u
 
-{
-    set -e
-    set -u
-
+function __install_ssh_pubkey() {
     MY_CMD="ssh-pubkey"
 
     rm -f "$HOME/.local/bin/$MY_CMD"
@@ -13,3 +12,5 @@
     # run the command
     "$HOME/.local/bin/$MY_CMD"
 }
+
+__install_ssh_pubkey

--- a/ssh-utils/ssh-pubkey.sh
+++ b/ssh-utils/ssh-pubkey.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+set -e
+set -u
 
-{
-    set -e
-    set -u
+function _ssh_pubkey() {
 
     if [ ! -d "$HOME/.ssh" ]; then
         mkdir -p "$HOME/.ssh/"
@@ -32,6 +32,7 @@
 
     # TODO use the comment (if any) for the name of the file
     echo >&2 ""
+    #shellcheck disable=SC2088
     echo >&2 "~/Downloads/id_rsa.$(whoami).pub":
     echo >&2 ""
     rm -f "$HOME/Downloads/id_rsa.$(whoami).pub"
@@ -39,3 +40,5 @@
     cat "$HOME/Downloads/id_rsa.$(whoami).pub"
     echo >&2 ""
 }
+
+_ssh_pubkey


### PR DESCRIPTION
This is not a security bug, but an additional security measure.

UsePAM is usually not turned on for Linux servers, but is often turned on for macOS.

This is more for completeness than the typical Linux use case.

Re: https://apple.stackexchange.com/questions/315881/disable-ssh-password-authentication-on-high-sierra/340006?noredirect=1#comment616104_340006