### PR TITLE
vim-commentary installer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@
       <https://gist.github.com/nicerobot/53cee11ee0abbdc997661e65b348f375>
     - Common exceptions:
 
-      ```txt
+      ```text
       # We make use of `.` (source) to import without exports
       SC2034: foo appears unused. Verify it or export it.
       SC2154: var is referenced but not assigned.
@@ -94,15 +94,15 @@ The general format is `<type>(<package>): <description>`, using these _types_:
 
 Try to write your commit messages (in the present tense) like this:
 
-```txt
+```text
 fix(node): update install.sh (fix #200)
 ```
 
-```txt
+```text
 feat(delta): add cheat sheet and install.sh
 ```
 
-```txt
+```text
 docs(ssh-adduser): document that foo does bar
 ```
 

--- a/_example/README.md
+++ b/_example/README.md
@@ -20,7 +20,7 @@ etc).
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.config/envman/PATH.env
 ~/.local/bin/foo
 ~/.local/opt/foo

--- a/arc/README.md
+++ b/arc/README.md
@@ -18,42 +18,42 @@ create a top-level directory if one does not exist.
 
 ### List
 
-```txt
+```text
 # arc ls <archive file>
 arc ls   example.zip
 ```
 
 ### Unarchive (whole)
 
-```txt
+```text
 # arc unarchive <archive file>
 arc unarchive   example.zip
 ```
 
 ### Extract (partial)
 
-```txt
+```text
 # arc extract <archive file> <archived path> <extracted path>
 arc extract   example.zip    example/foo     ~/Downloads/foo
 ```
 
 ### Archive (recursive)
 
-```txt
+```text
 # arc archive <archive file> <files or folders ...>
 arc archive   example.zip    ./README.md ./bin ./src
 ```
 
 ### Compress (single file)
 
-```txt
+```text
 # arc compress <single file> <format>
 arc compress   ./example.tar xz
 ```
 
 ### Decompress (single file)
 
-```txt
+```text
 # arc decompress <archive file>
 arc decompress   ./example.tar.xz
 ```

--- a/bat/README.md
+++ b/bat/README.md
@@ -62,7 +62,7 @@ Edit the config file:
 
 `~/.config/bat/config`:
 
-```txt
+```text
 # no numbers or headers, just highlighting and such
 --style="plain"
 ```

--- a/bun/README.md
+++ b/bun/README.md
@@ -13,7 +13,7 @@ To update or switch versions, run `webi bun@<tag>`. \
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.config/envman/PATH.env
 ~/.local/opt/bun/
 ~/.local/opt/bun-<VERSION>/

--- a/chromedriver/README.md
+++ b/chromedriver/README.md
@@ -33,7 +33,7 @@ sudo apt --fix-broken install -y
 
 You may get an error like this:
 
-```txt
+```text
 chromedriver: error while loading shared libraries: libnss3.so: cannot open shared object file: No such file or directory
 ```
 

--- a/dashmsg/README.md
+++ b/dashmsg/README.md
@@ -34,7 +34,7 @@ dashmsg gen > pirv.wif
 dashmsg sign ./priv.wif 'vote2022-alice|bob|charlie'
 ```
 
-```txt
+```text
 H2Opy9NX72iPZRcDVEHrFn2qmVwWMgc+DKILdVxl1yfmcL2qcpu9esw9wcD7RH0/dJHnIISe5j39EYahorWQM7I=
 ```
 
@@ -58,7 +58,7 @@ Addresses:
 dashmsg inspect 'XK5DHnAiSj6HQNsNcDkawd9qdp8UFMdYftdVZFuRreTMJtbJhk8i'
 ```
 
-```txt
+```text
 PrivateKey (hex): cc (coin type)
                 : e84f59fec1c8cc7feb9ce1c829849ae336f73e56437301eb5db945c8e0dd2683
                 : 01 (compressed)
@@ -76,7 +76,7 @@ Address   (b58c): Xn4A2vv5fb7LvmiiXPPMexYbSbiQ29rzDu
 dashmsg inspect 'IFLv0JVRM70bTZCTmzMfNX3NVkSULmnAR/3PSWpgC5GXBD7rRi5g4QsK968ITE3dfKdzhX7fAIXwhpnsP0WvQOc='
 ```
 
-```txt
+```text
 I     (0): 1 (quadrant)
 R  (1-32): 52efd0955133bd1b4d90939b331f357dcd5644942e69c047fdcf496a600b9197
 S (33-64): 043eeb462e60e10b0af7af084c4ddd7ca773857edf0085f08699ec3f45af40e7
@@ -88,7 +88,7 @@ S (33-64): 043eeb462e60e10b0af7af084c4ddd7ca773857edf0085f08699ec3f45af40e7
 dashmsg inspect 'Xn4A2vv5fb7LvmiiXPPMexYbSbiQ29rzDu'
 ```
 
-```txt
+```text
 Address    (hex): 4c (coin type)
                 : 7cb1500163c8d413314dc238f9268b6c723a48f0
 ```

--- a/delta/README.md
+++ b/delta/README.md
@@ -13,7 +13,7 @@ To update or switch versions, run `webi delta` (or `@0.9.1`, `@0.9.0`, etc).
 
 These are the files that are created and/or modified with this installer:
 
-```txt
+```text
 ~/.config/envman/PATH.env
 ~/.gitconfig
 ~/.local/bin/delta
@@ -73,7 +73,7 @@ Here's the current list, for convenience:
 
 ### Dark Syntax Themes
 
-```txt
+```text
 1337
 Coldark-Cold
 Coldark-Dark
@@ -97,7 +97,7 @@ zenburn
 
 ### Light Syntax Themes
 
-```txt
+```text
 GitHub
 Monokai Extended Light
 OneHalfLight

--- a/dotenv-linter/README.md
+++ b/dotenv-linter/README.md
@@ -67,7 +67,7 @@ dotenv-linter --skip QuoteCharacter --skip UnorderedKey
 
 You can see the full list of linter rules with `dotenv-linter --show-checks`:
 
-```txt
+```text
 DuplicatedKey
 EndingBlankLine
 ExtraBlankLine

--- a/dotenv/README.md
+++ b/dotenv/README.md
@@ -31,7 +31,7 @@ dotenv -f .env -- node server.js --debug
 
 ## ENV syntax
 
-```txt
+```text
 # comments and blank lines are ignored
 
 # you can use quotes of either style

--- a/duckdns.sh/README.md
+++ b/duckdns.sh/README.md
@@ -13,7 +13,7 @@ To update or switch versions, run `webi duckdns.sh@stable` (or `@v1.0.3`,
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.config/envman/PATH.env
 ~/.local/bin/duckdns.sh
 ~/.config/duckdns.sh/

--- a/fish/README.md
+++ b/fish/README.md
@@ -121,7 +121,7 @@ command -v fish
 
 Then update the Terminal preferences:
 
-```txt
+```text
 Terminal > Preferences > General > Shells open with:
 /Users/YOUR_USER/.local/bin/fish
 ```

--- a/fzf/README.md
+++ b/fzf/README.md
@@ -29,6 +29,6 @@ sudo journalctl -u my-app-name  --since '2020-01-01' | fzf
 
 ### Use space-delimited regular expressions to search
 
-```txt
+```text
 ^README | .md$ | .txt$
 ```

--- a/git-config-gpg/README.md
+++ b/git-config-gpg/README.md
@@ -29,7 +29,7 @@ git-config-gpg
 
 Example output:
 
-```txt
+```text
 GnuPG Public Key ID: CA025BC42F00BBBE
 
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -55,7 +55,7 @@ How to verify signed commits on GitHub:
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.config/envman/PATH.env
 ~/.local/bin/git-config-gpg
 ~/Downloads/YOU.KEY_ID.gpg.asc
@@ -75,7 +75,7 @@ set it to 400 days and call it good.
 
 `~/.gnupg/gpg-agent.conf`:
 
-```txt
+```text
 default-cache-ttl 34560000
 max-cache-ttl 34560000
 ```
@@ -137,7 +137,7 @@ Or, if you prefer to edit the text file directly:
 
 `~/.gitconfig`
 
-```txt
+```text
 [user]
   signingkey = CA025BC42F00BBBE
 [commit]
@@ -153,7 +153,7 @@ versions of gpg, like so:
 git config --global gpg.program ~/.local/opt/gnupg/bin/gpg
 ```
 
-```txt
+```text
 [gpg]
   program = /Users/me/.local/opt/gnupg/bin/gpg
 ```
@@ -163,7 +163,7 @@ git config --global gpg.program ~/.local/opt/gnupg/bin/gpg
 `gpg` is generally expected to be used with a Desktop client. On Linux servers
 you may get this error:
 
-```txt
+```text
 error: gpg failed to sign the data
 fatal: failed to write commit object
 ```

--- a/git/README.md
+++ b/git/README.md
@@ -29,7 +29,7 @@ git commit -m "my summary for this commit"
 In your project repository create a `.gitignore` file with patterns of fies to
 ignore
 
-```txt
+```text
 .env*
 *.bak
 *.tmp

--- a/gitdeploy/README.md
+++ b/gitdeploy/README.md
@@ -59,7 +59,7 @@ repository's URL, like this:
 The deploy scripts should exist in your `scripts/` directory, named after the
 repo's name.
 
-```txt
+```text
 scripts/github.com/YOUR_ORG/YOUR_PROJECT/deploy.sh
 ```
 

--- a/golang/README.md
+++ b/golang/README.md
@@ -63,7 +63,7 @@ You may also want to install the Go IDE tooling:
    ./hello
    ```
    You should see your output:
-   ```txt
+   ```text
    > Hello, World!
    ```
 

--- a/gpg-pubkey/README.md
+++ b/gpg-pubkey/README.md
@@ -27,7 +27,7 @@ curl https://webi.sh/gpg-pubkey | sh
 
 This is what the output of `gpg-pubkey` looks like (except much longer):
 
-```txt
+```text
 GnuPG Public Key ID: CA025BC42F00BBBE
 
 ~/Downloads/john@example.com.gpg.asc:
@@ -49,7 +49,7 @@ Note: Your public key is the _entire_ section starting with and including
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.config/envman/PATH.env
 ~/.local/bin/gpg-pubkey
 ~/.local/bin/gpg-pubkey-id
@@ -143,7 +143,7 @@ format:
 gpg --list-secret-keys --keyid-format LONG
 ```
 
-```txt
+```text
 /Users/me/.gnupg/pubring.kbx
 ----------------------------
 sec   rsa3072/CA025BC42F00BBBE 2021-11-10 [SCEA]
@@ -154,7 +154,7 @@ ssb   rsa3072/674124162BF19A32 2021-11-10 [SEA]
 
 The line with the Public Key ID is the one that starts with `sec`:
 
-```txt
+```text
 sec   rsa3072/CA025BC42F00BBBE 2021-11-10 [SCEA]
 ```
 

--- a/gpg/README.md
+++ b/gpg/README.md
@@ -31,7 +31,7 @@ Here we'll cover:
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.config/envman/PATH.env
 ~/.local/opt/gnupg/bin/gpg
 ~/.local/opt/gnupg/bin/gpg-agent
@@ -123,7 +123,7 @@ launchctl load -w ~/Library/LaunchAgents/gpg-agent.plist
 `gpg` is generally expected to be used with a Desktop client. On Linux servers
 you may get this error:
 
-```txt
+```text
 error: gpg failed to sign the data
 fatal: failed to write commit object
 ```

--- a/iterm2-themes/README.md
+++ b/iterm2-themes/README.md
@@ -15,7 +15,7 @@ tagline: |
 
 The installer will download them to `~/Downloads/webi/iterm2-themes`
 
-```txt
+```text
 ~/Downloads/webi/iterm2-themes/Tomorrow\ Night.itermcolors
 ~/Downloads/webi/iterm2-themes/Firewatch.itermcolors
 ~/Downloads/webi/iterm2-themes/Dracula.itermcolors

--- a/jq/README.md
+++ b/jq/README.md
@@ -27,7 +27,7 @@ You can also [try online](https://jqplay.org/).
 echo '{ "name": "foo" }' | jq '.name'
 ```
 
-```txt
+```text
 "foo"
 ```
 
@@ -39,7 +39,7 @@ The `-r` or `--raw-output` flag unwraps strings:
 echo '{ "name": "foo" }' | jq -r '.name'
 ```
 
-```txt
+```text
 foo
 ```
 
@@ -49,7 +49,7 @@ foo
 echo '{ "name": "foo" }' | jq '.'
 ```
 
-```txt
+```text
 {
   "name": "foo"
 }
@@ -61,7 +61,7 @@ echo '{ "name": "foo" }' | jq '.'
 echo '[ { "name": "foo" } ]' | jq '.[0]'
 ```
 
-```txt
+```text
 {
   "name": "foo"
 }
@@ -73,7 +73,7 @@ echo '[ { "name": "foo" } ]' | jq '.[0]'
 echo '[ { "name": "foo" } ]' | jq -r '.[0].name'
 ```
 
-```txt
+```text
 foo
 ```
 
@@ -84,7 +84,7 @@ echo '[ { "name": "foo" }, { "name": "bar" } ]' \
     | jq -r '.[].name'
 ```
 
-```txt
+```text
 foo
 bar
 ```
@@ -106,7 +106,7 @@ echo '[ { "name": "foo", "age": 0 }, { "name": "bar", "age": 2 } ]' \
     | jq '{ names: [.[] | .name], ages: [.[] | .age] }'
 ```
 
-```txt
+```text
 {
   "names": [
     "foo",

--- a/jshint/README.md
+++ b/jshint/README.md
@@ -13,7 +13,7 @@ etc).
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.config/envman/PATH.env
 ~/.local/opt/node
 ~/.jshintrc.defaults.json5

--- a/keypairs/README.md
+++ b/keypairs/README.md
@@ -50,7 +50,7 @@ keypairs sign --exp 1h key.jwk.json '{ "sub": "me@example.com" }' > token.jwt 2>
 A JWT (JSON Web Token) has 3 sections (protected header, payload, and signature)
 separated by dots (`.`):
 
-```txt
+```text
 eyJhbGciOiJFUzI1NiIsImtpZCI6ImpkeHhZY1NCZUJfeUdoZWlCVW14NjF0eHExZGFjR1hIX191bEJuWlZHMEUiLCJ0eXAiOiJKV1QifQ.eyJleHAiOjIxNDczODU3MTIsInN1YiI6Im1lQGV4YW1wbGUuY29tIn0.oh8-PUMdrbQU6seRXjo68wPWAKbA-V9LMnd_wZEkPHc3C8A5xJzV7mDDMNOLEy4VcuNGxced_yjYulzcMa5FLQ
 ```
 

--- a/koji/README.md
+++ b/koji/README.md
@@ -25,7 +25,7 @@ You can use koji in one of two ways:
 
 Here's the shortlist of options we've found most useful:
 
-```txt
+```text
 -e, --emoji - use emoji for commit type (ex: `✨ feat:`)
 -a, --autocomplete - guess 'scope' based on commit history (slow on large projects)
 --hook - expect to be run from 'git commit', rather than wrap it

--- a/macos/README.md
+++ b/macos/README.md
@@ -12,6 +12,6 @@ tagline: |
 
 Use with Balena Etcher to burn ISO to USB, or boot with VirtualBox.
 
-```txt
+```text
 Created ~/Downloads/el-capitan.iso
 ```

--- a/myip/README.md
+++ b/myip/README.md
@@ -20,7 +20,7 @@ webi myip
 
 Example output:
 
-```txt
+```text
 IPv4 (A)   : 136.36.196.101
 IPv6 (AAAA): 2605:a601:a919:9800:f8be:f2c4:9ad7:9763
 ```

--- a/ots/README.md
+++ b/ots/README.md
@@ -12,7 +12,7 @@ To update or switch versions, run `webi ots@stable` (or `@v2`, `@beta`, etc).
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.config/envman/PATH.env
 ~/.local/bin/ots
 ~/.local/opt/ots

--- a/pathman/README.md
+++ b/pathman/README.md
@@ -40,7 +40,7 @@ Note: Even on Windows it is best to use Unix-style `/` paths and `~` for
 pathman list
 ```
 
-```txt
+```text
 pathman-managed PATH entries:
 
 	$HOME/.local/bin

--- a/prettier/README.md
+++ b/prettier/README.md
@@ -13,7 +13,7 @@ etc).
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.config/envman/PATH.env
 ~/.local/opt/node
 ```

--- a/pyenv/README.md
+++ b/pyenv/README.md
@@ -71,7 +71,7 @@ pyenv global system
 pyenv install --list
 ```
 
-```txt
+```text
   3.10.7
   activepython-3.6.0
   anaconda3-2020.11

--- a/python/README.md
+++ b/python/README.md
@@ -35,7 +35,7 @@ sudo apt install -y libreadline-dev libbz2-dev libsqlite3-dev
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.bashrc (or your shell's equivalent)
 ~/.config/envman/PATH.env
 ~/.pyenv

--- a/python2/README.md
+++ b/python2/README.md
@@ -35,7 +35,7 @@ sudo apt install -y libreadline-dev libbz2-dev libsqlite3-dev
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.bashrc (or your shell's equivalent)
 ~/.config/envman/PATH.env
 ~/.pyenv

--- a/sclient/README.md
+++ b/sclient/README.md
@@ -85,7 +85,7 @@ sclient whatever.com -
 
 Use just like netcat or telnet. A manual HTTP request, for example:
 
-```txt
+```text
 > GET / HTTP/1.1
 > Host: whatever.com
 > Connection: close

--- a/serviceman/README.md
+++ b/serviceman/README.md
@@ -79,7 +79,7 @@ serviceman list --system
 serviceman list --user
 ```
 
-```txt
+```text
 serviceman-managed services:
 
         example-service
@@ -97,7 +97,7 @@ sudo env PATH="$PATH" serviceman start example-service
 
 ## What a typical systemd .service file looks like
 
-```txt
+```text
 [Unit]
 Description=example-service
 After=network-online.target
@@ -126,7 +126,7 @@ WantedBy=multi-user.target
 
 ## What a typical launchd .plist file looks like
 
-```txt
+```text
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated for serviceman. Edit as you wish, but leave this line. -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/setcap-netbind/README.md
+++ b/setcap-netbind/README.md
@@ -16,7 +16,7 @@ tagline: |
 
 Gives a command permission to run on privileged ports (80, 443, etc).
 
-```txt
+```text
 Usage:
     sudo setcap-netbind <COMMAND>
 

--- a/shfmt/README.md
+++ b/shfmt/README.md
@@ -19,7 +19,7 @@ used.
 
 ### Frequently used flags:
 
-```txt
+```text
 -version
 	Show version and exit.
 

--- a/ssh-pubkey/README.md
+++ b/ssh-pubkey/README.md
@@ -23,7 +23,7 @@ The easiest way to get your SSH Public Key:
 curl https://webi.sh/ssh-pubkey | sh
 ```
 
-```txt
+```text
 ~/Downloads/id_rsa.johndoe.pub:
 
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTOhRnzDJNBNBXVCgkxkEaDM4IAp81MtE8fuqeQuFvq5gYLWoZND39N++bUvjMRCveWzZlQNxcLjXHlZA3mGj1b9aMImrvyoq8FJepe+RLEuptJe3md4EtTXo8VJuMXV0lJCcd9ct+eqJ0jH0ww4FDJXWMaFbiVwJBO0IaYevlwcf0QwH12FCARZUSwXfsIeCZNGxOPamIUCXumpQiAjTLGHFIDyWwLDCNPi8GyB3VmqsTNEvO/H8yY4VI7l9hpztE5W6LmGUfTMZrnsELryP5oRlo8W5oVFFS85Lb8bVfn43deGdlLGkwmcJuXzZfostSTHI5Mj7MWezPZyoSqFLl johndoe@MacBook-Air

--- a/ssh-utils/README.md
+++ b/ssh-utils/README.md
@@ -19,7 +19,7 @@ and place it in `~/Downloads`.
 ssh-pubkey
 ```
 
-```txt
+```text
 ~/Downloads/id_rsa.johndoe.pub:
 
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTOhRnzDJNBNBXVCgkxkEaDM4IAp81MtE8fuqeQuFvq5gYLWoZND39N++bUvjMRCveWzZlQNxcLjXHlZA3mGj1b9aMImrvyoq8FJepe+RLEuptJe3md4EtTXo8VJuMXV0lJCcd9ct+eqJ0jH0ww4FDJXWMaFbiVwJBO0IaYevlwcf0QwH12FCARZUSwXfsIeCZNGxOPamIUCXumpQiAjTLGHFIDyWwLDCNPi8GyB3VmqsTNEvO/H8yY4VI7l9hpztE5W6LmGUfTMZrnsELryP5oRlo8W5oVFFS85Lb8bVfn43deGdlLGkwmcJuXzZfostSTHI5Mj7MWezPZyoSqFLl johndoe@MacBook-Air

--- a/vim-ale/README.md
+++ b/vim-ale/README.md
@@ -33,7 +33,7 @@ source ~/.vim/plugins/ale.vim
 
 `.vim/plugins/ale.vim`:
 
-```txt
+```text
 " turn on the syntax checker
 syntax on
 

--- a/vim-commentary/README.md
+++ b/vim-commentary/README.md
@@ -1,0 +1,49 @@
+---
+title: vim-commentary
+homepage: https://github.com/tpope/vim-commentary
+tagline: |
+  Toggle blocks of line comments.
+---
+
+To update (replacing the current version) run `webi vim-smartcase`.
+
+### Files
+
+These are the files / directories that are created and/or modified with this
+install:
+
+```text
+~/.vimrc
+~/.vim/pack/plugins/start/vim-commentary/
+~/.vim/plugins/smartcase.vim
+```
+
+## Cheat Sheet
+
+> Makes it super easy to toggle entire blocks of comments.
+
+```vim
+gc
+```
+
+- `v` to enter visual model
+- `hjkl` (or arrow keys) to select lines
+- `gc` to toggle comments on or off
+
+### How to add file types
+
+Update `~/.vim/plugins/commentary.vim` with a line like this:
+
+```vim
+autocmd FileType apache setlocal commentstring=#\ %s
+```
+
+### How to do Advanced Vim-Nerd Stuff
+
+All the typical navigation applies:
+
+> Use `gcc` to comment out a line (takes a count), `gc` to comment out the
+> target of a motion (for example, `gcap` to comment out a paragraph), `gc` in
+> operator pending mode to target a comment. You can also use it as a command,
+> either with a range like `:7,17Commentary`, or as part of a `:global`
+> invocation like with `:g/TODO/Commentary`. - The Official README

--- a/vim-commentary/commentary.vim
+++ b/vim-commentary/commentary.vim
@@ -1,0 +1,2 @@
+" Example of a adding additional file type support:
+"autocmd FileType apache setlocal commentstring=#\ %s

--- a/vim-commentary/install.ps1
+++ b/vim-commentary/install.ps1
@@ -1,0 +1,17 @@
+#!/usr/bin/env pwsh
+
+$my_name = "commentary"
+$my_pkg_name = "vim-commentary"
+$my_repo = "https://github.com/tpope/vim-commentary"
+
+IF (!(Test-Path -Path "$Env:USERPROFILE\.vim\pack\plugins\start")) {
+    New-Item -Path "$Env:USERPROFILE\.vim\pack\plugins\start" -ItemType Directory -Force | out-null
+}
+
+Remove-Item -Path "$Env:USERPROFILE\.vim\pack\plugins\start\${my_name}" -Recurse -ErrorAction Ignore
+& git clone --depth=1 "$my_repo" "$Env:USERPROFILE\.vim\pack\plugins\start\$my_name.vim"
+
+IF (!(Test-Path -Path "$Env:USERPROFILE\.vim\plugin\$my_name.vim")) {
+    IF ($Env:WEBI_HOST -eq $null -or $Env:WEBI_HOST -eq "") { $Env:WEBI_HOST = "https://webinstall.dev" }
+    curl.exe -sS -o "$Env:USERPROFILE\.vim\plugin\$my_name.vim" "$Env:WEBI_HOST/packages/${my_pkg_name}/${my_name}.vim"
+}

--- a/vim-commentary/install.sh
+++ b/vim-commentary/install.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+__install_vim_plugin() { (
+    set -e
+    set -u
+
+    my_name="commentary"
+    my_pkg_name="vim-commentary"
+    my_repo="https://github.com/tpope/vim-commentary.git"
+    my_note="vim-commentary: installed via webinstall.dev/vim-commentary"
+    my_installed_msg="${my_pkg_name} installed with example config"
+
+    mkdir -p ~/.vim/pack/plugins/start
+    rm -rf ~/.vim/pack/plugins/start/"${my_pkg_name}"
+    git clone --depth=1 "${my_repo}" ~/.vim/pack/plugins/start/"${my_pkg_name}"
+
+    if [ ! -f ~/.vimrc ]; then
+        touch ~/.vimrc
+    fi
+
+    mkdir -p ~/.vim/plugins
+    if ! [ -f ~/.vim/plugins/"${my_name}.vim" ]; then
+        WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
+        curl -fsSL -o ~/.vim/plugins/"${my_name}.vim" "$WEBI_HOST/packages/${my_pkg_name}/${my_name}.vim"
+    fi
+
+    if ! grep "source.*plugins.${my_name}.vim" -r ~/.vimrc > /dev/null 2> /dev/null; then
+        set +e
+        mkdir -p ~/.vim/plugins
+        printf '\n" %s\n' "${my_note}" >> ~/.vimrc
+        printf 'source ~/.vim/plugins/%s.vim\n' "${my_name}" >> ~/.vimrc
+        set -e
+        echo ""
+        echo "add ~/.vim/plugins/${my_name}.vim"
+        echo "updated ~/.vimrc with 'source ~/.vim/plugins/${my_name}.vim'"
+    fi
+
+    echo ""
+    echo "${my_installed_msg}"
+
+); }
+
+__install_vim_plugin

--- a/vim-essentials/README.md
+++ b/vim-essentials/README.md
@@ -12,7 +12,7 @@ To update (replacing the current version) run `webi vim-essentials`.
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.config/envman/PATH.env
 ~/.local/bin/
 ~/.local/opt/

--- a/vim-sensible/install.ps1
+++ b/vim-sensible/install.ps1
@@ -1,13 +1,17 @@
 #!/usr/bin/env pwsh
 
+$my_name = "sensible"
+$my_pkg_name = "vim-sensible"
+$my_repo = "https://github.com/tpope/vim-sensible"
+
 IF (!(Test-Path -Path "$Env:USERPROFILE\.vim\pack\plugins\start")) {
     New-Item -Path "$Env:USERPROFILE\.vim\pack\plugins\start" -ItemType Directory -Force | out-null
 }
-Remove-Item -Path "$Env:USERPROFILE\.vim\pack\plugins\start\vim-sensible" -Recurse -ErrorAction Ignore
 
-# Note: we've had resolution issues in the past, and it doesn't seem likely that tpope
-#       will switch from using GitHub as the primary host, so we skip the redirect
-#       and use GitHub directly. Open to changing this back in the future.
-#$sensible_repo = "https://tpope.io/vim/sensible.git"
-$sensible_repo = "https://github.com/tpope/vim-sensible.git"
-& git clone --depth=1 "$sensible_repo" "$Env:USERPROFILE\.vim\pack\plugins\start\vim-sensible"
+Remove-Item -Path "$Env:USERPROFILE\.vim\pack\plugins\start\${my_name}" -Recurse -ErrorAction Ignore
+& git clone --depth=1 "$my_repo" "$Env:USERPROFILE\.vim\pack\plugins\start\$my_name.vim"
+
+IF (!(Test-Path -Path "$Env:USERPROFILE\.vim\plugin\$my_name.vim")) {
+    IF ($Env:WEBI_HOST -eq $null -or $Env:WEBI_HOST -eq "") { $Env:WEBI_HOST = "https://webinstall.dev" }
+    curl.exe -sS -o "$Env:USERPROFILE\.vim\plugin\$my_name.vim" "$Env:WEBI_HOST/packages/${my_pkg_name}/${my_name}.vim"
+}

--- a/vim-sensible/install.sh
+++ b/vim-sensible/install.sh
@@ -1,19 +1,43 @@
 #!/bin/sh
 
-__init_vim_sensible() {
+__install_vim_plugin() { (
     set -e
     set -u
 
-    mkdir -p "$HOME/.vim/pack/plugins/start"
-    rm -rf "$HOME/.vim/pack/plugins/start/sensible" "$HOME/.vim/pack/plugins/start/vim-sensible"
+    my_name="sensible"
+    my_pkg_name="vim-sensible"
+    my_repo="https://github.com/tpope/vim-sensible.git"
+    my_note="vim-sensible: installed via webinstall.dev/vim-sensible"
+    my_installed_msg="${my_pkg_name} installed, and marked as such in ~/.vimrc"
 
-    # Note: we've had resolution issues in the past, and it doesn't seem likely
-    #       that tpope will switch from using GitHub as the primary host, so we
-    #       skip the redirect and use GitHub directly.
-    #       Open to changing this back in the future.
-    #my_sensible_repo="https://tpope.io/vim/sensible.git"
-    my_sensible_repo="https://github.com/tpope/vim-sensible.git"
-    git clone --depth=1 "${my_sensible_repo}" "$HOME/.vim/pack/plugins/start/vim-sensible"
-}
+    mkdir -p ~/.vim/pack/plugins/start
+    rm -rf ~/.vim/pack/plugins/start/"${my_pkg_name}"
+    git clone --depth=1 "${my_repo}" ~/.vim/pack/plugins/start/"${my_pkg_name}"
 
-__init_vim_sensible
+    if [ ! -f ~/.vimrc ]; then
+        touch ~/.vimrc
+    fi
+
+    mkdir -p ~/.vim/plugins
+    if ! [ -f ~/.vim/plugins/"${my_name}.vim" ]; then
+        WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
+        curl -fsSL -o ~/.vim/plugins/"${my_name}.vim" "$WEBI_HOST/packages/${my_pkg_name}/${my_name}.vim"
+    fi
+
+    if ! grep "source.*plugins.${my_name}.vim" -r ~/.vimrc > /dev/null 2> /dev/null; then
+        set +e
+        mkdir -p ~/.vim/plugins
+        printf '\n" %s\n' "${my_note}" >> ~/.vimrc
+        printf 'source ~/.vim/plugins/%s.vim\n' "${my_name}" >> ~/.vimrc
+        set -e
+        echo ""
+        echo "add ~/.vim/plugins/${my_name}.vim"
+        echo "updated ~/.vimrc with 'source ~/.vim/plugins/${my_name}.vim'"
+    fi
+
+    echo ""
+    echo "${my_installed_msg}"
+
+); }
+
+__install_vim_plugin

--- a/vim-sensible/sensible.vim
+++ b/vim-sensible/sensible.vim
@@ -1,0 +1,2 @@
+" vim-sensible has no config options
+" this is just a placeholder to mark that it's been installed

--- a/vim-shell/README.md
+++ b/vim-shell/README.md
@@ -12,7 +12,7 @@ To update (replacing the current version) run `webi vim-shell`.
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.vimrc
 ~/.vim/plugins/shell.vim
 ```

--- a/vim-shfmt/README.md
+++ b/vim-shfmt/README.md
@@ -7,6 +7,17 @@ tagline: |
 
 To update (replacing the current version) run `webi vim-shfmt`.
 
+### Files
+
+```text
+~/.config/envman/PATH.env
+~/.vimrc
+~/.vim/pack/plugins/start/shfmt
+~/.vim/plugins/shfmt.vim
+~/.local/bin/shfmt
+~/.local/bin/shellcheck
+```
+
 ## Cheat Sheet
 
 `vim-shfmt` uses [shfmt](https://webinstall.dev/shfmt) to format your `bash`
@@ -20,17 +31,6 @@ This plugin comes with reasonable defaults, which install to
 ```vim
 let g:shfmt_extra_args = '-i 4 -sr -ci -s'
 let g:shfmt_fmt_on_save = 1
-```
-
-### Files
-
-```txt
-~/.config/envman/PATH.env
-~/.vimrc
-~/.vim/pack/plugins/start/shfmt
-~/.vim/plugins/shfmt.vim
-~/.local/bin/shfmt
-~/.local/bin/shellcheck
 ```
 
 ### How to install and configure manually

--- a/vim-smartcase/README.md
+++ b/vim-smartcase/README.md
@@ -12,7 +12,7 @@ To update (replacing the current version) run `webi vim-smartcase`.
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.vimrc
 ~/.vim/plugins/smartcase.vim
 ```

--- a/vim-spell/README.md
+++ b/vim-spell/README.md
@@ -12,7 +12,7 @@ To update (replacing the current version) run `webi vim-spell`.
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.vimrc
 ~/.vim/plugins/spell.vim
 ```

--- a/vim-syntastic/README.md
+++ b/vim-syntastic/README.md
@@ -27,7 +27,7 @@ git clone --depth=1 https://github.com/vim-syntastic/syntastic.git ~/.vim/pack/p
 
 `.vimrc`:
 
-```txt
+```text
 " manually set plugin to use bash - not zsh, fish, etc
 set shell=bash
 
@@ -45,7 +45,7 @@ let g:syntastic_check_on_wq = 0
 
 ### How to configure language-specific linters
 
-```txt
+```text
 let g:syntastic_javascript_checkers = ['jshint']
 let g:syntastic_go_checkers = ['go', 'golint', 'errcheck']
 ```

--- a/vps-addswap/README.md
+++ b/vps-addswap/README.md
@@ -89,6 +89,6 @@ and create the swap file again.
 
 You need to open `/etc/fstab` and add a line like this:
 
-```txt
+```text
 /var/swapfile none swap sw 0 0
 ```

--- a/vps-utils/README.md
+++ b/vps-utils/README.md
@@ -35,7 +35,7 @@ Will output externally detected IPv4 and IPv6 addresses. See
 myip
 ```
 
-```txt
+```text
 IPv4 (A)   : 136.36.196.101
 IPv6 (AAAA): 2605:a601:a919:9800:f8be:f2c4:9ad7:9763
 ```

--- a/watchexec/README.md
+++ b/watchexec/README.md
@@ -15,7 +15,7 @@ It respects `.[git]ignore`.
 
 Here's the shortlist of options we've found most useful:
 
-```txt
+```text
 -w, --watch     ./src/      watch the given directory
 -e, --exts      js,css      watch only the given extensions
 -i, --ignore    '*.md'      do not watch the given pattern

--- a/xz/README.md
+++ b/xz/README.md
@@ -14,7 +14,7 @@ To update or switch versions, run `webi xz@stable` (or `@v5.2`, `@beta`, etc).
 
 Here's the shortlist of options we've found most useful:
 
-```txt
+```text
 -z, --compress      force compression
 -d, --decompress    force decompression
 -l, --list          list information about .xz files

--- a/zig/README.md
+++ b/zig/README.md
@@ -12,7 +12,7 @@ To update or switch versions, run `webi zig@stable` (or `@v0.9`, `@beta`, etc).
 These are the files / directories that are created and/or modified with this
 install:
 
-```txt
+```text
 ~/.config/envman/PATH.env
 ~/.local/opt/zig
 ```
@@ -96,7 +96,7 @@ zig targets | jq -r '.libc[]'
 
 Here's a few of the common targets:
 
-```txt
+```text
 aarch64-linux-musl
 aarch64-windows-gnu
 aarch64-macos-gnu


### PR DESCRIPTION
I am working on an installer for [vim-commentary](https://github.com/tpope/vim-commentary).

Should it be in vim-essentials? I think so.

# Preview Cheat Sheet

https://github.com/ryanburnette/webi-installers/tree/vim-commentary/vim-commentary