### PR TITLE
refactor: replace pkg_get_current_version with file check

### DIFF
--- a/_example/install.sh
+++ b/_example/install.sh
@@ -27,13 +27,15 @@ function __init_foobar() {
         mv ./foobar-*/foo "$pkg_src_cmd"
     }
 
-    # pkg_get_current_version is recommended, but (soon) not required
+    # pkg_get_current_version is recommended, but not required
     pkg_get_current_version() {
         # 'foo --version' has output in this format:
         #       foobar 0.99.9 (rev abcdef0123)
         # This trims it down to just the version number:
         #       0.99.9
-        echo $(foo --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
+        foo --version 2> /dev/null |
+            head -n 1 |
+            cut -d ' ' -f 2
     }
 
 }


### PR DESCRIPTION
This change removes the need for specialized version checks and should make switching between versions and installing webi versions that are intended to take precedence over local versions all more reliable.

Now, rather than checking the output of `pkg_get_current_version`, we just check that the source and destination files are either the same, or different, and do _The Right Thing™_ accordingly.

I think the changes have been fairly well tested.

# To test

Just rm -rf ~/.local/bin/{rg,sd,fd} ~/.local/opt/{rg,sd,fd,node,go}* and reinstall some stuff and see that it all works as expected.

# Time to Say Goodbye

For reference, this is the code we removed:

```bash
pkg_current_version=""
if [ -n "$(command -v pkg_get_current_version)" ]; then
    pkg_current_version="$(
        pkg_get_current_version 2> /dev/null |
            head -n 1
    )"
fi
# remove trailing '.0's for golang's sake
my_current_version="$(echo "$pkg_current_version" | sed 's:\.0::g')"
my_src_version="$(echo "$WEBI_VERSION" | sed 's:\.0::g')"
```