### PR TITLE
fix(webi): add check for windows pwsh being run as admin

### DIFF
--- a/_webi/template.ps1
+++ b/_webi/template.ps1
@@ -11,7 +11,7 @@ function Confirm-IsElevated {
 }
 
 if (Confirm-IsElevated)
-{ throw "Please run script NOT as administrator" }
+{ throw "Webi MUST NOT be run with elevated privileges. Please run again as a normal user, NOT as administrator." }
 
 # this allows us to call ps1 files, which allows us to have spaces in filenames
 # ('powershell "$Env:USERPROFILE\test.ps1" foo' will fail if it has a space in

--- a/_webi/template.ps1
+++ b/_webi/template.ps1
@@ -1,4 +1,17 @@
 ﻿#!/usr/bin/env pwsh
+#350 check if windows user run as admin
+
+function Confirm-IsElevated {
+	$id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+	$p = New-Object System.Security.Principal.WindowsPrincipal($id)
+	if ($p.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator))
+	{ Write-Output $true }
+	else
+	{ Write-Output $false }
+}
+
+if (Confirm-IsElevated)
+{ throw "Please run script NOT as administrator" }
 
 # this allows us to call ps1 files, which allows us to have spaces in filenames
 # ('powershell "$Env:USERPROFILE\test.ps1" foo' will fail if it has a space in


### PR DESCRIPTION
#350 
I think this is a good place to put this check. Tested it and it throws a nice ugly error when you try to run the install-whatever.ps1 with powershell as admin and works in a non-elevated environment.