### PR TITLE
Remove echo from the all repo

### DIFF
--- a/bat/install.sh
+++ b/bat/install.sh
@@ -15,7 +15,7 @@ function __init_bat() {
         #       bat 0.15.4
         # This trims it down to just the version number:
         #       0.15.4
-        echo $(bat --version 2> /dev/null | head -n 1 | cut -d' ' -f 2)
+        bat --version 2> /dev/null | head -n 1 | cut -d' ' -f 2
     }
 
     pkg_install() {

--- a/chromedriver/install.sh
+++ b/chromedriver/install.sh
@@ -33,7 +33,7 @@ function __init_chromedriver() {
         #       ChromeDriver 88.0.4324.96 (68dba2d8a0b149a1d3afac56fa74648032bcf46b-refs/branch-heads/4324@{#1784})
         # This trims it down to just the version number:
         #       88.0.4324.96
-        echo $(chromedriver --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
+        chromedriver --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2
     }
 
 }

--- a/comrak/install.sh
+++ b/comrak/install.sh
@@ -15,7 +15,7 @@ function __init_comrak() {
         #       comrak 0.8.1
         # This trims it down to just the version number:
         #       0.8.1
-        echo $(comrak --version 2> /dev/null | head -n 1 | cut -d' ' -f 2)
+        comrak --version 2> /dev/null | head -n 1 | cut -d' ' -f 2
     }
 
     pkg_install() {

--- a/curlie/install.sh
+++ b/curlie/install.sh
@@ -12,12 +12,10 @@ function __init_curlie() {
 
     pkg_get_current_version() {
         # 'curlie --version' has output in this format:
-        #       TODO
+        #       curlie 1.6.9 (2022-04-04T15:04:20Z)
         # This trims it down to just the version number:
-        #       TODO
-        #echo $(curlie --version 2>/dev/null | head -n 1 | cut -d' ' -f 2)
-        # See https://github.com/rs/curlie/issues/22
-        echo "0.0.0"
+        #       1.6.9
+        curlie version 2> /dev/null | head -n 1 | cut -d' ' -f 2
     }
 
     pkg_install() {

--- a/dotenv-linter/install.sh
+++ b/dotenv-linter/install.sh
@@ -33,7 +33,7 @@ function __init_dotenv_linter() {
         #       dotenv-linter 0.99.9 (rev abcdef0123)
         # This trims it down to just the version number:
         #       0.99.9
-        echo $(dotenv-linter --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
+        dotenv-linter --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2
     }
 
 }

--- a/fd/install.sh
+++ b/fd/install.sh
@@ -15,7 +15,7 @@ function __init_fd() {
         #       fd 8.1.1
         # This trims it down to just the version number:
         #       8.1.1
-        echo $(fd --version 2> /dev/null | head -n 1 | cut -d' ' -f 2)
+        fd --version 2> /dev/null | head -n 1 | cut -d' ' -f 2
     }
 
     pkg_install() {

--- a/ffmpeg/install.sh
+++ b/ffmpeg/install.sh
@@ -35,7 +35,7 @@ function __init_ffmpeg() {
         #       ...
         # This trims it down to just the version number:
         #       4.3.1
-        echo $(ffmpeg -version 2> /dev/null | head -n 1 | cut -d ' ' -f 3)
+        ffmpeg -version 2> /dev/null | head -n 1 | cut -d ' ' -f 3
     }
 
 }

--- a/fzf/install.sh
+++ b/fzf/install.sh
@@ -15,7 +15,7 @@ function __init_fzf() {
         #       0.21.1 (334a4fa)
         # This trims it down to just the version number:
         #       0.21.1
-        echo $(fzf --version 2> /dev/null | head -n 1 | cut -d' ' -f 1)
+        fzf --version 2> /dev/null | head -n 1 | cut -d' ' -f 1
     }
 
     pkg_install() {

--- a/gh/install.sh
+++ b/gh/install.sh
@@ -33,7 +33,7 @@ function __init_gh() {
         #       gh 0.99.9 (rev abcdef0123)
         # This trims it down to just the version number:
         #       0.99.9
-        echo $(gh --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
+        gh --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2
     }
 
 }

--- a/goreleaser/install.sh
+++ b/goreleaser/install.sh
@@ -33,7 +33,7 @@ function __init_goreleaser() {
         #       goreleaser 0.99.9 (rev abcdef0123)
         # This trims it down to just the version number:
         #       0.99.9
-        echo $(goreleaser --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
+        goreleaser --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2
     }
 
 }

--- a/hexyl/install.sh
+++ b/hexyl/install.sh
@@ -15,7 +15,7 @@ function __init_hexyl() {
         #       hexyl 0.8.0
         # This trims it down to just the version number:
         #       0.8.0
-        echo $(hexyl --version 2> /dev/null | head -n 1 | cut -d' ' -f 2)
+        hexyl --version 2> /dev/null | head -n 1 | cut -d' ' -f 2
     }
 
     pkg_install() {

--- a/jq/install.sh
+++ b/jq/install.sh
@@ -15,7 +15,7 @@ function __init_jq() {
         #       jq-1.6
         # This trims it down to just the version number:
         #       1.6
-        echo $(jq --version 2> /dev/null | head -n 1 | sed 's:^jq-::')
+        jq --version 2> /dev/null | head -n 1 | sed 's:^jq-::'
     }
 }
 

--- a/k9s/install.sh
+++ b/k9s/install.sh
@@ -37,7 +37,7 @@ function __init_k9s() {
 
         # This trims it down to just the version number:
         # 0.24.2
-        echo $(k9s version 2> /dev/null | grep Version: | cut -d 'v' -f 2)
+        k9s version 2> /dev/null | grep Version: | cut -d 'v' -f 2
     }
 
 }

--- a/lsd/install.sh
+++ b/lsd/install.sh
@@ -33,7 +33,7 @@ function __init_lsd() {
         #       lsd 0.17.0
         # This trims it down to just the version number:
         #       0.17.0
-        echo $(lsd --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
+        lsd --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2
     }
 
 }

--- a/mutagen/install.sh
+++ b/mutagen/install.sh
@@ -33,7 +33,7 @@ function __init_mutagen() {
         #       0.11.8
         # This trims it down to just the version number:
         #       0.11.8
-        echo $(mutagen version 2> /dev/null | head -n 1 | cut -d ' ' -f1)
+        mutagen version 2> /dev/null | head -n 1 | cut -d ' ' -f1
     }
 
 }

--- a/pandoc/install.sh
+++ b/pandoc/install.sh
@@ -40,7 +40,7 @@ function __init_pandoc() {
         # for a particular purpose.
         # This trims it down to just the version number:
         #       2.10.1
-        echo $(pandoc --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
+        pandoc --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2
     }
 }
 

--- a/pathman/install.sh
+++ b/pathman/install.sh
@@ -7,7 +7,7 @@ pkg_cmd_name="pathman"
 WEBI_SINGLE=true
 
 function pkg_get_current_version() {
-    echo $(pathman version 2> /dev/null | head -n 1 | cut -d ' ' -f2 | sed 's:^v::')
+    pathman version 2> /dev/null | head -n 1 | cut -d ' ' -f2 | sed 's:^v::'
 }
 
 function pkg_done_message() {

--- a/rg/install.sh
+++ b/rg/install.sh
@@ -35,7 +35,7 @@ function __init_rg() {
         #       +SIMD -AVX (runtime)
         # This trims it down to just the version number:
         #       12.1.1
-        echo $(rg --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
+        rg --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2
     }
 }
 

--- a/sass/install.sh
+++ b/sass/install.sh
@@ -26,7 +26,7 @@ function __init_sass() {
     }
 
     pkg_get_current_version() {
-        echo $(sass --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
+        sass --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2
     }
 
 }

--- a/sd/install.sh
+++ b/sd/install.sh
@@ -32,7 +32,7 @@ function __init_sd() {
         #       sd 0.99.9 (rev abcdef0123)
         # This trims it down to just the version number:
         #       0.99.9
-        echo $(sd --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
+        sd --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2
     }
 
 }

--- a/shellcheck/install.sh
+++ b/shellcheck/install.sh
@@ -37,7 +37,7 @@ function __init_shellcheck() {
 
         # This trims it down to just the version number:
         #       0.7.1
-        echo $(shellcheck --version 2> /dev/null | head -n 2 | tail -n 1 | cut -d' ' -f 2)
+        shellcheck --version 2> /dev/null | head -n 2 | tail -n 1 | cut -d' ' -f 2
     }
 
 }

--- a/shfmt/install.sh
+++ b/shfmt/install.sh
@@ -24,7 +24,7 @@ function __init_shfmt() {
     }
 
     pkg_get_current_version() {
-        echo $(shfmt --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
+        shfmt --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2
     }
 
 }

--- a/watchexec/install.sh
+++ b/watchexec/install.sh
@@ -33,7 +33,7 @@ function __init_watchexec() {
         #       watchexec 0.99.9
         # This trims it down to just the version number:
         #       0.99.9
-        echo $(watchexec --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2)
+        watchexec --version 2> /dev/null | head -n 1 | cut -d ' ' -f 2
     }
 
 }

--- a/xz/install.sh
+++ b/xz/install.sh
@@ -42,7 +42,7 @@ function __init_xz() {
         #       liblzma 5.2.5
         # This trims it down to just the version number:
         #       5.2.5
-        echo $(xz --version 2> /dev/null | head -n 1 | cut -d ' ' -f 4)
+        xz --version 2> /dev/null | head -n 1 | cut -d ' ' -f 4
     }
 }
 


### PR DESCRIPTION
List of the packages which I remove the echo command:  
```bash
yorune@MacBook ~/git/webi-installers main $ grep -iEr 'echo *\$\(' | awk -F: '{print $1}' | sed '/curlie/d'
./sd/install.sh
./comrak/install.sh
./ffmpeg/install.sh
./pandoc/install.sh
./gh/install.sh
./dotenv-linter/install.sh
./mutagen/install.sh
./fd/install.sh
./rg/install.sh
./lsd/install.sh
./xz/install.sh
./shfmt/install.sh
./goreleaser/install.sh
./pathman/install.sh
./hexyl/install.sh
./shellcheck/install.sh
./k9s/install.sh
./bat/install.sh
./chromedriver/install.sh
./jq/install.sh
./sass/install.sh
./watchexec/install.sh
./fzf/install.sh
```
  
  I tested the changed packages in the dev env in the docker container.