### PR TITLE
Drop unnecessary mentions of Windows version

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ webi_post_install       # Runs `webi_path_add $pkg_dst_bin`
 set WEBI_HOST=https://webinstall.dev
 ```
 
-Windows 10 has curl too!?
+Windows has curl too!?
 
 ```bat
 curl.exe -sL -A "MS" https://webinstall.dev/node | powershell

--- a/_npm/README.md
+++ b/_npm/README.md
@@ -23,7 +23,7 @@ Mac & Linux:
 curl -fsS https://webinstall.dev/node | bash
 ```
 
-Windows 10 (includes `curl.exe` and PowerShell by default):
+Windows (includes `curl.exe` and PowerShell by default):
 
 ```bash
 curl.exe -fsSA "MS" https://webinstall.dev/node | powershell

--- a/bat/README.md
+++ b/bat/README.md
@@ -12,9 +12,9 @@ To update or switch versions, run `webi bat@stable` (or `@v0.18`, `@beta`, etc).
 > `bat` is pretty much what `cat` would be if it were developed today's in the
 > world of Markdown, git, etc.
 
-### How to run on Windows 10
+### How to run on Windows
 
-On Windows 10 you'll get an error like this:
+On Windows you'll get an error like this:
 
 > execution cannot proceed run because vcruntime140.dll was not found
 

--- a/caddy/README.md
+++ b/caddy/README.md
@@ -21,7 +21,7 @@ Here's the things we find most useful:
 - Running as a system service on
   - Linux
   - MacOS
-  - Windows 10
+  - Windows
 
 ### How to serve a directory
 
@@ -173,7 +173,7 @@ powershell.exe -WindowStyle Hidden -Command $r = Get-NetFirewallRule -DisplayNam
 **Startup Registry**
 
 You can use [Serviceman](https://webinstall.dev/serviceman) to create and start
-the appropriate service launcher for Windows 10.
+the appropriate service launcher for Windows.
 
 Install Serviceman with Webi:
 

--- a/dotenv-linter/README.md
+++ b/dotenv-linter/README.md
@@ -11,9 +11,9 @@ tagline: |
 
 Use the `@beta` tag for pre-releases.
 
-#### Windows 10
+#### Windows
 
-On Windows 10 you'll get an error like this:
+On Windows you'll get an error like this:
 
 > execution cannot proceed run because `vcruntime140.dll` was not found
 

--- a/pathman/README.md
+++ b/pathman/README.md
@@ -33,7 +33,7 @@ pathman add ~/.local/bin
 pathman remove ~/.local/bin
 ```
 
-Note: Even on Windows 10 it is best to use Unix-style `/` paths and `~` for
+Note: Even on Windows it is best to use Unix-style `/` paths and `~` for
 `%USERPROFILE%`.
 
 ```bash

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -6,10 +6,10 @@ tagline: |
 ---
 
 > The core benefit of running `pwsh` on Mac or Linux is that you get a way to
-> debug Windows 10 scripts without having to boot up Windows 10.
+> debug Windows scripts without having to boot up Windows.
 
 For example, if you want to create a `curl.exe -A "windows" | powershell` script
-for Windows 10 (as we do), it's helpful to be able to do some level of debugging
+for Windows (as we do), it's helpful to be able to do some level of debugging
 on other platforms.
 
 <!--

--- a/webi/README.md
+++ b/webi/README.md
@@ -61,7 +61,7 @@ These are the files that are installed when you use [webinstall.dev](/):
 ~/.local/bin/pathman
 ~/.local/opt/pathman-*
 
-# Windows 10
+# Windows
 ~/.local/bin/webi.cmd
 ~/.local/bin/webi-pwsh.ps1
 ~/.local/bin/pathman.exe

--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -3,7 +3,7 @@ set -e
 set -u
 
 function __pass() {
-    echo "WSL (Windows Subsystem for Linux) can only be installed from Windows 10"
+    echo "WSL (Windows Subsystem for Linux) can only be installed from Windows"
     exit 0
 }
 

--- a/wsl1/install.sh
+++ b/wsl1/install.sh
@@ -3,7 +3,7 @@ set -e
 set -u
 
 function __pass() {
-    echo "WSL 1 (Windows Subsystem for Linux) can only be installed from Windows 10"
+    echo "WSL 1 (Windows Subsystem for Linux) can only be installed from Windows"
     exit 0
 }
 

--- a/wsl2/README.md
+++ b/wsl2/README.md
@@ -85,7 +85,7 @@ It may be that your computer does not support virtualization because:
 
 - it lacks hardware support in the CPU for VTx
 - VTx is disabled in the BIOS or EFI
-- Virtualization has disabled in Windows 10
+- Virtualization has disabled in Windows
 
 You should switch back to WSL 1 until you solve this problem:
 

--- a/wsl2/install.sh
+++ b/wsl2/install.sh
@@ -3,7 +3,7 @@ set -e
 set -u
 
 function __pass() {
-    echo "WSL 2 (Windows Subsystem for Linux with Hyper-V) can only be installed from Windows 10"
+    echo "WSL 2 (Windows Subsystem for Linux with Hyper-V) can only be installed from Windows"
     exit 0
 }
 


### PR DESCRIPTION
This pull request removes mentioning of Windows version. Some of them are only referring to the platform, not caring about the version, and the rest shouldn't need to either. webi packages are categorized for developers and few developers are using Windows version that old.  <sub>Remember, Windows 10 came out in July _2015_, when io.js was still around and Alphabet Inc. doesn't exist.</sub>

This also helps in case people are searching for "Windows 11", despite it being just a glorified version of Windows 10.