### PR TITLE
Webi post install instructions update

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ More technically:
    - common release APIs are in `_common/` (i.e. `_common/github.js`)
 2. `_webi/bootstrap.sh` is a template that exchanges system information for a
    correct installer
-   - contructs a user agent with os, cpu, and utility info (i.e. `macos`,
+   - constructs a user agent with os, cpu, and utility info (i.e. `macos`,
      `amd64`, can unpack `tar,zip,xz`)
 3. `_webi/template.sh` is the base installer template with common functions for
    - checking versions
@@ -185,7 +185,7 @@ pkg_get_current_version() {
 }
 ```
 
-For the rest of the functions you can like copy/paste from the examples:
+For the rest of the functions you can copy/paste from the examples:
 
 ```bash
 pkg_format_cmd_version() {}         # Override, pretty prints version

--- a/_webi/bootstrap.sh
+++ b/_webi/bootstrap.sh
@@ -130,14 +130,13 @@ function __webi_main () {
             if [ -f "\$_webi_tmp/.PATH.env" ]; then
                 my_paths=\$(cat "\$_webi_tmp/.PATH.env" | sort -u)
                 if [ -n "\$my_paths" ]; then
-                    echo "IMPORTANT: You must update you PATH to use the installed program(s)"
-                    echo ""
-                    echo "You can either"
-                    echo "A) can CLOSE and REOPEN Terminal or"
-                    echo "B) RUN these exports:"
-                    echo ""
-                    echo "\$my_paths"
-                    echo ""
+                    printf 'PATH.env updated with:\\n'
+                    printf "%s\\n" "\$my_paths"
+                    printf '\\n'
+                    printf "\\e[31mTO FINISH\\e[0m: copy, paste & run the following command:\\n"
+                    printf "\\n"
+                    printf "        \\e[34msource ~/.config/envman/PATH.env\\e[0m\\n"
+                    printf "        (newly opened terminal windows will update automatically)\\n"
                 fi
                 rm -f "\$_webi_tmp/.PATH.env"
             fi

--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -244,8 +244,12 @@ function __bootstrap_webi() {
 
         # in case pathman was recently installed and the PATH not updated
         mkdir -p "$_webi_tmp"
-        # prevent "too few arguments" output on bash when there are 0 lines of stdout
-        "$HOME/.local/bin/pathman" add "$1" | grep "export" 2> /dev/null >> "$_webi_tmp/.PATH.env" || true
+        # 'true' to prevent "too few arguments" output on bash
+        # when there are 0 lines of stdout
+        "$HOME/.local/bin/pathman" add "$1" |
+            grep "export" 2> /dev/null \
+                >> "$_webi_tmp/.PATH.env" ||
+            true
     }
 
     # group common pre-install tasks as default
@@ -404,10 +408,16 @@ function __bootstrap_webi() {
     webi_path_add "$HOME/.local/bin"
     if [[ -z ${_WEBI_CHILD:-} ]] && [[ -f "$_webi_tmp/.PATH.env" ]]; then
         if [[ -n $(cat "$_webi_tmp/.PATH.env") ]]; then
-            echo "You need to update your PATH to use $PKG_NAME:"
-            echo ""
+            printf 'PATH.env updated with:\n'
             sort -u "$_webi_tmp/.PATH.env"
+            printf "\n"
+
             rm -f "$_webi_tmp/.PATH.env"
+
+            printf "\e[31mTO FINISH\e[0m: copy, paste & run the following command:\n"
+            printf "\n"
+            printf "        \e[34msource ~/.config/envman/PATH.env\e[0m\n"
+            printf "        (newly opened terminal windows will update automatically)\n"
         fi
     fi
 


### PR DESCRIPTION
### Problem:

Prior instructions gave this new coder the impression that further changes to PATH were required after the completion of the Webi script (e.g. with Golang):
```console
Installed 'go v1.18.0' to ~/.local/opt/go
Installed go "x" tools to GOBIN=$HOME/go/bin

You need to update your PATH to use golang:

	export PATH="/home/db/go/bin:$PATH"
	export PATH="/home/db/.local/opt/go/bin:$PATH"

```

### Solution:

```console
Installed 'go v1.18.0' to ~/.local/opt/go
Installed go "x" tools to GOBIN=$HOME/go/bin

PATH.env updated with:
    export PATH="$HOME/go/bin:$PATH"
    export PATH="$HOME/.local/opt/go/bin:$PATH"

IMPORTANT: To use golang, copy, paste, and run this command to update your current PATH:

    source ~/.config/envman/PATH.env
    (opening a new shell will have the same effect)
```

Revised to clarify the actual actions required following the completion of the webi script.

Deliberately retained the notification to the user that PATH.env has been updated.

The revised version may be too verbose.  Feedback very welcome.

### Testing: 
Install something with Webi that requires PATH changes (e.g. golang)



### RELATED PATHMAN ISSUE:
https://git.rootprojects.org/root/pathman/issues/6

Below may fail in CMD.  Need to check + update

https://git.rootprojects.org/root/pathman/compare/master...DBBrowne:windows-path-update

https://stackoverflow.com/a/714918/15995918
```
$env:Path                             # shows the actual content
$env:Path = 'C:\foo;' + $env:Path     # attach to the beginning
$env:Path += ';C:\foo'                # attach to the end
```
 - replace powershell path update with , eg:
 $env:PATH += ";C:\Users\_/.local/opt/go/bin"
 
![image](https://user-images.githubusercontent.com/72463218/161112066-681b854e-809d-4218-8eed-7780536e196b.png)
