### PR TITLE
feat(notion-md-gen): add notion-md-gen

### DIFF
--- a/notion-md-gen/README.md
+++ b/notion-md-gen/README.md
@@ -1,0 +1,25 @@
+---
+title: notion-md-gen
+homepage: https://github.com/bonaysoft/notion-md-gen
+tagline: |
+  notion-md-gen allows you to use Notion as a CMS for pages built with any static site generators.
+---
+
+To update or switch versions, run `webi notion-md-gen@stable`.
+
+
+## Requisites
+
+- Notion database for your articles.
+- Notion API secret token.
+- A blog by any static site generators.
+
+
+## Usage
+
+### CLI
+
+```bash
+cd your-blog-dir
+notion-md-gen
+```

--- a/notion-md-gen/install.ps1
+++ b/notion-md-gen/install.ps1
@@ -1,0 +1,57 @@
+#!/usr/bin/env pwsh
+
+####################
+# Install notion-md-gen #
+####################
+
+# Every package should define these variables
+$pkg_cmd_name = "notion-md-gen"
+
+$pkg_dst_cmd = "$Env:USERPROFILE\.local\bin\notion-md-gen.exe"
+$pkg_dst = "$pkg_dst_cmd"
+
+$pkg_src_cmd = "$Env:USERPROFILE\.local\opt\notion-md-gen-v$Env:WEBI_VERSION\bin\notion-md-gen.exe"
+$pkg_src_bin = "$Env:USERPROFILE\.local\opt\notion-md-gen-v$Env:WEBI_VERSION\bin"
+$pkg_src_dir = "$Env:USERPROFILE\.local\opt\notion-md-gen-v$Env:WEBI_VERSION"
+$pkg_src = "$pkg_src_cmd"
+
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+
+# Fetch archive
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
+{
+    echo "Downloading notion-md-gen from $Env:WEBI_PKG_URL to $pkg_download"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
+    & move "$pkg_download.part" "$pkg_download"
+}
+
+IF (!(Test-Path -Path "$pkg_src_cmd"))
+{
+    echo "Installing notion-md-gen"
+
+    # TODO: create package-specific temp directory
+    # Enter tmp
+    pushd .local\tmp
+
+        # Remove any leftover tmp cruft
+        Remove-Item -Path ".\notion-md-gen-v*" -Recurse -ErrorAction Ignore
+        Remove-Item -Path ".\notion-md-gen.exe" -Recurse -ErrorAction Ignore
+
+        # Unpack archive file into this temporary directory
+        # Windows BSD-tar handles zip. Imagine that.
+        echo "Unpacking $pkg_download"
+        & tar xf "$pkg_download"
+
+        # Settle unpacked archive into place
+        echo "Install Location: $pkg_src_cmd"
+        New-Item "$pkg_src_bin" -ItemType Directory -Force | out-null
+        Move-Item -Path ".\notion-md-gen.exe" -Destination "$pkg_src_bin"
+
+    # Exit tmp
+    popd
+}
+
+echo "Copying into '$pkg_dst_cmd' from '$pkg_src_cmd'"
+Remove-Item -Path "$pkg_dst_cmd" -Recurse -ErrorAction Ignore | out-null
+Copy-Item -Path "$pkg_src" -Destination "$pkg_dst" -Recurse

--- a/notion-md-gen/install.sh
+++ b/notion-md-gen/install.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+function __init_notion-md-gen() {
+    set -e
+    set -u
+
+    ####################
+    # Install notion-md-gen #
+    ####################
+
+    # Every package should define these 6 variables
+    pkg_cmd_name="notion-md-gen"
+
+    pkg_dst_cmd="$HOME/.local/bin/notion-md-gen"
+    pkg_dst="$pkg_dst_cmd"
+
+    pkg_src_cmd="$HOME/.local/opt/notion-md-gen-v$WEBI_VERSION/bin/notion-md-gen"
+    pkg_src_dir="$HOME/.local/opt/notion-md-gen-v$WEBI_VERSION"
+    pkg_src="$pkg_src_cmd"
+
+    pkg_install() {
+        # $HOME/.local/opt/notion-md-gen-v1.0.0/bin
+        mkdir -p "$(dirname $pkg_src_cmd)"
+
+        # mv ./notion-md-gen* "$HOME/.local/opt/notion-md-gen-v1.0.0/bin/notion-md-gen"
+        mv ./"$pkg_cmd_name"* "$pkg_src_cmd"
+
+        # chmod a+x "$HOME/.local/opt/notion-md-gen-v1.0.0/bin/notion-md-gen"
+        chmod a+x "$pkg_src_cmd"
+    }
+
+    pkg_get_current_version() {
+        # 'notion-md-gen version' has output in this format:
+        #       release: 1.0.0, repo: https://github.com/bonaysoft/notion-md-gen.git
+        # This trims it down to just the version number:
+        #       1.0.0
+        echo "echo $(notion-md-gen version 2> /dev/null | head -n 1 | cut -d',' -f1 | cut -d' ' -f2)"
+    }
+
+}
+
+__init_notion-md-gen

--- a/notion-md-gen/releases.js
+++ b/notion-md-gen/releases.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var github = require('../_common/github.js');
+var owner = 'bonaysoft';
+var repo = 'notion-md-gen';
+
+module.exports = function (request) {
+  return github(request, owner, repo).then(function (all) {
+    return all;
+  });
+};
+
+if (module === require.main) {
+  module.exports(require('@root/request')).then(function (all) {
+    all = require('../_webi/normalize.js')(all);
+    console.info(JSON.stringify(all, null, 2));
+  });
+}


### PR DESCRIPTION
notion-md-gen allows you to use Notion as a CMS for pages built with any static site generators. You can use it as a cli or even automate your blog repo to update itself with the Github Action.

Project: https://github.com/bonaysoft/notion-md-gen