### PR TITLE
Run bootstrap.ps1 from any directory

### DIFF
--- a/_webi/bootstrap.ps1
+++ b/_webi/bootstrap.ps1
@@ -1,5 +1,5 @@
 # Download the latest webi, then install {{ exename }}
-New-Item -Path .local\bin -ItemType Directory -Force | out-null
+New-Item -Path "$Env:USERPROFILE\.local\bin" -ItemType Directory -Force | out-null
 IF ($Env:WEBI_HOST -eq $null -or $Env:WEBI_HOST -eq "") { $Env:WEBI_HOST = "https://webinstall.dev" }
 curl.exe -s -A "windows" "$Env:WEBI_HOST/packages/_webi/webi-pwsh.ps1" -o "$Env:USERPROFILE\.local\bin\webi-pwsh.ps1"
 Set-ExecutionPolicy -Scope Process Bypass


### PR DESCRIPTION
This fixes bug whereby one could only run webi from the home directory because it created the `.local\bin` in whatever directory it was run.