### PR TITLE
add go-essentials, migrate go tooling from go

### DIFF
--- a/go-essentials/README.md
+++ b/go-essentials/README.md
@@ -1,0 +1,33 @@
+---
+title: go-essentials
+homepage: https://webinstall.dev/go-essentials
+tagline: |
+  meta package for go and the de facto standard go tools packages
+---
+
+To update (replacing the current version) run `webi go-essentials`.
+
+## Cheat Sheet
+
+> A collection of extremely useful official and de facto standard go tooling.
+
+This meta package will install [Go](https://golang.org/) at the specified
+version as well as the full set of tooling used by most IDEs and editor plugins,
+including:
+
+- [godoc](https://pkg.go.dev/golang.org/x/tools/cmd/godoc)
+- [gopls](https://pkg.go.dev/golang.org/x/tools/gopls)
+- [guru](https://pkg.go.dev/golang.org/x/tools/cmd/guru)
+- [golint](https://pkg.go.dev/golang.org/x/lint/golint)
+- [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports)
+- [gomvpkg](https://pkg.go.dev/golang.org/x/tools/cmd/gomvpkg)
+- [gorename](https://pkg.go.dev/golang.org/x/tools/cmd/gorename)
+- [gotype](https://pkg.go.dev/golang.org/x/tools/cmd/gotype)
+- [stringer](https://pkg.go.dev/golang.org/x/tools/cmd/stringer)
+
+It **DOES NOT** include these, which you may also want:
+
+- Vim Utilities
+  - [vim-essentials](/vim-essentials) (de facto standard plugins and one-liners
+    for vim)
+  - [vim-go](/vim-go) (golang support for vim, and VSCode)

--- a/go-essentials/install.ps1
+++ b/go-essentials/install.ps1
@@ -1,0 +1,5 @@
+#!/bin/pwsh
+
+echo "'go@$Env:WEBI_TAG' is an alias for 'golang@$Env:WEBI_VERSION'"
+IF ($Env:WEBI_HOST -eq $null -or $Env:WEBI_HOST -eq "") { $Env:WEBI_HOST = "https://webinstall.dev" }
+curl.exe -fsSL "$Env:WEBI_HOST/golang@$Env:WEBI_VERSION" | powershell

--- a/go-essentials/install.sh
+++ b/go-essentials/install.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+set -e
+set -u
+
+__run_go_essentials() {
+    WEBI__GO_ESSENTIALS='true'
+    export WEBI__GO_ESSENTIALS
+    if [ -z "${WEBI__GO_INSTALL:-}" ]; then
+        webi "golang@${WEBI_TAG}"
+    fi
+
+    export PATH="$HOME/.local/opt/go/bin:$PATH"
+
+    my_install="install"
+    # go1.16 is the min version for proper 'go install'
+    my_version="$(
+        go version | cut -d' ' -f3
+    )"
+    my_major="$(
+        echo "${my_version}" | cut -d'.' -f1 || echo '0'
+    )"
+    my_minor="$(
+        echo "${my_version}" | cut -d'.' -f2 || echo '0'
+    )"
+
+    my_install="get"
+    if [ "${my_major}" = "go1" ]; then
+        if [ "${my_minor}" -ge 16 ]; then
+            my_install="install"
+        fi
+    elif [ "${my_major}" = "go2" ]; then
+        my_install="install"
+    fi
+
+    # Install x go
+    echo "Building go language tools..."
+    export GO111MODULE=on
+
+    # See https://pkg.go.dev/mod/golang.org/x/tools?tab=packages
+
+    echo ""
+    echo godoc
+    go "${my_install}" golang.org/x/tools/cmd/godoc@latest > /dev/null #2>/dev/null
+
+    echo ""
+    echo gopls
+    go "${my_install}" golang.org/x/tools/gopls@latest > /dev/null #2>/dev/null
+
+    echo ""
+    echo guru
+    go "${my_install}" golang.org/x/tools/cmd/guru@latest > /dev/null #2>/dev/null
+
+    echo ""
+    echo golint
+    go "${my_install}" golang.org/x/lint/golint@latest > /dev/null #2>/dev/null
+
+    echo ""
+    echo goimports
+    go "${my_install}" golang.org/x/tools/cmd/goimports@latest > /dev/null #2>/dev/null
+
+    echo ""
+    echo gomvpkg
+    go "${my_install}" golang.org/x/tools/cmd/gomvpkg@latest > /dev/null #2>/dev/null
+
+    echo ""
+    echo gorename
+    go "${my_install}" golang.org/x/tools/cmd/gorename@latest > /dev/null #2>/dev/null
+
+    echo ""
+    echo gotype
+    go "${my_install}" golang.org/x/tools/cmd/gotype@latest > /dev/null #2>/dev/null
+
+    echo ""
+    echo stringer
+    go "${my_install}" golang.org/x/tools/cmd/stringer@latest > /dev/null #2>/dev/null
+
+    echo ""
+
+    printf '\n'
+    printf 'Suggestion: Also check out these great productivity multipliers:\n'
+    printf '\n'
+    printf '    - vim-essentials  (sensible defaults for vim)\n'
+    printf '    - vim-go          (golang linting, etc)\n'
+    printf '\n'
+}
+
+__run_go_essentials

--- a/golang/install.ps1
+++ b/golang/install.ps1
@@ -17,6 +17,15 @@ if (!(Get-Command "git.exe" -ErrorAction SilentlyContinue))
     $Env:PATH = "$Env:USERPROFILE\.local\opt\git\cmd;$Env:PATH"
 }
 
+Write-Host '' -ForegroundColor red -BackgroundColor white
+Write-Host '*********************' -ForegroundColor red -BackgroundColor white
+Write-Host '*  BREAKING CHANGE  *' -ForegroundColor red -BackgroundColor white
+Write-Host '*********************' -ForegroundColor red -BackgroundColor white
+Write-Host ''  -ForegroundColor red -BackgroundColor white
+Write-Host '    ''webi golang'' will NOT install go tooling starting with go1.21+' -ForegroundColor red -BackgroundColor white
+Write-Host '    use ''webi go-essentials'' to preserve the previous behavior' -ForegroundColor red -BackgroundColor white
+Write-Host ''  -ForegroundColor red -BackgroundColor white
+
 # Fetch archive
 IF (!(Test-Path -Path "$pkg_download"))
 {
@@ -59,21 +68,21 @@ IF (!(Test-Path -Path go\bin)) { New-Item -Path go\bin -ItemType Directory -Forc
 # Special to go: re-run all go tooling builds
 echo "Building go language tools..."
 echo gopls
-& "$pkg_dst_cmd" get golang.org/x/tools/gopls
+& "$pkg_dst_cmd" install golang.org/x/tools/gopls
 echo golint
-& "$pkg_dst_cmd" get golang.org/x/lint/golint
+& "$pkg_dst_cmd" install golang.org/x/lint/golint
 echo errcheck
-& "$pkg_dst_cmd" get github.com/kisielk/errcheck
+& "$pkg_dst_cmd" install github.com/kisielk/errcheck
 echo gotags
-& "$pkg_dst_cmd" get github.com/jstemmer/gotags
+& "$pkg_dst_cmd" install github.com/jstemmer/gotags
 echo goimports
-& "$pkg_dst_cmd" get golang.org/x/tools/cmd/goimports
+& "$pkg_dst_cmd" install golang.org/x/tools/cmd/goimports
 echo gorename
-& "$pkg_dst_cmd" get golang.org/x/tools/cmd/gorename
+& "$pkg_dst_cmd" install golang.org/x/tools/cmd/gorename
 echo gotype
-& "$pkg_dst_cmd" get golang.org/x/tools/cmd/gotype
+& "$pkg_dst_cmd" install golang.org/x/tools/cmd/gotype
 echo stringer
-& "$pkg_dst_cmd" get golang.org/x/tools/cmd/stringer
+& "$pkg_dst_cmd" install golang.org/x/tools/cmd/stringer
 
 # Add to path
 & "$Env:USERPROFILE\.local\bin\pathman.exe" add ~/.local/opt/go/bin

--- a/golang/install.sh
+++ b/golang/install.sh
@@ -15,6 +15,19 @@ pkg_cmd_name="go"
 #
 # Their defaults are defined in _webi/template.sh at https://github.com/webinstall/packages
 
+if [ -z "${WEBI__GO_ESSENTIALS:-}" ]; then
+    # TODO nix for go1.21+
+    echo >&2 ""
+    printf >&2 '\e[31m%s:\e[0m\n' '#####################'
+    printf >&2 '\e[31m%s:\e[0m\n' '#  BREAKING CHANGE  #'
+    printf >&2 '\e[31m%s:\e[0m\n' '#####################'
+    echo >&2 ""
+    printf >&2 "\e[31m    'webi golang' will NOT install go tooling starting with go1.21+\e[0m\n"
+    printf >&2 "\e[31m    use 'webi go-essentials' to preserve the previous behavior\e[0m\n"
+    echo >&2 ""
+    sleep 4
+fi
+
 function pkg_get_current_version() {
     # 'go version' has output in this format:
     #       go version go1.14.2 darwin/amd64
@@ -56,56 +69,12 @@ function pkg_post_install() {
     webi_path_add "$pkg_dst_bin"
     webi_path_add "$GOBIN/bin"
 
-    # Install x go
-    echo "Building go language tools..."
-    export GO111MODULE=on
-
-    # See https://pkg.go.dev/mod/golang.org/x/tools?tab=packages
-
-    my_install="install"
-    # note: we intend a lexical comparison, so this is correct
-    #shellcheck disable=SC2072
-    if [[ ${WEBI_VERSION} < "1.16" ]]; then
-        my_install="get"
+    if [ -z "${WEBI__GO_ESSENTIALS:-}" ]; then
+        # TODO nix for go1.21+
+        WEBI__GO_INSTALL='true'
+        export WEBI__GO_INSTALL
+        webi "go-essentials@${WEBI_TAG}"
     fi
-
-    echo ""
-    echo godoc
-    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/godoc@latest > /dev/null #2>/dev/null
-
-    echo ""
-    echo gopls
-    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/gopls@latest > /dev/null #2>/dev/null
-
-    echo ""
-    echo guru
-    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/guru@latest > /dev/null #2>/dev/null
-
-    echo ""
-    echo golint
-    "$pkg_dst_cmd" "${my_install}" golang.org/x/lint/golint@latest > /dev/null #2>/dev/null
-
-    echo ""
-    echo goimports
-    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/goimports@latest > /dev/null #2>/dev/null
-
-    echo ""
-    echo gomvpkg
-    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/gomvpkg@latest > /dev/null #2>/dev/null
-
-    echo ""
-    echo gorename
-    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/gorename@latest > /dev/null #2>/dev/null
-
-    echo ""
-    echo gotype
-    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/gotype@latest > /dev/null #2>/dev/null
-
-    echo ""
-    echo stringer
-    "$pkg_dst_cmd" "${my_install}" golang.org/x/tools/cmd/stringer@latest > /dev/null #2>/dev/null
-
-    echo ""
 }
 
 function pkg_done_message() {


### PR DESCRIPTION
Due to complications with version changes between go 1.16 and go 1.18 I think it's best to remove the non-required go tooling from the `go` package and install it instead with `go-essentials`.

This provides a path forward to that with notification of upcoming breaking change.