### PR TITLE
add a few Github Actions entries to the cheat sheet

### DIFF
--- a/gh/README.md
+++ b/gh/README.md
@@ -20,6 +20,28 @@ Installation:
 - For linux Installation on specific distribution
   [linux](https://github.com/cli/cli/blob/trunk/docs/install_linux.md)
 
+### Actions
+
+Get a status of the most recently ran Actions workflows.
+
+```bash
+gh run list
+```
+
+View why a specific run failed.
+
+```bash
+gh view N
+```
+- where N is your failed job ID (third from the right column)
+
+Rerun a specific workflow that failed.
+
+```bash
+gh rerun N
+```
+- where N is your failed job ID (third from the right column)
+
 ### Authentication
 
 Authenticate with your Github account.

--- a/gh/README.md
+++ b/gh/README.md
@@ -20,28 +20,6 @@ Installation:
 - For linux Installation on specific distribution
   [linux](https://github.com/cli/cli/blob/trunk/docs/install_linux.md)
 
-### Actions
-
-Get a status of the most recently ran Actions workflows.
-
-```bash
-gh run list
-```
-
-View why a specific run failed.
-
-```bash
-gh view N
-```
-- where N is your failed job ID (third from the right column)
-
-Rerun a specific workflow that failed.
-
-```bash
-gh rerun N
-```
-- where N is your failed job ID (third from the right column)
-
 ### Authentication
 
 Authenticate with your Github account.
@@ -61,10 +39,10 @@ gh pr create -t <title> -b <body>
 Check out pull requests locally.
 
 ```bash
-gh pr checkout
+gh pr checkout <pr#>
 ```
 
-Check the status of yout pull requests.
+Check the status of your pull requests.
 
 ```bash
 gh pr status
@@ -92,6 +70,28 @@ Create a new release.
 gh release create 0.1
 ```
 
+### Actions
+
+How to see the status of recent jobs
+
+```bash
+gh run list
+```
+
+_Note_: The **Job ID** is the third from the right column.
+
+How to view failure details
+
+```bash
+gh run view <job-id>
+```
+
+How to rerun a failed job
+
+```bash
+gh run rerun <job-id>
+```
+
 ### Repo
 
 View repository READMEs.
@@ -102,7 +102,7 @@ gh repo view
 
 ### Create Shortcut
 
-Create Shortcut for a gh command.
+Create Shortcut for a `gh` command.
 
 ```bash
 gh alias set bugs 'issue list --label="bugs"'


### PR DESCRIPTION
Adds the following items to a new section called Actions:
- listing action workflows
- viewing the pass/fail steps of a workflow by ID
- rerun a workflow