### PR TITLE
bugfix(linux): prefer musl builds + allow armv7l or arm64 for RPi

### DIFF
--- a/_webi/normalize.js
+++ b/_webi/normalize.js
@@ -72,6 +72,13 @@ function normalize(all) {
           return osMap[regKey].test(rel.name || rel.download);
         }) || 'unknown';
     }
+    // Hacky-doo for musl
+    // TODO some sort of glibc vs musl tag?
+    if (!rel._musl) {
+      if (/(\b|\.|_|-)(musl)(\b|\.|_|-)/.test(rel.download)) {
+        rel._musl = true;
+      }
+    }
     supported.oses[rel.os] = true;
 
     if (!rel.arch) {

--- a/_webi/normalize.js
+++ b/_webi/normalize.js
@@ -104,7 +104,7 @@ function normalize(all) {
       if ('tar' === exts[1]) {
         rel.ext = exts.reverse().join('.');
         tarExt = 'tar';
-      } else if ('tgz' == exts[0]) {
+      } else if ('tgz' === exts[0]) {
         rel.ext = 'tar.gz';
         tarExt = 'tar';
       } else {

--- a/_webi/normalize.js
+++ b/_webi/normalize.js
@@ -28,26 +28,37 @@ formats.forEach(function (name) {
 // evaluation order matters
 // (i.e. otherwise x86 and x64 can cross match)
 var arches = [
-  'amd64', // first and most likely match
+  // arm 7 cannot be confused with arm64
+  'armv7l',
+  // amd64 is more likely than arm64
+  'amd64',
+  // arm6 has the same prefix as arm64
+  'armv6l',
+  // arm64 is more likely than arm6, and should be the default
   'arm64',
   'x86',
   'ppc64le',
   'ppc64',
-  'armv7l',
-  'armv6l',
   's390x'
 ];
+// Used for detecting system arch from package download url, for example:
+//
+// https://git.com/org/foo/releases/v0.7.9/foo-aarch64-linux-musl.tar.gz
+// https://git.com/org/foo/releases/v0.7.9/foo-arm-linux-musleabihf.tar.gz
+// https://git.com/org/foo/releases/v0.7.9/foo-armv7-linux-musleabihf.tar.gz
+// https://git.com/org/foo/releases/v0.7.9/foo-x86_64-linux-musl.tar.gz
+//
 var archMap = {
+  armv7l: /(\b|_)(armv?7l?)/i,
   //amd64: /(amd.?64|x64|[_\-]64)/i,
   amd64:
     /(\b|_|amd|(dar)?win(dows)?|mac(os)?|linux|osx|x)64([_\-]?bit)?(\b|_)/i,
   //x86: /(86)(\b|_)/i,
+  armv6l: /(\b|_)(aarch32|armv?6l?)(\b|_)/i,
+  arm64: /(\b|_)((aarch|arm)64|arm)/i,
   x86: /(\b|_|amd|(dar)?win(dows)?|mac(os)?|linux|osx|x)(86|32)([_\-]?bit)(\b|_)/i,
   ppc64le: /(\b|_)(ppc64le)/i,
   ppc64: /(\b|_)(ppc64)(\b|_)/i,
-  arm64: /(\b|_)((aarch|arm)64|arm)/i,
-  armv7l: /(\b|_)(armv?7l)/i,
-  armv6l: /(\b|_)(aarch32|armv?6l)/i,
   s390x: /(\b|_)(s390x)/i
 };
 arches.forEach(function (name) {

--- a/gh/README.md
+++ b/gh/README.md
@@ -15,8 +15,10 @@ To update or switch versions, run `webi gh@stable` (or `@v1`, `@beta`, etc).
 
 Installation:
 
-- For macOS and Windows [macOS/Windows](https://github.com/cli/cli/blob/trunk/README.md)
-- For linux Installation on specific distribution [linux](https://github.com/cli/cli/blob/trunk/docs/install_linux.md)
+- For macOS and Windows
+  [macOS/Windows](https://github.com/cli/cli/blob/trunk/README.md)
+- For linux Installation on specific distribution
+  [linux](https://github.com/cli/cli/blob/trunk/docs/install_linux.md)
 
 ### Authentication
 

--- a/package.json
+++ b/package.json
@@ -5,18 +5,14 @@
   "description": "webinstall script repository",
   "main": "_webi/",
   "scripts": {
+    "prettier": "npx prettier@2 -w '**/*.{js,md,html}'",
     "test": "node _webi/test.js ./node/"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/webinstall/webi-installers.git"
   },
-  "keywords": [
-    "webinstall",
-    "brew",
-    "apt",
-    "chocolately"
-  ],
+  "keywords": ["webinstall", "brew", "apt", "chocolately"],
   "author": "AJ ONeal <coolaj86@gmail.com> (https://coolaj86.com/)",
   "license": "MPL-2.0",
   "bugs": {

--- a/test/README.md
+++ b/test/README.md
@@ -8,5 +8,5 @@ linux: true
 
 ## Cheat Sheet
 
-> Don't install this package. It will install (almost) everything.
-> This is for webi CI/CD testing, etc.
+> Don't install this package. It will install (almost) everything. This is for
+> webi CI/CD testing, etc.


### PR DESCRIPTION
- `linux-musl` should be higher sort order (preferred) than `linux-gnu`
- `arm64` can be given instead of `armv7l` (for RPi 3+ Raspbian)
- `armv7l` can be given instead of `arm64` (for RPi 3+ Ubuntu  + _Bionic_)