### PR TITLE
Add make-workflows.sh

### DIFF
--- a/make-workflows.sh/README.md
+++ b/make-workflows.sh/README.md
@@ -4,3 +4,61 @@ homepage: https://github.com/kuvaldini/make-workflows.sh
 tagline: |
   make-workflows.sh: A tool to support YAML anchors for GitHub Actions Workflows – DRY for GHA 
 ---
+
+To update or switch versions, run `webi make-workflows.sh@stable` (or `@1.0.0`, `@beta`, etc).
+
+
+## Cheat Sheet
+
+> GitHub Workflow description in YAML does not support anchors.
+There are several workarounds => anyway [they](#links) come to building-editing workflow yaml from source.
+> So I suggest yet another one `make-workflows.sh` based on YAML tool [`yq`](https://github.com/mikefarah/yq) version 4.
+
+This simple script expands YAML anchors in GitHub workflows sources.
+
+
+### USAGE
+```
+$ ./make-workflows.sh --help
+make-workflows:
+   This script expands '*.src.yml' from $1..$[N-1] (default: REPO_ROOT/.github/)
+   to $N (default:REPO_ROOT/.github/workflows/) with corresponding name '*.yml'
+   Main goal is to dereference YAML anchors.
+   Deals only with Git cached/indexed files until --worktree passed.
+   DEBUG: use option -x
+   NOTE: spaces in filenames are not allowed to keep code simplicity.
+Usage:
+    make-workflows.sh [--worktree] [dirs_from... [dir_to]]
+    make-workflows.sh [--help]
+Options:
+   --worktree       List files and get contents from working tree
+                    instead of git index
+   -h, --help       show this help
+   -x, --trace, +x, --no-trace   enable/disable bash trace
+   -i, --install
+   --update
+   -V, --version
+```
+
+### Automate using pre-commit (recommended)
+There is a nice tool [pre-commit](https://pre-commit.com) to do checks and some actions just before commit. The tool is called by Git pre-commit hook.
+
+Making workflows is better being automated – just 
+```sh
+$ pre-commit install
+```
+and add next sample to [`.pre-commit-config.yaml`](/.pre-commit-config.yaml)
+```yaml
+repos:
+- repo: local
+  hooks:
+  - id: make-workflows
+    name: Make GitHub workflows from *.src.yml
+    entry: bash -c '.github/make-workflows.sh && git add .github/workflows'
+    language: system
+    files: '.github/.*\.src\.ya?ml'
+    pass_filenames: false
+```
+> NOTE: pay attention to path to `make-workflows.sh`
+
+> NOTE2: pay attention to path(s) where source files are stored `files: 'PATH_REGEXP'`

--- a/make-workflows.sh/README.md
+++ b/make-workflows.sh/README.md
@@ -1,0 +1,6 @@
+---
+title: make-workflows.sh
+homepage: https://github.com/kuvaldini/make-workflows.sh
+tagline: |
+  make-workflows.sh: A tool to support YAML anchors for GitHub Actions Workflows – DRY for GHA 
+---

--- a/make-workflows.sh/install.sh
+++ b/make-workflows.sh/install.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+# function __install_make_workflows_sh() {
+#     pkg_cmd_name="make-workflows.sh"
+#     pkg_dst_cmd="$HOME/.local/bin/$pkg_cmd_name"
+#     curl -LsSf \
+#         'https://raw.githubusercontent.com/kuvaldini/make-workflows.sh/main/make-workflows.sh' \
+#         >"$pkg_dst_cmd" \
+#     && chmod +x "$pkg_dst_cmd"
+# }
+# __install_make_workflows_sh
+
+
+function __init_make_workflows_sh() {
+
+    # Every package should define these 6 variables
+    pkg_cmd_name="make-workflows.sh"
+    pkg_dst_cmd="$HOME/.local/bin/$pkg_cmd_name"
+    pkg_dst="$pkg_dst_cmd"
+    pkg_src_dir="$HOME/.local/opt/$pkg_cmd_name-v$WEBI_VERSION"
+    pkg_src_cmd="$HOME/.local/opt/$pkg_cmd_name-v$WEBI_VERSION/bin/$pkg_cmd_name"
+    pkg_src="$pkg_src_cmd"
+
+    # pkg_install must be defined by every package
+    pkg_install() {
+        # ~/.local/opt/PACKAGE-v0.99.9/bin
+        mkdir -p "$(dirname "$pkg_src_cmd")"
+        # mv ./delta-*/delta ~/.local/opt/delta-v0.99.9/bin/delta
+        mv ./$pkg_cmd_name-*/$pkg_cmd_name "$pkg_src_cmd"
+    }
+
+    # pkg_get_current_version is recommended, but not required
+    pkg_get_current_version() {
+        # 'make-workflows.sh --version' has output in this format:
+        #       make-workflows.sh 1.0.0
+        # This trims it down to just the version number:
+        #       1.0.0
+        make-workflows.sh --version 2> /dev/null |
+            head -n 1 |
+            cut -d ' ' -f 2
+    }
+
+}
+
+__init_make_workflows_sh

--- a/make-workflows.sh/install.sh
+++ b/make-workflows.sh/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eu
 
 # function __install_make_workflows_sh() {
 #     pkg_cmd_name="make-workflows.sh"

--- a/make-workflows.sh/releases.js
+++ b/make-workflows.sh/releases.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var github = require('../_common/github.js');
+var owner = 'kuvaldini';
+var repo = 'make-workflows.sh';
+
+module.exports = function (request) {
+  return github(request, owner, repo).then(function (all) {
+    // remove checksums and .deb
+    all.releases = all.releases.filter(function (rel) {
+      return !/(\.txt)|(\.deb)|(\.asc)|(\.sha256)$/i.test(rel.name);
+    });
+    return all;
+  });
+};
+
+if (module === require.main) {
+  module.exports(require('@root/request')).then(function (all) {
+    all = require('../_webi/normalize.js')(all);
+    all.releases = all.releases.slice(0, 10);
+    console.info(JSON.stringify(all, null, 2));
+  });
+}


### PR DESCRIPTION
Hello, guys maintainers. There is one simple but useful repo for github actions users, who wants to be DRY and keep going with GHA. 

I like webi idea. It is strange to have just 168 stars. It would be nice to do not  make people to maintain yet another package manager. For example i can install it simply with npm without publishing to anywhere, just having  npmignore and package.json files in repo/. 

I do not like you use several languages and files for installer. releases.js and install.sh could be merged in one file. And since there are many utils with very similar instructions, they would look nicer just saying `webi kuvaldini/make-workflows.sh` to download and install the latest release for GH. Without publishing it here. What do you think about this?