### PR TITLE
Add help command usage

### DIFF
--- a/_webi/bootstrap.sh
+++ b/_webi/bootstrap.sh
@@ -145,36 +145,53 @@ function __webi_main () {
 
     }
 
-    usage() {
-
-        ## show help if no params given or help flags are used
-        if [ \$# -eq 0 ] || [[ "\$1" =~ ^(-h|--help)$ ]]; then
-            printf "\e[31mwebi\e[32m v1.x\e[0m Copyright 2020+ AJ ONeal\n"
-            printf "    \e[34mhttps://webinstall.dev/webi\e[0m\n"
-            echo ""
-            echo "Webi is the best way to install the modern developer tools you love."
-            echo "It's fast, easy-to-remember, and conflict free."
-            echo ""
-            echo "Usage:"
-            echo ""
-            echo "To install things:"
-            echo "    webi <thing1>[@version] [thing2] ..."
-            echo ""
-            echo "To uninstall things:"
-            echo "    rm -rf ~/.local/opt/<thing1>"
-            echo "(see, for example, https://webinstall.dev/<thing1> for any special notes on uninstalling)"
-            echo ""
-            echo "FAQ:"
-            printf "    See \e[34mhttps://webinstall.dev/faq\e[0m\n"
-            echo ""
-            echo "And always remember:"
-            echo "    Friends don't let friends use brew for simple, modern tools that don't need it."
-            exit 0
-        fi
-
+    function version() {
+        my_version=v1.1.15
+        printf "\\e[31mwebi\\e[32m %s\\e[0m Copyright 2020+ AJ ONeal\\n" "\${my_version}"
+        printf "    \\e[34mhttps://webinstall.dev/webi\\e[0m\\n"
     }
 
-    usage "\$@"
+    # show help if no params given or help flags are used
+    function usage() {
+        echo ""
+        version
+        echo ""
+
+        printf "\\e[1mSUMMARY\\e[0m\\n"
+        echo "    Webi is the best way to install the modern developer tools you love."
+        echo "    It's fast, easy-to-remember, and conflict free."
+        echo ""
+        printf "\\e[1mUSAGE\\e[0m\\n"
+        echo "    webi <thing1>[@version] [thing2] ..."
+        echo ""
+        printf "\\e[1mUNINSTALL\\e[0m\\n"
+        echo "    Almost everything that is installed with webi is scoped to"
+        echo "    ~/.local/opt/<thing1>, so you can remove it like so:"
+        echo ""
+        echo "    rm -rf ~/.local/opt/<thing1>"
+        echo "    rm -f ~/.local/bin/<thing1>"
+        echo ""
+        echo "    Some packages have special uninstall instructions, check"
+        echo "    https://webinstall.dev/<thing1> to be sure."
+        echo ""
+        printf "\\e[1mFAQ\\e[0m\\n"
+        printf "    See \\e[34mhttps://webinstall.dev/faq\\e[0m\\n"
+        echo ""
+        printf "\\e[1mALWAYS REMEMBER\\e[0m\\n"
+        echo "    Friends don't let friends use brew for simple, modern tools that don't need it."
+        echo "    (and certainly not apt either **shudder**)"
+        echo ""
+    }
+
+    if [[ \$# -eq 0 ]] || [[ "\$1" =~ ^(-V|--version|version)$ ]]; then
+        version
+        exit 0
+    fi
+
+    if [[ "\$1" =~ ^(-h|--help|help)$ ]]; then
+        usage "\$@"
+        exit 0
+    fi
 
     for pkgname in "\$@"
     do
@@ -191,7 +208,7 @@ EOF
 
     chmod a+x "$HOME/.local/bin/webi"
 
-    if [ -n "${WEBI_PKG:-}" ]; then
+    if [[ -n ${WEBI_PKG:-} ]]; then
         "$HOME/.local/bin/webi" "${WEBI_PKG}"
     else
         echo ""

--- a/_webi/bootstrap.sh
+++ b/_webi/bootstrap.sh
@@ -145,6 +145,37 @@ function __webi_main () {
 
     }
 
+    usage() {
+
+        ## show help if no params given or help flags are used
+        if [ \$# -eq 0 ] || [[ "\$1" =~ ^(-h|--help)$ ]]; then
+            printf "\e[31mwebi\e[32m v1.x\e[0m Copyright 2020+ AJ ONeal\n"
+            printf "    \e[34mhttps://webinstall.dev/webi\e[0m\n"
+            echo ""
+            echo "Webi is the best way to install the modern developer tools you love."
+            echo "It's fast, easy-to-remember, and conflict free."
+            echo ""
+            echo "Usage:"
+            echo ""
+            echo "To install things:"
+            echo "    webi <thing1>[@version] [thing2] ..."
+            echo ""
+            echo "To uninstall things:"
+            echo "    rm -rf ~/.local/opt/<thing1>"
+            echo "(see, for example, https://webinstall.dev/<thing1> for any special notes on uninstalling)"
+            echo ""
+            echo "FAQ:"
+            printf "    See \e[34mhttps://webinstall.dev/faq\e[0m\n"
+            echo ""
+            echo "And always remember:"
+            echo "    Friends don't let friends use brew for simple, modern tools that don't need it."
+            exit 0
+        fi
+
+    }
+
+    usage "\$@"
+
     for pkgname in "\$@"
     do
         webinstall "\$pkgname"

--- a/_webi/webi-pwsh.ps1
+++ b/_webi/webi-pwsh.ps1
@@ -74,29 +74,41 @@ if (!$has_local_bin)
 # {{ baseurl }}
 # {{ version }}
 
+$my_version = 'v1.1.15'
+
 ## show help if no params given or help flags are used
-if ($exename -eq $null -or $exename -eq "-h" -or $exename -eq "--help" -or $exename -eq "/?") {
-    Write-Host "webi " -ForegroundColor Green -NoNewline; Write-Host "v1.x " -ForegroundColor Red -NoNewline; Write-Host "Copyright 2020+ AJ ONeal"
+if ($exename -eq $null -or $exename -eq "-h" -or $exename -eq "--help" -or $exename -eq "help" -or $exename -eq "/?") {
+    Write-Host "webi " -ForegroundColor Green -NoNewline; Write-Host "$my_version " -ForegroundColor Red -NoNewline; Write-Host "Copyright 2020+ AJ ONeal"
     Write-Host "  https://webinstall.dev/webi" -ForegroundColor blue
     echo ""
-    echo "Webi is the best way to install the modern developer tools you love."
-    echo "It's fast, easy-to-remember, and conflict free."
+    echo "SUMMARY"
+    echo "    Webi is the best way to install the modern developer tools you love."
+    echo "    It's fast, easy-to-remember, and conflict free."
     echo ""
-    echo "Usage:"
-    echo ""
-    echo "  To install things:"
+    echo "USAGE"
     echo "    webi <thing1>[@version] [thing2] ..."
     echo ""
-    echo "  To uninstall things:"
-    echo "    rm -rf ~/.local/opt/<thing1>"
-    echo "      (see, for example, https://webinstall.dev/<thing1> for any special notes on uninstalling)"
+    echo "UNINSTALL"
+    echo "    Almost everything that is installed with webi is scoped to"
+    echo "    ~/.local/opt/<thing1>, so you can remove it like so:"
     echo ""
-    echo "FAQ:"
+    echo "    rmdir /s %USERPROFILE%\.local\opt\<thing1>"
+    echo "    del %USERPROFILE%\.local\bin\<thing1>"
     echo ""
-    Write-Host "  See " -NoNewline; Write-Host "https://webinstall.dev/faq" -ForegroundColor blue
+    echo "    Some packages have special uninstall instructions, check"
+    echo "    https://webinstall.dev/<thing1> to be sure."
     echo ""
-    echo "And always remember:"
+    echo "FAQ"
+    Write-Host "    See " -NoNewline; Write-Host "https://webinstall.dev/faq" -ForegroundColor blue
+    echo ""
+    echo "ALWAYS REMEMBER"
     echo "    Friends don't let friends use brew for simple, modern tools that don't need it."
+    exit 0
+}
+
+if ($exename -eq "-V" -or $exename -eq "--version" -or $exename -eq "version" -or $exename -eq "/v") {
+    Write-Host "webi " -ForegroundColor Green -NoNewline; Write-Host "$my_version " -ForegroundColor Red -NoNewline; Write-Host "Copyright 2020+ AJ ONeal"
+    Write-Host "  https://webinstall.dev/webi" -ForegroundColor blue
     exit 0
 }
 

--- a/_webi/webi-pwsh.ps1
+++ b/_webi/webi-pwsh.ps1
@@ -74,6 +74,32 @@ if (!$has_local_bin)
 # {{ baseurl }}
 # {{ version }}
 
+## show help if no params given or help flags are used
+if ($exename -eq $null -or $exename -eq "-h" -or $exename -eq "--help" -or $exename -eq "/?") {
+    Write-Host "webi " -ForegroundColor Green -NoNewline; Write-Host "v1.x " -ForegroundColor Red -NoNewline; Write-Host "Copyright 2020+ AJ ONeal"
+    Write-Host "  https://webinstall.dev/webi" -ForegroundColor blue
+    echo ""
+    echo "Webi is the best way to install the modern developer tools you love."
+    echo "It's fast, easy-to-remember, and conflict free."
+    echo ""
+    echo "Usage:"
+    echo ""
+    echo "  To install things:"
+    echo "    webi <thing1>[@version] [thing2] ..."
+    echo ""
+    echo "  To uninstall things:"
+    echo "    rm -rf ~/.local/opt/<thing1>"
+    echo "      (see, for example, https://webinstall.dev/<thing1> for any special notes on uninstalling)"
+    echo ""
+    echo "FAQ:"
+    echo ""
+    Write-Host "  See " -NoNewline; Write-Host "https://webinstall.dev/faq" -ForegroundColor blue
+    echo ""
+    echo "And always remember:"
+    echo "    Friends don't let friends use brew for simple, modern tools that don't need it."
+    exit 0
+}
+
 # Fetch <whatever>.ps1
 # TODO detect formats
 $PKG_URL = "$Env:WEBI_HOST/api/installers/$exename.ps1?formats=zip,exe,tar"


### PR DESCRIPTION
This commit adds usage/help information to the webi installer in 3 scenarios.

1. if no command is provided _Eg. `webi`_
2. if `-h` is appended _Eg. `webi -h`_
3. or if `--help` is appended _Eg. `webi --help`_
