### PR TITLE
Replace '```bash' with '```sh' in all .md files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,16 +12,16 @@
   linters:
   - Node / JavaScript:
     - [prettier](https://webinstall.dev/prettier)
-      ```bash
+      ```sh
       npm run prettier
       ```
     - [jshint](https://webinstall.dev/jshint)
-      ```bash
+      ```sh
       npm run lint
       ```
   - Bash
     - [shfmt](https://webinstall.dev/shfmt)
-      ```bash
+      ```sh
       npm run shfmt
       ```
     - [shellcheck](https://webinstall.dev/shellcheck)
@@ -42,7 +42,7 @@ Please **enable gpg-signing**.
 You can do this **in about 30 seconds**:
 
 1. Run [`git-config-gpg`](https://webinstall.dev/git-config-gpg) from Webi:
-   ```bash
+   ```sh
    # On Mac & Linux
    curl https://webinstall.dev/git-config-gpg | bash
    ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - no messing with system permissions
 - in short: no nonsense
 
-```bash
+```sh
 curl https://webinstall.dev/webi | bash
 ```
 
@@ -97,13 +97,13 @@ You just fill in the blanks.
 
 Just create an empty directory and run the tests until you get a good result.
 
-```bash
+```sh
 git clone git@github.com:webinstall/packages.git
 pushd packages
 npm install
 ```
 
-```bash
+```sh
 mkdir -p ./new-package/
 node _webi/test.js ./new-package/
 ```
@@ -124,7 +124,7 @@ description: |
   Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine
 ---
 
-```bash
+```sh
 node -e 'console.log("Hello, World!")'
 > Hello, World!
 ```
@@ -161,7 +161,7 @@ module.exports = function (request) {
 
 (optional, if needed) Bash variables that you _may_ define:
 
-```bash
+```sh
 # Define this if the package name is different from the command name (i.e. golang => go)
 pkg_cmd_name="foobar"
 
@@ -178,7 +178,7 @@ pkg_src_cmd="$HOME/.local/opt/foobar-v$WEBI_VERSION/bin/foobar"
 
 (required) A version check function that strips all non-version junk
 
-```bash
+```sh
 pkg_get_current_version() {
     # foobar-v1.1.7 => 1.1.7
     echo "$(foobar --version | head -n 1 | sed 's:foobar-v::')"
@@ -187,7 +187,7 @@ pkg_get_current_version() {
 
 For the rest of the functions you can copy/paste from the examples:
 
-```bash
+```sh
 pkg_format_cmd_version() {}         # Override, pretty prints version
 
 pkg_link                            # Override, replaces webi_link()
@@ -214,7 +214,7 @@ See `webi/template.sh`
 
 These variables will be set by the server:
 
-```bash
+```sh
 WEBI_PKG=example@v1
 WEBI_TAG=v1
 WEBI_HOST=https://webinstall.dev
@@ -231,19 +231,19 @@ WEBI_PKG_URL=https://cdn.example.com/example-macos-amd64.tar.gz
 WEBI_PKG_FILE=example-macos-amd64.tar.gz
 ```
 
-```bash
+```sh
 PKG_NAME=example
 PKG_OSES=macos,linux,windows
 PKG_ARCHES=amd64,arm64,x86
 PKG_FORMATS=zip,xz
 ```
 
-```bash
+```sh
 WEBI_TMP=${WEBI_TMP:-"$(mktemp -d -t webinstall-foobar.XXXXXXXX)"}
 WEBI_SINGLE=""
 ```
 
-```bash
+```sh
 webi_check              # Checks to see if the selected version is already installed (and re-links if so)
 webi_download           # Downloads the selected release to $HOME/Downloads/webi/<package-name>.tar.gz
 webi_extract            # Extracts the download to /tmp/<package-name>-<random>/

--- a/_example/README.md
+++ b/_example/README.md
@@ -33,7 +33,7 @@ install:
 
 To run foo:
 
-```bash
+```sh
 foo
 ```
 
@@ -41,6 +41,6 @@ foo
 
 To run foo with both bar and baz highlighting turned on:
 
-```bash
+```sh
 foo --bar=baz
 ```

--- a/_examples/built-with-goreleaser/README.md
+++ b/_examples/built-with-goreleaser/README.md
@@ -16,7 +16,7 @@ Each example has four files that need to be modified, just slightly:
 
 See [./keypairs/](/keypairs/) as an example.
 
-```bash
+```sh
 rsync -av ./keypairs/ ./my-project/
 ```
 
@@ -26,7 +26,7 @@ Keypairs is packaged for Mac and Linux as `.tar.gz`, and as `.zip` for Windows.
 
 See [./arc/](/arc/) as an example.
 
-```bash
+```sh
 rsync -av ./arc/ ./my-project/
 ```
 

--- a/_examples/compressed-with-xz/README.md
+++ b/_examples/compressed-with-xz/README.md
@@ -16,7 +16,7 @@ Each example has four files that need to be modified, just slightly:
 
 See [./gitea/](/gitea/) as an example.
 
-```bash
+```sh
 rsync -av ./keypairs/ ./my-project/
 ```
 

--- a/_npm/README.md
+++ b/_npm/README.md
@@ -11,7 +11,7 @@ Effortlessly install developer tools with easy-to-remember URLs.
 
 ## Install webi via npm:
 
-```bash
+```sh
 npm install -g webi
 ```
 
@@ -19,13 +19,13 @@ npm install -g webi
 
 Mac & Linux:
 
-```bash
+```sh
 curl -fsS https://webinstall.dev/node | bash
 ```
 
 Windows (includes `curl.exe` and PowerShell by default):
 
-```bash
+```sh
 curl.exe -fsSA "MS" https://webinstall.dev/node | powershell
 ```
 
@@ -34,7 +34,7 @@ curl.exe -fsSA "MS" https://webinstall.dev/node | powershell
 Once `webi` is installed, you can then install commands or switch versions with
 webi itself:
 
-```bash
+```sh
 webi node@stable
 webi node@lts
 webi node@v10

--- a/_vim-example/README.md
+++ b/_vim-example/README.md
@@ -26,7 +26,7 @@ If there are some important key bindings, use a table like this:
 
 1. Place EXAMPLE into your `~/.vim/pack/plugins/start`:
 
-   ```bash
+   ```sh
    mkdir -p ~/.vim/pack/plugins/start/
    git clone --depth=1 https://github.com/CHANGEME/EXAMPLE.git ~/.vim/pack/plugins/start/example
    ```

--- a/awless/README.md
+++ b/awless/README.md
@@ -12,7 +12,7 @@ To update or switch versions, run `webi awless@stable` (or `@v2`, `@beta`, etc).
 awless is modeled after popular command-line tools such as Git. Most commands
 are in the form of:
 
-```bash
+```sh
 awless verb [entity] [parameter=value ...]
 ```
 
@@ -26,13 +26,13 @@ Unlike the standard awscli tools, `awless` aims to be more human readable.
 
 For instance, let's list some resources:
 
-```bash
+```sh
 awless list vpcs
 ```
 
 Which outputs a friendly human readable table!
 
-```bash
+```sh
 |         ID ▲          | NAME | DEFAULT |   STATE   |     CIDR      |
 |-----------------------|------|---------|-----------|---------------|
 | vpc-00fd208a070000000 |      | false   | available | 172.16.0.0/16 |
@@ -42,13 +42,13 @@ Which outputs a friendly human readable table!
 There's also filter capabilities, in case the list is long. For example, let's
 list all EC2 instances with "api" in the name:
 
-```bash
+```sh
 awless list instances --filter name=api
 ```
 
 In addition to the default table output, there's also csv, tsv, json.
 
-```bash
+```sh
 awless list loadbalancers --format csv
 ```
 
@@ -56,7 +56,7 @@ awless list loadbalancers --format csv
 
 awless allows specifying things by name rather than ID by using the `@` prefix.
 
-```bash
+```sh
 awless create subnet cidr=10.0.0.0/24 vpc=@wordpress-vpc name=wordpress-public-subnet
 ```
 
@@ -65,13 +65,13 @@ awless create subnet cidr=10.0.0.0/24 vpc=@wordpress-vpc name=wordpress-public-s
 If you leave out a parameter, awless will prompt you for the missing
 information.
 
-```bash
+```sh
 awless delete i-123456789000abcd
 ```
 
 It will correctly detect what you were probably trying to do:
 
-```bash
+```sh
 Did you mean `awless delete instance ids=i-051fcef0537a53eb0` ?  [Y/n]
 ```
 

--- a/bat/README.md
+++ b/bat/README.md
@@ -25,14 +25,14 @@ You need to download and install the
 
 Update your `.bashrc`, `.zshrc`, or `.profile`
 
-```bash
+```sh
 alias cat="bat --style=plain"
 ```
 
 For situations in which you must use `cat` exactly, remember that you can escape
 the alias:
 
-```bash
+```sh
 \cat foo
 ```
 
@@ -40,13 +40,13 @@ the alias:
 
 Take a look at the config options:
 
-```bash
+```sh
 bat --help
 ```
 
 Check to see where your config file is:
 
-```bash
+```sh
 echo 'N' | bat --generate-config-file
 ```
 

--- a/brew/README.md
+++ b/brew/README.md
@@ -9,7 +9,7 @@ tagline: |
 
 `brew` has its own built-in upgrade management.
 
-```bash
+```sh
 brew update
 brew upgrade
 ```
@@ -26,27 +26,27 @@ way, report it to brew.
 
 ### How to install CLI packages
 
-```bash
+```sh
 brew update
 brew install node
 ```
 
 ### How to install GUI packages
 
-```bash
+```sh
 brew update
 brew cask install docker
 ```
 
 ### Where are things installed?
 
-```bash
+```sh
 ~/.local/opt/brew/
 ```
 
 For reference, traditional `brew` installs here:
 
-```bash
+```sh
 /usr/local/Cellar/
 /opt/homebrew-cask/Caskroom/
 ```
@@ -58,7 +58,7 @@ like `brew upgrade` or `brew update python`, and your whole system gets borked.
 
 If you need to _uninstall_ and _reinstall_ local brew:
 
-```bash
+```sh
 rm -rf ~/.local/opt/brew
 webi brew
 ```
@@ -67,12 +67,12 @@ If you need to _uninstall_ global brew:
 
 For _Mojave_, _Catalina_, _Big Sur_, and above:
 
-```bash
+```sh
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"
 ```
 
 For _High Sierra_ and below:
 
-```bash
+```sh
 /bin/bash -c ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"
 ```

--- a/caddy/README.md
+++ b/caddy/README.md
@@ -25,7 +25,7 @@ Here's the things we find most useful:
 
 ### How to serve a directory
 
-```bash
+```sh
 caddy file-server --browse --listen :4040
 ```
 
@@ -91,7 +91,7 @@ example.com {
 
 ### How to run caddy
 
-```bash
+```sh
 caddy run --config ./Caddyfile
 ```
 
@@ -112,7 +112,7 @@ Using a user named `app` to run your services is common industry convention.
 
 You can use `setcap` to allow Caddy to use privileged ports.
 
-```bash
+```sh
 sudo setcap cap_net_bind_service=+ep $(readlink -f $(command -v caddy))
 ```
 
@@ -123,13 +123,13 @@ start the appropriate systemd launcher for Linux.
 
 Install Serviceman with Webi:
 
-```bash
+```sh
 webi serviceman
 ```
 
 Use Serviceman to create a _systemd_ config file.
 
-```bash
+```sh
 sudo env PATH="$PATH" \
     serviceman add --system --username $(whoami) --name caddy -- \
         caddy run --config ./Caddyfile
@@ -138,7 +138,7 @@ sudo env PATH="$PATH" \
 This will create `/etc/systemd/system/caddy.service`, which can be managed with
 `systemctl`. For example:
 
-```bash
+```sh
 sudo systemctl restart caddy
 ```
 
@@ -155,13 +155,13 @@ start the appropriate service launcher file for MacOS.
 
 Install Serviceman with Webi:
 
-```bash
+```sh
 webi serviceman
 ```
 
 Use Serviceman to create a _launchd_ plist file.
 
-```bash
+```sh
 serviceman add --username $(whoami) --name caddy -- \
     caddy run --config ./Caddyfile
 ```
@@ -169,7 +169,7 @@ serviceman add --username $(whoami) --name caddy -- \
 This will create `~//Library/LaunchAgents/caddy.plist`, which can be managed
 with `launchctl`. For example:
 
-```bash
+```sh
 launchctl unload -w "$HOME/Library/LaunchAgents/caddy.plist"
 launchctl load -w "$HOME/Library/LaunchAgents/caddy.plist"
 ```
@@ -195,20 +195,20 @@ the appropriate service launcher for Windows.
 
 Install Serviceman with Webi:
 
-```bash
+```sh
 webi.bat serviceman
 ```
 
 Use Serviceman to create a Startup entry in the Windows Registry:
 
-```bash
+```sh
 serviceman.exe add --name caddy -- \
     caddy run --config ./Caddyfile
 ```
 
 You can manage the service directly with Serviceman. For example:
 
-```bash
+```sh
 serviceman stop caddy
 serviceman start caddy
 ```

--- a/chromedriver/README.md
+++ b/chromedriver/README.md
@@ -24,7 +24,7 @@ Also, **Chrome must be installed first** in order for ChromeDriver to work.
 On Debian (and Ubuntu) Linux you should be able to install Chrome with `dpkg`
 and `apt`:
 
-```bash
+```sh
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 sudo dpkg -i google-chrome-stable_current_amd64.deb
 sudo apt install -y google-chrome-stable
@@ -39,7 +39,7 @@ chromedriver: error while loading shared libraries: libnss3.so: cannot open shar
 
 If so, try installing `chromium-browser`:
 
-```bash
+```sh
 sudo apt install -y chromium-browser
 sudo apt --fix-broken install -y
 ```

--- a/comrak/README.md
+++ b/comrak/README.md
@@ -14,7 +14,7 @@ etc).
 > Flavored Markdown Spec: Tables, Task list items, Strikethrough, Autolinks, &
 > Disallowed Raw HTML
 
-```bash
+```sh
 comrak --gfm index.md > index.html
 ```
 
@@ -28,7 +28,7 @@ Here you'll learn how to:
 
 ## How to Convert Markdown to HTML
 
-```bash
+```sh
 comrak --gfm --header-ids '' README.md > README.html
 ```
 
@@ -39,7 +39,7 @@ defaults to always include your favorite options.
 
 Here's what I suggest:
 
-```bash
+```sh
 echo "--gfm --header-ids ''" > ~/.config/comrak/config
 ```
 
@@ -62,7 +62,7 @@ Example:
 Then, to sanitize `<script>` and `<iframe>` tags you must add `-e tagfilter`
 (which the `--gfm` option also enables).
 
-```bash
+```sh
 comrak --unsafe --gfm --header-ids '' README.md
 ```
 
@@ -75,7 +75,7 @@ The `--unsafe` option
 If you want Github-Flavored Markdown with trusted scripts, you'll need to enable
 its extensions by hand:
 
-```bash
+```sh
 echo "
 # WARNING: allows <script>, <iframe>
 # and <a href=javascript:alert('')>
@@ -100,7 +100,7 @@ echo "
 " > ~/.config/comrak/allow-scripts
 ```
 
-```bash
+```sh
 comrak --config ~/.config/comrak/allow-scripts README.md
 ```
 
@@ -110,6 +110,6 @@ You can disable all options with `--config-file none`.
 
 Example:
 
-```bash
+```sh
 comrak --config-file none -e table README.md
 ```

--- a/curlie/README.md
+++ b/curlie/README.md
@@ -22,19 +22,19 @@ etc).
 
 ### Simple GET
 
-```bash
+```sh
 curlie -v example.com
 ```
 
 ### POST simple JSON with headers
 
-```bash
+```sh
 curlie -v POST httpbin.org/status/201 "Authorization: Bearer xxxx" "name=John Doe"
 ```
 
 ### POST large JSON
 
-```bash
+```sh
 curlie -v POST httpbin.org/status/201 "Authorization: Bearer xxxx" -d '
 [
     {
@@ -49,7 +49,7 @@ curlie -v POST httpbin.org/status/201 "Authorization: Bearer xxxx" -d '
 The `--resolve` option is for when you need to test a local service as if it had
 a remote hostname and TLS SNI (or when you want to break things 😈).
 
-```bash
+```sh
 curlie https://foo.example.com:8443 "Host: foo.example.com" \
     --resolve foo.example.com:8443:127.0.0.1
 ```

--- a/dashmsg/README.md
+++ b/dashmsg/README.md
@@ -18,18 +18,18 @@ To update or switch versions, run `webi dashmsg@stable`.
 
 ### How to generate a new Private Key (WIF)
 
-```bash
+```sh
 # dashmsg gen <key>
 dashmsg gen priv.wif
 ```
 
-```bash
+```sh
 dashmsg gen > pirv.wif
 ```
 
 ### How to sign a message
 
-```bash
+```sh
 # dashmsg sign <priv key> <data or file>
 dashmsg sign ./priv.wif 'vote2022-alice|bob|charlie'
 ```
@@ -40,7 +40,7 @@ H2Opy9NX72iPZRcDVEHrFn2qmVwWMgc+DKILdVxl1yfmcL2qcpu9esw9wcD7RH0/dJHnIISe5j39EYah
 
 ### How to verify a signature
 
-```bash
+```sh
 # dashmsg verify <payment address> <message> <signature>
 dashmsg verify 'Xn4A2vv5fb7LvmiiXPPMexYbSbiQ29rzDu' \
     'vote2022-alice|bob|charly' \
@@ -72,7 +72,7 @@ Address   (b58c): Xn4A2vv5fb7LvmiiXPPMexYbSbiQ29rzDu
 
 #### How to inspect a signature
 
-```bash
+```sh
 dashmsg inspect 'IFLv0JVRM70bTZCTmzMfNX3NVkSULmnAR/3PSWpgC5GXBD7rRi5g4QsK968ITE3dfKdzhX7fAIXwhpnsP0WvQOc='
 ```
 
@@ -84,7 +84,7 @@ S (33-64): 043eeb462e60e10b0af7af084c4ddd7ca773857edf0085f08699ec3f45af40e7
 
 #### How to inspect a payment address
 
-```bash
+```sh
 dashmsg inspect 'Xn4A2vv5fb7LvmiiXPPMexYbSbiQ29rzDu'
 ```
 

--- a/delta/README.md
+++ b/delta/README.md
@@ -43,7 +43,7 @@ Delta uses `~/.gitconfig` for most of its options.
 
 Set `delta.syntax-theme` to change the color scheme:
 
-```bash
+```sh
 git config --global delta.syntax-theme 'Coldark-Dark'
 ```
 
@@ -52,19 +52,19 @@ git config --global delta.syntax-theme 'Coldark-Dark'
 You can list all available themes with `--list-syntax-themes`, or see each color
 schemes in action with `--show-syntax-themes`:
 
-```bash
+```sh
 delta --list-syntax-themes --dark
 delta --show-syntax-themes --dark
 ```
 
 You can also show only light or dark themes:
 
-```bash
+```sh
 delta --list-syntax-themes --light
 delta --show-syntax-themes --light
 ```
 
-```bash
+```sh
 delta --list-syntax-themes --dark
 delta --show-syntax-themes --dark
 ```
@@ -110,7 +110,7 @@ gruvbox-light
 You can use `git config --global` to get or set any arbitrary option of
 `~/.gitconfig`.
 
-```bash
+```sh
 git config --global page.diff delta
 git config --global page.show delta
 git config --global page.log delta

--- a/deno/README.md
+++ b/deno/README.md
@@ -17,25 +17,25 @@ etc).
 
 The obligatory Hello World
 
-```bash
+```sh
 deno run https://deno.land/std/examples/welcome.ts
 ```
 
 Run a local file
 
-```bash
+```sh
 deno run ./hello.ts
 ```
 
 Enable [permissions](https://deno.land/manual/getting_started/permissions)
 
-```bash
+```sh
 deno run --allow-read=./data,./public --allow-write=./data \
   --allow-net=example.com,example.net ./hello.ts
 ```
 
 Format source code, recursively
 
-```bash
+```sh
 deno fmt ./my-project
 ```

--- a/dotenv-linter/README.md
+++ b/dotenv-linter/README.md
@@ -27,19 +27,19 @@ You need to download and install the
 
 By default, `dotenv-linter` checks all `.env` files in the current directory:
 
-```bash
+```sh
 dotenv-linter
 ```
 
 This is the same as the default behavior:
 
-```bash
+```sh
 dotenv-linter .env .env.*
 ```
 
 To lint .env files recursively, use `-r`:
 
-```bash
+```sh
 dotenv-linter -r
 ```
 
@@ -50,7 +50,7 @@ For the complete usage, see the official
 
 Use the `--fix` flag.
 
-```bash
+```sh
 dotenv-linter --fix
 ```
 
@@ -61,7 +61,7 @@ can use `--no-backup` to skip this.
 
 You can turn off certain linter checks with `--skip` options, for example:
 
-```bash
+```sh
 dotenv-linter --skip QuoteCharacter --skip UnorderedKey
 ```
 

--- a/dotenv/README.md
+++ b/dotenv/README.md
@@ -13,7 +13,7 @@ To update or switch versions, run `webi dotenv@stable`.
 > variables) from a .env file. It works cross platform, and with any programming
 > environment (Node.js, Go, Rust, Ruby, Python, etc)
 
-```bash
+```sh
 # Usage: dotenv [-f .env.alt] -- <command> [arguments]
 
 # Example:

--- a/fd/README.md
+++ b/fd/README.md
@@ -16,7 +16,7 @@ To update or switch versions, run `webi fd@stable` (or `@v8.2`, `@beta`, etc).
 
 ### Colorized Recursive List
 
-```bash
+```sh
 fd
 ```
 
@@ -24,7 +24,7 @@ fd
 
 Anytime you use only lowercase letters, it's case-insensitive by default.
 
-```bash
+```sh
 fd foo
 ```
 
@@ -32,7 +32,7 @@ fd foo
 
 All `.` files and folders, and anything in `.gitignore` are ignored by default.
 
-```bash
+```sh
 fd -s -I -H foo
 ```
 
@@ -40,7 +40,7 @@ fd -s -I -H foo
 
 Use `-e` as many times as there are extensions that you want to match.
 
-```bash
+```sh
 fd -e md -e mkdn -e js -e mjs
 ```
 
@@ -48,6 +48,6 @@ fd -e md -e mkdn -e js -e mjs
 
 For options see:
 
-```bash
+```sh
 hexyl --help
 ```

--- a/ffmpeg/README.md
+++ b/ffmpeg/README.md
@@ -16,6 +16,6 @@ etc).
 Many simple conversions can be auto-detected by file extension and the options
 that produce the most similar quality by default.
 
-```bash
+```sh
 ffmpeg -i input.m4a output.mp3
 ```

--- a/fish/README.md
+++ b/fish/README.md
@@ -40,7 +40,7 @@ This also covers how to
 A bash script should have a "bash shebang" (`#!/bin/bash`) as the first line of
 the file:
 
-```bash
+```sh
 #!/bin/bash
 
 echo "Who am I? I'm $(whoami)."
@@ -48,7 +48,7 @@ echo "Who am I? I'm $(whoami)."
 
 You can also run bash explicitly:
 
-```bash
+```sh
 bash ./some-script.sh
 ```
 
@@ -57,7 +57,7 @@ bash ./some-script.sh
 You may like to have your `fish` theme match your Terminal or iTerm2 theme (such
 as _Solarized_, _Dracula_, or _Tomorrow Night_).
 
-```bash
+```sh
 fish_config colors
 ```
 
@@ -78,14 +78,14 @@ use the Terminal-specific methods.
 
 First, `fish` must be installed and in the `PATH`.
 
-```bash
+```sh
 # if you don't see a file path as output, fish is not in the path
 which fish
 ```
 
 Second, fish must be in the system-approved list of shells in `/etc/shells`:
 
-```bash
+```sh
 #!/bin/bash
 
 if ! grep $(which fish) /etc/shells > /dev/null; then
@@ -96,7 +96,7 @@ fi
 
 You should use `chsh` to change your shell:
 
-```bash
+```sh
 #!/bin/bash
 
 sudo chsh -s "$(which fish)" "$(whoami)"
@@ -115,7 +115,7 @@ You can also set is as the default for a particular Terminal, or for your user.
 
 Find out where `fish` is:
 
-```bash
+```sh
 which fish
 ```
 
@@ -130,7 +130,7 @@ Terminal > Preferences > General > Shells open with:
 
 Or, you can quit Terminal and change the preferences from the command line:
 
-```bash
+```sh
 #!/bin/bash
 
 defaults write com.apple.Terminal "Shell" -string "$HOME/.local/bin/fish"
@@ -140,7 +140,7 @@ defaults write com.apple.Terminal "Shell" -string "$HOME/.local/bin/fish"
 
 Find out where `fish` is:
 
-```bash
+```sh
 which fish
 ```
 
@@ -155,7 +155,7 @@ Custom Shell: /Users/YOUR_USER/.local/bin/fish
 
 Or, you can quit iTerm2 and change the preferences from the command line:
 
-```bash
+```sh
 #!/bin/bash
 
 /usr/libexec/PlistBuddy -c "SET ':New Bookmarks:0:Custom Command' 'Custom Shell'" \
@@ -193,7 +193,7 @@ shell:
 
 If you don't yet have an alacritty config, this will do:
 
-```bash
+```sh
 #!/bin/bash
 
 mkdir -p ~/.config/alacritty
@@ -213,13 +213,13 @@ The default `alacritty.yml` is included as an _asset_ with each
 
 Fish will be installed to the standard user location:
 
-```bash
+```sh
 ~/.local/opt/fish/
 ```
 
 It's config will also go in the standard user location:
 
-```bash
+```sh
 ~/.config/fish/config.fish
 ```
 

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -15,6 +15,6 @@ etc).
 
 ### How to create a new app
 
-```bash
+```sh
 flutter create my_app
 ```

--- a/fzf/README.md
+++ b/fzf/README.md
@@ -17,13 +17,13 @@ To update or switch versions, run `webi fzf@stable` (or `@v0.23`, `@beta`, etc).
 
 ### Live filter search results
 
-```bash
+```sh
 find . | fzf
 ```
 
 ### Live filter logs
 
-```bash
+```sh
 sudo journalctl -u my-app-name  --since '2020-01-01' | fzf
 ```
 

--- a/gh/README.md
+++ b/gh/README.md
@@ -24,7 +24,7 @@ Installation:
 
 Authenticate with your Github account.
 
-```bash
+```sh
 gh auth login
 ```
 
@@ -32,25 +32,25 @@ gh auth login
 
 Create a pull request.
 
-```bash
+```sh
 gh pr create -t <title> -b <body>
 ```
 
 Check out pull requests locally.
 
-```bash
+```sh
 gh pr checkout <pr#>
 ```
 
 Check the status of your pull requests.
 
-```bash
+```sh
 gh pr status
 ```
 
 View Your pull requests' checks.
 
-```bash
+```sh
 gh pr check
 ```
 
@@ -58,7 +58,7 @@ gh pr check
 
 View and filter a repository's open issues.
 
-```bash
+```sh
 gh issue list
 ```
 
@@ -66,7 +66,7 @@ gh issue list
 
 Create a new release.
 
-```bash
+```sh
 gh release create 0.1
 ```
 
@@ -74,7 +74,7 @@ gh release create 0.1
 
 How to see the status of recent jobs
 
-```bash
+```sh
 gh run list
 ```
 
@@ -82,13 +82,13 @@ _Note_: The **Job ID** is the third from the right column.
 
 How to view failure details
 
-```bash
+```sh
 gh run view <job-id>
 ```
 
 How to rerun a failed job
 
-```bash
+```sh
 gh run rerun <job-id>
 ```
 
@@ -96,7 +96,7 @@ gh run rerun <job-id>
 
 View repository READMEs.
 
-```bash
+```sh
 gh repo view
 ```
 
@@ -104,6 +104,6 @@ gh repo view
 
 Create Shortcut for a `gh` command.
 
-```bash
+```sh
 gh alias set bugs 'issue list --label="bugs"'
 ```

--- a/git-config-gpg/README.md
+++ b/git-config-gpg/README.md
@@ -23,7 +23,7 @@ Here we'll cover
 
 Usage:
 
-```bash
+```sh
 git-config-gpg
 ```
 
@@ -83,7 +83,7 @@ max-cache-ttl 34560000
 You'll need to reload `gpg-agent` for this to take effect, or just logout and
 login again.
 
-```bash
+```sh
 # kill gpg-agent dead
 killall gpg-agent
 gpgconf killall gpg-agent
@@ -109,7 +109,7 @@ See:
 Run [gpg-pubkey-id](./gpg-pubkey) to get your GnuPG Public Key ID and then
 update your `~/.gitconfig` to sign with it by default:
 
-```bash
+```sh
 #!/bin/bash
 
 MY_KEY_ID="$(
@@ -123,7 +123,7 @@ git config --global log.showSignature true
 
 Or, for Windows users:
 
-```bash
+```sh
 #!/usr/bin/env pwsh
 
 $my_key_id = gpg-pubkey-id
@@ -149,7 +149,7 @@ Or, if you prefer to edit the text file directly:
 In some cases you may also want to prevent conflicts between different installed
 versions of gpg, like so:
 
-```bash
+```sh
 git config --global gpg.program ~/.local/opt/gnupg/bin/gpg
 ```
 
@@ -170,7 +170,7 @@ fatal: failed to write commit object
 
 Try to load the `gpg-agent`, set `GPG_TTY`, and then run a clearsign test.
 
-```bash
+```sh
 gpg-connect-agent /bye
 export GPG_TTY=$(tty)
 echo "test" | gpg --clearsign
@@ -179,7 +179,7 @@ echo "test" | gpg --clearsign
 If that works, update your `~/.bashrc`, `~/.zshrc`, and/or
 `~/.config/fish/config.fish` to include the following:
 
-```bash
+```sh
 gpg-connect-agent /bye
 export GPG_TTY=$(tty)
 ```

--- a/git/README.md
+++ b/git/README.md
@@ -18,7 +18,7 @@ is a good place to get started if you're new to git.
 
 ### How to commit files
 
-```bash
+```sh
 git add ./path/to/file1
 git add ./path/to/file2
 git commit -m "my summary for this commit"
@@ -40,13 +40,13 @@ ignore
 
 This will branch from the branch you're currently on.
 
-```bash
+```sh
 git checkout -b my-branch-name
 ```
 
 ### How to rebase by default
 
-```bash
+```sh
 git config --global pull.rebase true
 ```
 
@@ -57,13 +57,13 @@ git config --global pull.rebase true
 
 Rebase when fetching new updates
 
-```bash
+```sh
 git pull --rebase origin master
 ```
 
 Rebase a feature branch from master before a merge
 
-```bash
+```sh
 # update master
 git fetch
 git checkout master
@@ -88,7 +88,7 @@ Abbreviated from
 First, update `.gitconfig` to handle each type of git URL (git, ssh, and http)
 as https:
 
-```bash
+```sh
 git config --global url."https://api@github.com/".insteadOf "https://github.com/"
 git config --global url."https://ssh@github.com/".insteadOf "ssh://git@github.com/"
 git config --global url."https://git@github.com/".insteadOf "git@github.com:"
@@ -96,14 +96,14 @@ git config --global url."https://git@github.com/".insteadOf "git@github.com:"
 
 Next, create a `.git-askpass`:
 
-```bash
+```sh
 echo 'echo $MY_GIT_TOKEN' > $HOME/.git-askpass
 chmod +x $HOME/.git-askpass
 ```
 
 Finally, add the following ENVs to your deployment environment:
 
-```bash
+```sh
 GIT_ASKPASS=$HOME/.git-askpass
 
 # Relpace xxxx... with your deploy token

--- a/gitdeploy/README.md
+++ b/gitdeploy/README.md
@@ -21,7 +21,7 @@ Works with
 
 To get set up, you'll want to copy the example scripts and dotenv:
 
-```bash
+```sh
 # The example scripts are a good starting point
 rsync -av examples/ scripts/
 
@@ -29,14 +29,14 @@ rsync -av examples/ scripts/
 mv scripts/dotenv .env
 ```
 
-```bash
+```sh
 gitdeploy run --listen :4483 --github-secret xxxxx --exec scripts/
 ```
 
 When gitdeploy receives a webhook it runs `scripts/deploy.sh` with the following
 environment variables set:
 
-```bash
+```sh
 GIT_REPO_ID=github.com/my-org/my-project
 
 GIT_CLONE_URL=https://github.com/my-org/my-project.git
@@ -64,12 +64,12 @@ scripts/github.com/YOUR_ORG/YOUR_PROJECT/deploy.sh
 ```
 
 1. Create a directory that matches the `GIT_REPO_ID`:
-   ```bash
+   ```sh
    mkdir -p scripts/github.com/YOUR_ORG/YOUR_PROJECT
    ```
 2. Create a `deploy.sh` that builds and deploys your project:
 
-   ```bash
+   ```sh
    #!/bin/bash
 
    # Put bash in strict mode or bad things will happen.
@@ -106,7 +106,7 @@ scripts/github.com/YOUR_ORG/YOUR_PROJECT/deploy.sh
 ### How to set up a webhook
 
 1. Generate a 128-bit random string:
-   ```bash
+   ```sh
    xxd -l16 -ps /dev/urandom
    ```
 2. Create a new Web Hook on your git platform:
@@ -118,7 +118,7 @@ scripts/github.com/YOUR_ORG/YOUR_PROJECT/deploy.sh
 3. Set the content type to JSON.
 4. Add the Webhook URL:
 
-   ```bash
+   ```sh
    # Github
    https://YOUR_DOMAIN/api/webhooks/github
 
@@ -134,7 +134,7 @@ scripts/github.com/YOUR_ORG/YOUR_PROJECT/deploy.sh
 Most of the flags, such as `--port` and `--github-secret` can also be set as
 ENVs. You can create a `.env` like this, for example:
 
-```bash
+```sh
 PORT=4483
 
 GITHUB_SECRET=xxxxxxxxxxx

--- a/gitea/README.md
+++ b/gitea/README.md
@@ -19,7 +19,7 @@ etc).
 
 ### How to run `gitea`
 
-```bash
+```sh
 gitea web --config ~/.local/opt/gitea/custom/conf/app.ini
 ```
 

--- a/golang/README.md
+++ b/golang/README.md
@@ -24,17 +24,17 @@ You may also want to install the Go IDE tooling:
 ### Hello World
 
 1. Make and enter your project directory
-   ```bash
+   ```sh
    mkdir -p ./hello/cmd/hello
    pushd ./hello/
    ```
 2. Initialize your `go.mod` to your _git repository_ url:
-   ```bash
+   ```sh
    go mod init github.com/example/hello
    ```
 3. Create a `hello.go`
 
-   ```bash
+   ```sh
    cat << EOF >> ./cmd/hello/hello.go
    package main
 
@@ -49,7 +49,7 @@ You may also want to install the Go IDE tooling:
    ```
 
 4. Format, build, and run your `./hello`
-   ```bash
+   ```sh
    go fmt ./...
    go build -o hello ./cmd/hello/
    ./hello
@@ -63,12 +63,12 @@ You may also want to install the Go IDE tooling:
 
 On Linux:
 
-```bash
+```sh
 # Install serviceman (compatible with systemd)
 webi serviceman
 ```
 
-```bash
+```sh
 # go into your programs 'opt' directory
 pushd ./hello/
 

--- a/goreleaser/README.md
+++ b/goreleaser/README.md
@@ -29,7 +29,7 @@ found the most useful for the majority of projects:
 
 To create an example `.goreleaser.yaml` file, and test the configuration:
 
-```bash
+```sh
 goreleaser init
 goreleaser --snapshot --skip-publish --rm-dist
 ```
@@ -70,13 +70,13 @@ You can get one at <https://github.com/settings/tokens/new>.
 
 You can export the environment variable:
 
-```bash
+```sh
 export GITHUB_TOKEN="YOUR_GITHUB_TOKEN"
 ```
 
 Or place the token in the default config location:
 
-```bash
+```sh
 ~/.config/goreleaser/github_token
 ```
 
@@ -91,14 +91,14 @@ Running GoReleaser without `--snapshot` must use the latest
 [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) of your repository.
 Create a tag and push it to Git:
 
-```bash
+```sh
 git tag -a v1.0.0 -m "First release"
 git push origin v1.0.0
 ```
 
 Running GoReleaser without `--skip-publish` will publish the builds:
 
-```bash
+```sh
 goreleaser --rm-dist
 ```
 
@@ -209,14 +209,14 @@ From macOS you can easily cross-compile cgo for Windows and Linux.
 
 Install [brew](https://webinstall.dev/brew), if needed:
 
-```bash
+```sh
 curl -sS https://webinstall.dev/brew | bash
 ```
 
 Install mingw and musl-cross: \
 (this may take hours if pre-built binaries are not available)
 
-```bash
+```sh
 brew install mingw-w64
 brew install FiloSottile/musl-cross/musl-cross --with-aarch64 --with-arm # --with-mips --with-486
 ```
@@ -224,7 +224,7 @@ brew install FiloSottile/musl-cross/musl-cross --with-aarch64 --with-arm # --wit
 You may want to manually test compiling for multiple platforms before automating
 it:
 
-```bash
+```sh
 GOARCH=amd64 GOOS=darwin                              go build -o unarr_darwin cmd/unarr/unarr.go
 GOARCH=amd64 GOOS=windows CC=x86_64-w64-mingw32-gcc   go build -o unarr.exe cmd/unarr/unarr.go
 GOARCH=amd64 GOOS=linux   CC=x86_64-linux-musl-gcc    go build -o unarr_linux_amd64 cmd/unarr/unarr.go
@@ -296,7 +296,7 @@ You'll need to manually create a different `builds` item for each unique `id`:
 If you compile without `-static`, you will need the `musl` libraries to run on
 (non-Alpine) Linuxes:
 
-```bash
+```sh
 sudo apt-get install -y musl
 ```
 

--- a/gpg-pubkey/README.md
+++ b/gpg-pubkey/README.md
@@ -21,7 +21,7 @@ This installs two commands.
 
 The easiest way to get your GnuPG Public Key:
 
-```bash
+```sh
 curl https://webinstall.dev/gpg-pubkey | bash
 ```
 
@@ -69,7 +69,7 @@ install:
 Run `gpg-pubkey-id` to get your GnuPG Public Key ID and then update your
 `~/.gitconfig` to sign with it by default:
 
-```bash
+```sh
 #!/bin/bash
 
 MY_KEY_ID="$(
@@ -83,7 +83,7 @@ git config --global log.showSignature true
 
 Or, for Windows users:
 
-```bash
+```sh
 #!/usr/bin/env pwsh
 
 $my_key_id = gpg-pubkey-id
@@ -106,7 +106,7 @@ All _Secret Keys_ have _Public IDs_ (and corresponding _Public Keys_).
 Here's a command to list your secret key(s) and get the Public ID (of the first
 one, if you have many):
 
-```bash
+```sh
 #!/bin/bash
 
 MY_KEY_ID="$(
@@ -139,7 +139,7 @@ Let's break that down, for good measure:
 All secret keys have a Public Key and a Public ID, which can be viewed in _LONG_
 format:
 
-```bash
+```sh
 gpg --list-secret-keys --keyid-format LONG
 ```
 
@@ -169,13 +169,13 @@ example), not just keys that you own.
 
 Here's how to copy your Public Key into your Downloads folder:
 
-```bash
+```sh
 gpg --armor --export "${MY_KEY_ID}" > ~/Downloads/"${MY_EMAIL}".gpg.asc
 ```
 
 Or, if you just want to print it to your console, run this:
 
-```bash
+```sh
 gpg --armor --export "${MY_KEY_ID}"
 ```
 
@@ -187,7 +187,7 @@ Generally speaking you'll want to use the same name and email for `git` and
 Here's how you can automate creating a key using the same info as what's in your
 `~/.gitconfig`:
 
-```bash
+```sh
 #!/bin/bash
 
 MY_NAME="$( git config --global user.name )"
@@ -210,7 +210,7 @@ EOF
 
 Or, for the Windows folk...
 
-```bash
+```sh
 #!/usr/bin/env pwsh
 
 $my_name = git config --global user.name

--- a/gpg/README.md
+++ b/gpg/README.md
@@ -46,7 +46,7 @@ See the [Cheat Sheet](./gpg-pubkey) at [gpg-pubkey](./gpg-pubkey).
 
 ### How to List GPG Key(s)
 
-```bash
+```sh
 gpg --list-secret-keys --keyid-format LONG
 ```
 
@@ -65,7 +65,7 @@ GPG is the OG "blockchain", as it were.
 If you'd like to publish your (public) key(s) to the public Key Servers for time
 and all eternity, you can:
 
-```bash
+```sh
 gpg --send-keys "${MY_KEY_ID}"
 ```
 
@@ -114,7 +114,7 @@ You need to use `gpg-connect-agent` instead.
 
 And then start it with launchctl:
 
-```bash
+```sh
 launchctl load -w ~/Library/LaunchAgents/gpg-agent.plist
 ```
 
@@ -130,7 +130,7 @@ fatal: failed to write commit object
 
 Try to load the `gpg-agent`, set `GPG_TTY`, and then run a clearsign test.
 
-```bash
+```sh
 gpg-connect-agent /bye
 export GPG_TTY=$(tty)
 echo "test" | gpg --clearsign
@@ -139,7 +139,7 @@ echo "test" | gpg --clearsign
 If that works, update your `~/.bashrc`, `~/.zshrc`, and/or
 `~/.config/fish/config.fish` to include the following:
 
-```bash
+```sh
 gpg-connect-agent /bye
 export GPG_TTY=$(tty)
 ```

--- a/gprox/README.md
+++ b/gprox/README.md
@@ -21,7 +21,7 @@ given to an interpreter you dont know much about if you're using `webi`.
 
 The fastest way to get started is just by running:
 
-```bash
+```sh
 gprox
 # example output
 # 9:12PM INF Running proxy! from=https://localhost:9001 to=http://localhost:9000
@@ -33,20 +33,20 @@ That is... if you're app happens to be running on port `9000`. If not, no
 worries! Simply pass the target port option `-t, --target` and specify the port
 your app _is_ running on.
 
-```bash
+```sh
 gprox -t 8080
 ```
 
 Feeling like you should save this magic built-in cert so you can inspect it for
 anything?
 
-```bash
+```sh
 gprox --dropcert
 ```
 
 Want to use your own cert/key?
 
-```bash
+```sh
 gprox -c testcert.crt -k testkey.key
 ```
 

--- a/hexyl/README.md
+++ b/hexyl/README.md
@@ -21,14 +21,14 @@ etc).
 If you know that you need a _hex viewer_, then you probably already know enough
 to see why this is particularly useful, and can figure out how to use it.
 
-```bash
+```sh
 echo "hello" > foo.bin
 hexyl foo.bin
 ```
 
 For options, such as `--length`, `--skip`, and `--offset`, see:
 
-```bash
+```sh
 hexyl --help
 ```
 
@@ -37,7 +37,7 @@ hexyl --help
 If you have some hex (say from some server logs) that you'd like to encode back
 to binary to view in hexyl, you can convert it with `xxd`:
 
-```bash
+```sh
 echo '48656c6c6f210a' > foo.hex
 xxd -r -p foo.hex foo.bin
 ```

--- a/hugo/README.md
+++ b/hugo/README.md
@@ -15,17 +15,17 @@ etc).
 
 ### Create a new site
 
-```bash
+```sh
 # create a new site
 hugo new site ./blog.example.com
 ```
 
-```bash
+```sh
 # compile a site
 hugo
 ```
 
-```bash
+```sh
 # serve a site in dev mode
 hugo server -D
 ```

--- a/iterm2-themes/README.md
+++ b/iterm2-themes/README.md
@@ -28,7 +28,7 @@ The installer will download them to `~/Downloads/webi/iterm2-themes`
 
 It's up to you to open them, and then iTerm2 will ask you to confirm.
 
-```bash
+```sh
 open ~/Downloads/webi/iterm2-themes/*.itermcolors
 ```
 
@@ -66,7 +66,7 @@ Grape
 If you're using [fish](https://webinstall.dev/fish) (as you should be!), be sure
 to set your shell color theme to the same or similar:
 
-```bash
+```sh
 fish_config colors
 ```
 

--- a/iterm2-utils/README.md
+++ b/iterm2-utils/README.md
@@ -10,7 +10,7 @@ To update, just run `webi iterm2-utils` again.
 Note: On first use you'll need to source the new config, or login and login
 again.
 
-```bash
+```sh
 source ~/.iterm2_shell_integration.bash
 ```
 

--- a/iterm2/README.md
+++ b/iterm2/README.md
@@ -107,6 +107,6 @@ Grape
 If you're using [fish](https://webinstall.dev/fish) (as you should be!), be sure
 to set your shell color theme to the same or similar:
 
-```bash
+```sh
 fish_config colors
 ```

--- a/jq/README.md
+++ b/jq/README.md
@@ -23,7 +23,7 @@ You can also [try online](https://jqplay.org/).
 
 ### How to select a single a property from an object
 
-```bash
+```sh
 echo '{ "name": "foo" }' | jq '.name'
 ```
 
@@ -35,7 +35,7 @@ echo '{ "name": "foo" }' | jq '.name'
 
 The `-r` or `--raw-output` flag unwraps strings:
 
-```bash
+```sh
 echo '{ "name": "foo" }' | jq -r '.name'
 ```
 
@@ -45,7 +45,7 @@ foo
 
 ### How to select a whole object
 
-```bash
+```sh
 echo '{ "name": "foo" }' | jq '.'
 ```
 
@@ -57,7 +57,7 @@ echo '{ "name": "foo" }' | jq '.'
 
 ### How to select an element from an array
 
-```bash
+```sh
 echo '[ { "name": "foo" } ]' | jq '.[0]'
 ```
 
@@ -69,7 +69,7 @@ echo '[ { "name": "foo" } ]' | jq '.[0]'
 
 ### How to select a single property from an array element
 
-```bash
+```sh
 echo '[ { "name": "foo" } ]' | jq -r '.[0].name'
 ```
 
@@ -79,7 +79,7 @@ foo
 
 ### How to select some properties from multiple elements
 
-```bash
+```sh
 echo '[ { "name": "foo" }, { "name": "bar" } ]' \
     | jq -r '.[].name'
 ```
@@ -101,7 +101,7 @@ Be sure to checkout the
 [official tutorial](https://stedolan.github.io/jq/tutorial/) and
 [jq manual](https://stedolan.github.io/jq/manual/) for more info.
 
-```bash
+```sh
 echo '[ { "name": "foo", "age": 0 }, { "name": "bar", "age": 2 } ]' \
     | jq '{ names: [.[] | .name], ages: [.[] | .age] }'
 ```

--- a/jshint/README.md
+++ b/jshint/README.md
@@ -59,7 +59,7 @@ projects.
 You can copy our recommended settings into your project directory by running
 this command:
 
-```bash
+```sh
 # convert from JSON5 (with comments) to JSON and copy into current directory
 sed -e 's://.*::g' \
     ~/.jshintrc.webi.json5 \
@@ -125,7 +125,7 @@ The list of JSHint's default options can be found here:
 
 Give `jshint` a list of files and/or directories to check `.js` files:
 
-```bash
+```sh
 jshint ./
 ```
 
@@ -133,7 +133,7 @@ jshint ./
 
 Create a `.jshintignore` to tell JSHint which files to ignore every time
 
-```bash
+```sh
 echo "dist/" >> .jshintignore
 ```
 

--- a/k9s/README.md
+++ b/k9s/README.md
@@ -21,13 +21,13 @@ common command line arguments from k9s (https://github.com/derailed/k9s).
 K9s uses 256 colors terminal mode. On `Nix system make sure TERM is set
 accordingly.
 
-```bash
+```sh
 export TERM=xterm-256color
 ```
 
 To run k9s:
 
-```bash
+```sh
 k9s
 ```
 
@@ -35,30 +35,30 @@ k9s
 
 List all available CLI options
 
-```bash
+```sh
 k9s help
 ```
 
 To get info about K9s runtime (logs, configs, etc..)
 
-```bash
+```sh
 k9s info
 ```
 
 To run K9s in a given namespace
 
-```bash
+```sh
 k9s -n mycoolns
 ```
 
 Start K9s in an existing KubeConfig context
 
-```bash
+```sh
 k9s --context coolCtx
 ```
 
 Start K9s in readonly mode - with all cluster modification commands disabled
 
-```bash
+```sh
 k9s --readonly
 ```

--- a/keypairs/README.md
+++ b/keypairs/README.md
@@ -17,32 +17,32 @@ To update or switch versions, run `webi keypairs@stable`.
 
 ### How to generate JSON Web Keys (JWKs)
 
-```bash
+```sh
 # keypairs gen -key <key.format> -pub <pub.format>
 keypairs gen -key key.jwk.json -pub pub.jwk.json
 ```
 
 JWK is the default format, for which you can use stdout (key) and stderr (pub)
 
-```bash
+```sh
 keypairs gen > key.jwk.json 2> pub.jwk.json
 ```
 
 ### How to generate PEM (PKCS) keys
 
-```bash
+```sh
 keypairs gen -key key.pem -pub pub.pem
 ```
 
 Or DER
 
-```bash
+```sh
 keypairs gen -key key.der -pub pub.der
 ```
 
 ### How to sign a payload
 
-```bash
+```sh
 # keypairs sign --exp 1h <priv key> <data or file> > token.jwt 2> sig.jws
 keypairs sign --exp 1h key.jwk.json '{ "sub": "me@example.com" }' > token.jwt 2> sig.jws
 ```
@@ -78,14 +78,14 @@ rather than the `kid` thumbprint.
 
 ### How to verify a signature
 
-```bash
+```sh
 # keypairs verify <pub key> <signed file or data>
 keypairs verify pub.jwk.json token.jwt
 ```
 
 You can use files or strings.
 
-```bash
+```sh
 keypairs verify \
   '{ "crv": "P-256", "kty": "EC", "x": "5K5ALgtWw37KsZOrBdwCyGOGKCFd27u-t61dmUiieJY", "y": "wr3BNL-CeqkGtiRVqo3yizKxUA0bwS1MNZeqytdwICA" }' \
   eyJhbGciOiJFUzI1NiIsImtpZCI6ImpkeHhZY1NCZUJfeUdoZWlCVW14NjF0eHExZGFjR1hIX191bEJuWlZHMEUiLCJ0eXAiOiJKV1QifQ.eyJleHAiOjIxNDczODU3MTIsInN1YiI6Im1lQGV4YW1wbGUuY29tIn0.oh8-PUMdrbQU6seRXjo68wPWAKbA-V9LMnd_wZEkPHc3C8A5xJzV7mDDMNOLEy4VcuNGxced_yjYulzcMa5FLQ

--- a/kind/README.md
+++ b/kind/README.md
@@ -16,25 +16,25 @@ User Guide - Quick Start: https://kind.sigs.k8s.io/docs/user/quick-start
 
 To create a cluster with default name
 
-```bash
+```sh
 kind create cluster
 ```
 
 Create a cluster with a specific name
 
-```bash
+```sh
 kind create cluster --name foo
 ```
 
 List clusters
 
-```bash
+```sh
 kind get clusters
 ```
 
 Specify Kubernetes version
 
-```bash
+```sh
 kind create cluster --image "kindest/node:$favoriteTag"
 ```
 
@@ -43,24 +43,24 @@ kind create cluster --image "kindest/node:$favoriteTag"
 
 Export all logs from a cluster
 
-```bash
+```sh
 kind exports logs $HOME/somedir
 ```
 
 To delete a cluster with default name
 
-```bash
+```sh
 kind delete cluster
 ```
 
 To delete a cluster with specific name
 
-```bash
+```sh
 kind delete cluster --name foo
 ```
 
 Get the kubeconfig of a cluster
 
-```bash
+```sh
 kind get kubeconfig --name foo
 ```

--- a/koji/README.md
+++ b/koji/README.md
@@ -35,7 +35,7 @@ Here's the shortlist of options we've found most useful:
 
 These are the files that are created and/or modified with this installer:
 
-```bash
+```sh
 ~/.config/envman/PATH.env
 ~/.local/bin/koji
 ~/.local/opt/koji-VERSION/bin/koji
@@ -45,7 +45,7 @@ These are the files that are created and/or modified with this installer:
 
 In this case, `koji` acts as a wrapper around `git commit`:
 
-```bash
+```sh
 git add example.env
 
 # same as `git commit`, but interactive
@@ -56,7 +56,7 @@ koji
 
 Just add `koji --hook` to your project's `.git/hooks/prepare-commit-msg`:
 
-```bash
+```sh
 echo >> ./.git/hooks/prepare-commit-msg << "EOF"
 #!/bin/bash
 koji --hook
@@ -65,7 +65,7 @@ EOF
 chmod a+x ./.git/hooks/prepare-commit-msg
 ```
 
-```bash
+```sh
 # will run koji by way of prepare-commit-msg
 git commit
 ```
@@ -75,7 +75,7 @@ git commit
 You can use `-e` (or `--emoji`) to prepend your commit message with the relevant
 emoji for the commit type:
 
-```bash
+```sh
 koji -e
 ```
 
@@ -83,7 +83,7 @@ As a git hook:
 
 `.git/hooks/prepare-commit-msg`:
 
-```bash
+```sh
 #!/bin/bash
 koji --emoji --hook
 ```

--- a/kubectx/README.md
+++ b/kubectx/README.md
@@ -14,13 +14,13 @@ etc).
 
 To run kubectx:
 
-```bash
+```sh
 kubectx
 ```
 
 ### Command line arguments
 
-```bash
+```sh
 USAGE:
   kubectx                   : list the contexts
   kubectx <NAME>            : switch to context <NAME>

--- a/kubens/README.md
+++ b/kubens/README.md
@@ -14,6 +14,6 @@ etc).
 
 To run kubens:
 
-```bash
+```sh
 kubens
 ```

--- a/lf/README.md
+++ b/lf/README.md
@@ -14,7 +14,7 @@ To update or switch versions, run `webi lf@stable` (or `@v2`, `@beta`, etc).
 
 To start the application in the current directory:
 
-```bash
+```sh
 lf
 ```
 
@@ -35,12 +35,12 @@ lf
 
 ### For command line options:
 
-```bash
+```sh
 lf --help
 ```
 
 ### For documentation
 
-```bash
+```sh
 lf --doc
 ```

--- a/lsd/README.md
+++ b/lsd/README.md
@@ -20,13 +20,13 @@ update the font in your Terminal for `lsd` to show icons.
 
 Run `lsd` exactly as you would `ls`:
 
-```bash
+```sh
 lsd
 ```
 
 But wait, there's more, you can `tree` as well:
 
-```bash
+```sh
 lsd --tree
 ```
 
@@ -35,13 +35,13 @@ lsd --tree
 If you just want the benefits of a cross-platform `ls` without having to install
 nerdfont or needing a modern terminal, you've got options:
 
-```bash
+```sh
 lsd --icon=never --color=never
 ```
 
 Since that can be a little awkward to type over and over, you can use an alias:
 
-```bash
+```sh
 alias lsd=lsd --icon=never --color=never
 lsd
 ```
@@ -50,7 +50,7 @@ lsd
 
 Update your `.bashrc`, `.zshrc`, or `.profile`
 
-```bash
+```sh
 alias ls="lsd -F"
 alias la="lsd -AF"
 alias ll="lsd -lAF"
@@ -60,7 +60,7 @@ alias lg="lsd -F --group-dirs=first"
 For situations in which you must use `ls` exactly, remember that you can escape
 the alias:
 
-```bash
+```sh
 \ls -lAF
 ```
 
@@ -68,12 +68,12 @@ the alias:
 
 Update your `.bashrc`, `.zshrc`, or `.profile`
 
-```bash
+```sh
 alias tree="lsd -AF --tree"
 ```
 
 And when you want to use GNU `tree`, just escape the alias:
 
-```bash
+```sh
 \tree
 ```

--- a/mutagen/README.md
+++ b/mutagen/README.md
@@ -20,50 +20,50 @@ etc).
 Create a synchronization session named "web-app-code" between the local path
 ~/project and an SSH-accessible endpoint.
 
-```bash
+```sh
 mutagen sync create --name=web-app-code ~/project user@example.org:~/project
 ```
 
 OR Create a forwarding session named "web-app" between port 8080 on localhost
 and port 1313 inside a Docker container.
 
-```bash
+```sh
 mutagen forward create --name=web-app tcp:localhost:8080 docker://devcontainer:tcp:localhost:1313
 ```
 
 ### Listing sessions
 
-```bash
+```sh
 mutagen sync list
 ```
 
 OR
 
-```bash
+```sh
 mutagen forward list
 ```
 
 ### Monitoring a session
 
-```bash
+```sh
 mutagen sync monitor web-app-code
 ```
 
 OR
 
-```bash
+```sh
 mutagen forward monitor web-app
 ```
 
 ### Pausing/resuming sessions
 
-```bash
+```sh
 mutagen sync pause web-app-code
 ```
 
 OR
 
-```bash
+```sh
 mutagen forward pause web-app
 ```
 
@@ -71,30 +71,30 @@ To resume replace `pause` with `resume` in the above commands
 
 ### Resetting session
 
-```bash
+```sh
 mutagen sync reset web-app-code
 ```
 
 ### Terminating session
 
-```bash
+```sh
 mutagen sync terminate web-app-code
 ```
 
 OR
 
-```bash
+```sh
 mutagen forward terminate web-app
 ```
 
 For general help
 
-```bash
+```sh
 mutagen --help
 ```
 
 For specific command help
 
-```bash
+```sh
 mutagen <command> --help
 ```

--- a/myip/README.md
+++ b/myip/README.md
@@ -7,7 +7,7 @@ tagline: |
 
 ## Updating `myip`
 
-```bash
+```sh
 webi myip
 ```
 
@@ -46,19 +46,19 @@ You likely have an IPv4 or A address as well as an IPv6 or AAAA address.
 
 To find out your IPv4 or A address:
 
-```bash
+```sh
 curl -s https://api.ipify.org
 ```
 
 To find out your IPv6 or AAAA address:
 
-```bash
+```sh
 curl -s https://api6.ipify.org
 ```
 
 To find out either address:
 
-```bash
+```sh
 curl -s https://api46.ipify.org
 ```
 

--- a/nerdfont/README.md
+++ b/nerdfont/README.md
@@ -138,7 +138,7 @@ Find `Terminal` in the top Mac menu, then...
 
 **Mac**:
 
-```bash
+```sh
 ~/Library/Fonts/
 ```
 
@@ -154,6 +154,6 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\Fonts
 
 **Linux**:
 
-```bash
+```sh
 ~/.local/share/fonts/
 ```

--- a/node/README.md
+++ b/node/README.md
@@ -27,7 +27,7 @@ Installing node via webi will:
 
 ### Hello World
 
-```bash
+```sh
 node -e 'console.log("Hello, World!")'
 > Hello, World!
 ```
@@ -36,7 +36,7 @@ node -e 'console.log("Hello, World!")'
 
 `server.js`:
 
-```bash
+```sh
 var http = require('http');
 var app = function (req, res) {
   res.end('Hello, World!');
@@ -46,7 +46,7 @@ http.createServer(app).listen(8080, function () {
 });
 ```
 
-```bash
+```sh
 node server.js
 ```
 
@@ -54,20 +54,20 @@ node server.js
 
 This generates a hex-encoded 128-bit random key.
 
-```bash
+```sh
 node -p 'crypto.randomBytes(16).toString("hex")'
 ```
 
 This generates a url-safe base64 256-bit random key.
 
-```bash
+```sh
 node -p 'crypto.randomBytes(32).toString("base64")
             .replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "")'
 ```
 
 ### An Express App
 
-```bash
+```sh
 mkdir my-server
 pushd my-server/
 npm init
@@ -102,6 +102,6 @@ http.createServer(app).listen(8080, function () {
 });
 ```
 
-```bash
+```sh
 npm start
 ```

--- a/ots/README.md
+++ b/ots/README.md
@@ -22,49 +22,49 @@ install:
 
 ### Share a generated secret
 
-```bash
+```sh
 ots share -g
 ```
 
 ### Share custom secret with ttl and passphrase
 
-```bash
+```sh
 ots share -s hellosecret -t 300 -p hello
 ```
 
 ### Share secret from file
 
-```bash
+```sh
 cat <<EOF | ots share -f -
 secret: hello
 seret: secret
 EOF
 ```
 
-```bash
+```sh
 echo "hellosecret" | ots share -f
 ```
 
 ### Burn secrets
 
-```bash
+```sh
 ots burn METADATA_KEY
 ```
 
 ### Get secret value
 
-```bash
+```sh
 ots get secret SECRET_KEY
 ```
 
 ### Get secret metadata
 
-```bash
+```sh
 ots get meta METADATA_KEY
 ```
 
 ### Get recent secrets (requires auth)
 
-```bash
+```sh
 ots get recent
 ```

--- a/pandoc/README.md
+++ b/pandoc/README.md
@@ -13,13 +13,13 @@ etc).
 > Pandoc is a Haskell library for converting from one markup format to another,
 > and a command-line tool that uses this library.
 
-```bash
+```sh
 pandoc -o output.html input.txt
 ```
 
 Specifying formats
 
-```bash
+```sh
 pandoc -f markdown -t latex hello.txt
 ```
 

--- a/pathman/README.md
+++ b/pathman/README.md
@@ -7,7 +7,7 @@ tagline: |
 
 ## Updating `pathman`
 
-```bash
+```sh
 webi pathman
 ```
 
@@ -19,24 +19,24 @@ Manages PATH on various OSes and shells
 - Bash, Zsh, Fish
 - Command, Powershell
 
-```bash
+```sh
 pathman help
 ```
 
 ### Usage
 
-```bash
+```sh
 pathman add ~/.local/bin
 ```
 
-```bash
+```sh
 pathman remove ~/.local/bin
 ```
 
 Note: Even on Windows it is best to use Unix-style `/` paths and `~` for
 `%USERPROFILE%`.
 
-```bash
+```sh
 pathman list
 ```
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -18,13 +18,13 @@ etc).
 
 Run just once (for development):
 
-```bash
+```sh
 postgres -D $HOME/.local/share/postgres/var -p 5432
 ```
 
 Run as a system service on Linux:
 
-```bash
+```sh
 sudo env PATH="$PATH" \
     serviceman add --system --username "$(whoami)" --name postgres -- \
     postgres -D "$HOME/.local/share/postgres/var" -p 5432
@@ -35,13 +35,13 @@ sudo systemctl restart systemd-journald
 
 ### Connect with the psql client
 
-```bash
+```sh
 psql 'postgres://postgres:postgres@localhost:5432/postgres'
 ```
 
 ### Initialize a database with a password
 
-```bash
+```sh
 echo "postgres" > /tmp/pwfile
 mkdir -p $HOME/.local/share/postgres/var/
 
@@ -55,12 +55,12 @@ rm /tmp/pwfile
 ### Add and secure remote users
 
 1. Set your server name or IP address
-   ```bash
+   ```sh
    PG_HOST=pg-1.example.com
    ```
 2. Generate a 10-year self-signed TLS certificate
 
-   ```bash
+   ```sh
    openssl req -new -x509 -days 3650 -nodes -text \
        -out server.crt \
        -keyout server.key \
@@ -71,7 +71,7 @@ rm /tmp/pwfile
    ```
 
 3. Enable SSL (TLS)
-   ```bash
+   ```sh
    vim ~/.local/share/postgres/var/postgresql.conf
    ```
    ```ini
@@ -81,7 +81,7 @@ rm /tmp/pwfile
    ```
 4. Generate a user with a random token password
 
-   ```bash
+   ```sh
    MY_USER='my_user'
    MY_PASSWORD="$(xxd -l16 -ps /dev/urandom)"
 
@@ -90,23 +90,23 @@ rm /tmp/pwfile
    ```
 
 5. Show the token password and save it somewhere
-   ```bash
+   ```sh
    echo "$MY_PASSWORD"
    ```
 6. Allow the user to connect via IPv4 and IPv6
-   ```bash
+   ```sh
    echo "# Allow $MY_USER to connect remotely over the internet
    hostssl all             $MY_USER        0.0.0.0/0               scram-sha-256
    hostssl all             $MY_USER        ::0/0                   scram-sha-256" \
        >> ~/.local/share/postgres/var/pg_hba.conf
    ```
 7. Restart postgres
-   ```bash
+   ```sh
    sudo systemctl restart postgres
    ```
 8. Test the connection from a remote system
 
-   ```bash
+   ```sh
    PG_HOST="pg-1.example.com"
    PG_USER="my_user"
 
@@ -119,7 +119,7 @@ rm /tmp/pwfile
 
 ### Add or update a user's password
 
-```bash
+```sh
 MY_USER='my_user'
 MY_NEW_PASSWORD="$(xxd -l16 -ps /dev/urandom)"
 

--- a/prettier/README.md
+++ b/prettier/README.md
@@ -26,13 +26,13 @@ install:
 
 Prettify all web files in a project, recursively:
 
-```bash
+```sh
 prettier --write '**/*{.md,.js,.html,.css}'
 ```
 
 Tell Prettier which files to ignore every time
 
-```bash
+```sh
 echo "dist/" >> .prettierignore
 ```
 
@@ -41,7 +41,7 @@ necessary!
 
 **`.prettierrc.json`**:
 
-```bash
+```sh
 {
   "trailingComma": "none",
   "tabWidth": 2,

--- a/pyenv/README.md
+++ b/pyenv/README.md
@@ -11,7 +11,7 @@ To update run `pyenv update`.
 
 Make sure that you already have Xcode tools installed:
 
-```bash
+```sh
 xcode-select --install
 ```
 
@@ -19,7 +19,7 @@ xcode-select --install
 
 Make sure that you already have the necessary build tools installed:
 
-```bash
+```sh
 # required
 sudo apt update
 sudo apt install -y build-essential zlib1g-dev libssl-dev
@@ -39,21 +39,21 @@ pre-requisites above).
 
 Here's how you can check for the latest version:
 
-```bash
+```sh
 pyenv install --list | grep -v -- - | tail -n 1
 #>   3.9.1
 ```
 
 And install it:
 
-```bash
+```sh
 pyenv install -v 3.9.1
 #> Installed Python-3.9.1 to ~/.pyenv/versions/3.9.1
 ```
 
 And use it:
 
-```bash
+```sh
 pyenv global 3.9.1
 python --version
 #> Python 3.9.1
@@ -61,13 +61,13 @@ python --version
 
 Revert back to your system python:
 
-```bash
+```sh
 pyenv global system
 ```
 
 ### List all available python version
 
-```bash
+```sh
 pyenv install --list
 ```
 
@@ -87,7 +87,7 @@ pyenv install --list
 
 ### Install Python versions
 
-```bash
+```sh
 pyenv install <version>
 pyenv rehash
 ```
@@ -96,7 +96,7 @@ pyenv rehash
 
 List installed versions:
 
-```bash
+```sh
 pyenv versions
 ```
 
@@ -104,13 +104,13 @@ pyenv versions
 
 Pin an application to a specific Python version:
 
-```bash
+```sh
 pyenv local 2.7.6
 ```
 
 Unset the local version:
 
-```bash
+```sh
 pyenv local --unset
 ```
 
@@ -118,7 +118,7 @@ pyenv local --unset
 
 ### List existing virtualenvs
 
-```bash
+```sh
 pyenv virtualenvs
 ```
 
@@ -126,26 +126,26 @@ pyenv virtualenvs
 
 From current version with name "venv35":
 
-```bash
+```sh
 pyenv virtualenv venv35
 ```
 
 From version 2.7.10 with name "venv27":
 
-```bash
+```sh
 pyenv virtualenv 2.7.10
 venv27
 ```
 
 ### Activate/deactivate
 
-```bash
+```sh
 pyenv activate <name>
 pyenv deactivate
 ```
 
 ### Delete existing virtualenv
 
-```bash
+```sh
 pyenv uninstall venv27
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -11,7 +11,7 @@ To update or switch versions, run `pyenv install -v 3` (or `3.10`, etc).
 
 Make sure that you already have Xcode tools installed:
 
-```bash
+```sh
 xcode-select --install
 ```
 
@@ -21,7 +21,7 @@ You may also need to install Xcode proper from the App Store.
 
 Make sure that you already have the necessary build tools installed:
 
-```bash
+```sh
 # required
 sudo apt update
 sudo apt install -y build-essential zlib1g-dev libssl-dev
@@ -60,7 +60,7 @@ system utilities (which is why we love it so much).
 However, in the rare event that you need to switch your user profile's python
 back to the system version, you can do so:
 
-```bash
+```sh
 pyenv global system
 ```
 
@@ -68,7 +68,7 @@ pyenv global system
 
 Go into the root of your project repository and run this, for example:
 
-```bash
+```sh
 pyenv local -v 3.10.0
 ```
 

--- a/python2/README.md
+++ b/python2/README.md
@@ -11,7 +11,7 @@ To update or switch versions, run `pyenv install -v 2` (or `2.6`, etc).
 
 Make sure that you already have Xcode tools installed:
 
-```bash
+```sh
 xcode-select --install
 ```
 
@@ -21,7 +21,7 @@ You may also need to install Xcode proper from the App Store.
 
 Make sure that you already have the necessary build tools installed:
 
-```bash
+```sh
 # required
 sudo apt update
 sudo apt install -y build-essential zlib1g-dev libssl-dev

--- a/rclone/README.md
+++ b/rclone/README.md
@@ -42,13 +42,13 @@ fragmentation.
 
 Example:
 
-```bash
+```sh
 rclone sync -vP --transfers=1 --order-by name --check-first ~/ /Volumes/Backup/home
 ```
 
 Example, excluding common temporary directories:
 
-```bash
+```sh
 rclone sync -vP --transfers=1 --order-by name --check-first \
   --exclude 'node_modules/**' --exclude '.Spotlight-*/**' --exclude '.cache*/**' \
   ~/ /Volumes/Backup/home

--- a/rg/README.md
+++ b/rg/README.md
@@ -14,15 +14,15 @@ To update or switch versions, run `webi rg@stable` (or `@v13.0`, `@beta`, etc).
 > (colors, numbers, etc) turned on by default, is written in Rust, and typically
 > outperforms grep in many use cases.
 
-```bash
+```sh
 rg <search-term> # searches recursively, ignoring .git, node_modules, etc
 ```
 
-```bash
+```sh
 rg 'function doStuff'
 ```
 
-```bash
+```sh
 rg 'doStuff\(.*\)'
 ```
 
@@ -30,7 +30,7 @@ rg 'doStuff\(.*\)'
 
 Use `-v` to filter out all matches so that only non-matches are left.
 
-```bash
+```sh
 rg 'bar' | rg -v 'foobar'
 ```
 
@@ -41,6 +41,6 @@ ignores many types of hidden files, dot files, etc.
 
 You can use `-uu` to set all of the `--no-ignore-*` options and others.
 
-```bash
+```sh
 rg -uu 'SECRET='
 ```

--- a/rustlang/README.md
+++ b/rustlang/README.md
@@ -7,7 +7,7 @@ tagline: |
 
 ## Updating rustlang
 
-```bash
+```sh
 rustup update
 ```
 
@@ -27,17 +27,17 @@ You can `rustup use x.y.z` for a specific version or toolchain.
 
 ### Install rust from rust.rs
 
-```bash
+```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 ### Hello World
 
-```bash
+```sh
 cargo install ripgrep
 ```
 
-```bash
+```sh
 cargo new hello --bin
 pushd ./hello/
 cargo build --release

--- a/sass/README.md
+++ b/sass/README.md
@@ -14,13 +14,13 @@ To update or switch versions, run `webi sass@stable` (or `@v2`, `@beta`, etc).
 
 ### Command format:
 
-```bash
+```sh
 sass <input.scss> [output.css]
 ```
 
 or
 
-```bash
+```sh
 sass <input.scss>:<output.css> <input/>:<output/> <dir/>
 ```
 

--- a/sclient/README.md
+++ b/sclient/README.md
@@ -17,13 +17,13 @@ To update or switch versions, run `webi sclient@stable`.
 
 You can _literally_ use this on example.com:
 
-```bash
+```sh
 sclient example.com:443 localhost:3000
 ```
 
 To use it with an http client, just set the Host header to the original domain:
 
-```bash
+```sh
 curl -H "Host: example.com" http://localhost:3000
 ```
 
@@ -44,7 +44,7 @@ curl -H "Host: example.com" http://localhost:3000
 
 SSH can be tunneled within HTTPS, TLS, SSL, WebSockets, etc.
 
-```bash
+```sh
 ssh -o ProxyCommand="sclient %h" jon.telebit.io
 ```
 
@@ -54,21 +54,21 @@ ssh connections through a single host.
 
 ### How to unwrap TLS for Telnet (HTTP/HTTPS)
 
-```bash
+```sh
 sclient example.com:443 localhost:3000
 ```
 
-```bash
+```sh
 telnet localhost 3000
 ```
 
 ### How to unwrap TLS for SMTP/SMTPS/STARTTLS
 
-```bash
+```sh
 sclient smtp.gmail.com:465 localhost:2525
 ```
 
-```bash
+```sh
 telnet localhost 2525
 
 Trying 127.0.0.1...
@@ -79,7 +79,7 @@ Escape character is '^]'.
 
 ### How to use with stdin / stdout
 
-```bash
+```sh
 sclient whatever.com -
 ```
 
@@ -94,7 +94,7 @@ Use just like netcat or telnet. A manual HTTP request, for example:
 
 ### How to pipe connections
 
-```bash
+```sh
 printf "GET / HTTP/1.1\r\nHost: telebit.cloud\r\n\r\n" | sclient telebit.cloud
 ```
 
@@ -106,14 +106,14 @@ attacks, such as Domain Fronting.
 The literal domains `example.net` and `example.com` are _actually_ vulnerable to
 SNI spoofing:
 
-```bash
+```sh
 sclient --servername example.net example.com:443 localhost:3000
 curl -H "example.com" http://localhost:3000
 ```
 
 Most domains, however, are not:
 
-```bash
+```sh
 sclient --servername google.net google.com:443 localhost:3000
 curl -H "google.com" http://localhost:3000
 ```

--- a/sd/README.md
+++ b/sd/README.md
@@ -17,20 +17,20 @@ To update or switch versions, run `webi sd@stable` (or `@v0.7`, `@beta`, etc).
 
 ### Replacing Text in a File
 
-```bash
+```sh
 sd 'original word' 'final word' ./file_to_be_changed
 ```
 
 ### Taking out word inside slashes from a given string
 
-```bash
+```sh
 echo "string output shown /word inside slashes/" | sd '.*(/.*/)' '$1'
   /word inside slashes/
 ```
 
 ### Using the string mode (-s)
 
-```bash
+```sh
  cat exm.txt
   here is an @example
 

--- a/serviceman/README.md
+++ b/serviceman/README.md
@@ -27,7 +27,7 @@ add the `--dryrun` option.
 
 ### Example: Bash
 
-```bash
+```sh
 sudo env PATH="$PATH" serviceman add bash ./backup.sh /mnt/data
 ```
 
@@ -35,7 +35,7 @@ sudo env PATH="$PATH" serviceman add bash ./backup.sh /mnt/data
 
 **Development Server**
 
-```bash
+```sh
 pushd ./my-node-app/
 
 sudo env PATH="$PATH" \
@@ -45,7 +45,7 @@ sudo env PATH="$PATH" \
 
 **Production Server**
 
-```bash
+```sh
 pushd ./my-node-app/
 
 sudo env PATH="$PATH" \
@@ -55,7 +55,7 @@ sudo env PATH="$PATH" \
 
 ### Example: Golang
 
-```bash
+```sh
 pushd ./my-go-package/
 
 sudo env PATH="$PATH" \
@@ -63,7 +63,7 @@ sudo env PATH="$PATH" \
     go run -mod=vendor cmd/my-service/*.go --port 3000
 ```
 
-```bash
+```sh
 pushd ./my-go-package/
 go build -mod=vendor cmd/my-service
 
@@ -74,7 +74,7 @@ sudo env PATH="$PATH" \
 
 ### How to see all services
 
-```bash
+```sh
 serviceman list --system
 serviceman list --user
 ```
@@ -90,7 +90,7 @@ serviceman-managed services:
 You can either `add` the service again (which will update any changed options),
 or you can `stop` and then `start` any service by its name:
 
-```bash
+```sh
 sudo env PATH="$PATH" serviceman stop example-service
 sudo env PATH="$PATH" serviceman start example-service
 ```
@@ -158,7 +158,7 @@ WantedBy=multi-user.target
 
 ### Use `--dryrun` to see the generated launcher config:
 
-```bash
+```sh
 sudo env PATH="$PATH" \
     serviceman add --system --dryrun \
     bash ./backup.sh /mnt/data
@@ -168,12 +168,12 @@ sudo env PATH="$PATH" \
 
 The main help, showing all subcommands:
 
-```bash
+```sh
 serviceman --help
 ```
 
 Sub-command specific help:
 
-```bash
+```sh
 serviceman add --help
 ```

--- a/setcap-netbind/README.md
+++ b/setcap-netbind/README.md
@@ -37,11 +37,11 @@ command.
 
 These two commands are equivalent:
 
-```bash
+```sh
 sudo setcap-netbind node
 ```
 
-```bash
+```sh
 sudo setcap 'cap_net_bind_service=+ep' "$(readlink -f "$(command -v node)")"
 ```
 

--- a/shellcheck/README.md
+++ b/shellcheck/README.md
@@ -17,7 +17,7 @@ Also recommended by Google's
 
 ### How to run shellcheck from the CLI
 
-```bash
+```sh
 shellcheck ./script.sh
 ```
 
@@ -50,11 +50,11 @@ check-scripts:
 You can ignore an error by putting a comment with the `SCXXXX` error code above
 it:
 
-```bash
+```sh
 # shellcheck disable=<code>
 ```
 
-```bash
+```sh
 # shellcheck disable=SC1004
 NOT_AN_ERROR='Look, a literal \
 inside of a string!'

--- a/shfmt/README.md
+++ b/shfmt/README.md
@@ -43,13 +43,13 @@ used.
 
 To list files being formatted and write directly to file
 
-```bash
+```sh
 shfmt -l -w <filepath>
 ```
 
 To show differences between shfmt formatting and original file formatting
 
-```bash
+```sh
 shfmt -d <filepath>
 ```
 

--- a/ssh-adduser/README.md
+++ b/ssh-adduser/README.md
@@ -22,7 +22,7 @@ linux: true
 
 How to create a new user named 'app':
 
-```bash
+```sh
 # --disable-password prevents a password prompt
 # --gecos "" skips the useless questions
 adduser --disabled-password --gecos "" app
@@ -30,7 +30,7 @@ adduser --disabled-password --gecos "" app
 
 How to create a and set a random password:
 
-```bash
+```sh
 # sets 'my_password' to 32 random hex characters (16 bytes)
 my_password=$(openssl rand -hex 16)
 
@@ -40,19 +40,19 @@ printf "$my_password"'\n'"$my_password" | passwd app
 
 How to make the user 'app' a "sudo"er (an admin):
 
-```bash
+```sh
 adduser app sudo
 ```
 
 How to allow 'app' to run sudo commands without a password:
 
-```bash
+```sh
 echo "app ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/app
 ```
 
 How to copy allowed keys from root to the new user:
 
-```bash
+```sh
 mkdir -p /home/app/.ssh/
 chmod 0700 /home/app/.ssh/
 

--- a/ssh-pubkey/README.md
+++ b/ssh-pubkey/README.md
@@ -19,7 +19,7 @@ tagline: |
 
 The easiest way to get your SSH Public Key:
 
-```bash
+```sh
 curl https://webinstall.dev/ssh-pubkey | bash
 ```
 
@@ -31,13 +31,13 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTOhRnzDJNBNBXVCgkxkEaDM4IAp81MtE8fuqeQuFv
 
 The standard location for your SSH Public Key:
 
-```bash
+```sh
 ~/.ssh/id_rsa.pub
 ```
 
 How to create an SSH Keypair if it doesn't already exist:
 
-```bash
+```sh
 if [ -f "$HOME/.ssh/id_rsa" ];then
     ssh-keygen -b 2048 -t rsa -f "$HOME/.ssh/id_rsa" -q -N ""
 fi
@@ -46,13 +46,13 @@ fi
 How to copy your SSH Public Key to from its hidden folder to your `Downloads`
 folder:
 
-```bash
+```sh
 rsync -av "$HOME/.ssh/id_rsa.pub" \
     "$HOME/Downloads/id_rsa.$(whoami).pub"
 ```
 
 How to print your public key to the Terminal:
 
-```bash
+```sh
 cat "$HOME/Downloads/id_rsa.pub"
 ```

--- a/ssh-setpass/README.md
+++ b/ssh-setpass/README.md
@@ -11,6 +11,6 @@ linux: true
 > `ssh-setpass` will ask you for your old passphrase and then for the new one to
 > reset it with.
 
-```bash
+```sh
 ssh-setpass
 ```

--- a/ssh-utils/README.md
+++ b/ssh-utils/README.md
@@ -15,7 +15,7 @@ tagline: |
 `ssh-pubkey` will make sure you have an SSH key, and then print it to the screen
 and place it in `~/Downloads`.
 
-```bash
+```sh
 ssh-pubkey
 ```
 

--- a/sudo/README.md
+++ b/sudo/README.md
@@ -13,7 +13,7 @@ tagline: |
 
 ### Example: Enabling WSL
 
-```bash
+```sh
 sudo.cmd dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart
 ```
 

--- a/syncthing/README.md
+++ b/syncthing/README.md
@@ -22,18 +22,18 @@ Files are updated about every 30 seconds.
 
 You can test that syncthing was installed correctly by checking it's version:
 
-```bash
+```sh
 syncthing --version
 ```
 
 If that works, you'll want to set your system launcher to run it on login. You
 can install and use [serviceman](/serviceman) to do this:
 
-```bash
+```sh
 webi serviceman
 ```
 
-```bash
+```sh
 mkdir -p ~/.config/syncthing/
 env PATH="$PATH" serviceman add --user --name syncthing -- \
   syncthing --home ~/.config/syncthing/
@@ -84,6 +84,6 @@ Otherwise, yes, forward both UDP and TCP ports 22000.
 It can be useful for debugging and testing configuration to run syncthing from
 your Terminal. Just run `syncthing` pointing to the config directory:
 
-```bash
+```sh
 syncthing --home ~/.config/syncthing/
 ```

--- a/vim-ale/README.md
+++ b/vim-ale/README.md
@@ -19,7 +19,7 @@ This installer includes a few reasonable defaults.
 
 ### How to install and configure manually
 
-```bash
+```sh
 mkdir -p ~/.vim/pack/plugins/start/
 git clone --depth=1 https://github.com/dense-analysis/ale.git ~/.vim/pack/plugins/start/ale
 ```

--- a/vim-go/README.md
+++ b/vim-go/README.md
@@ -18,7 +18,7 @@ You'll also need to install [`ALE`](https://webinstall.dev/vim-ale) (part of
 
 ### How to install by hand
 
-```bash
+```sh
 git clone --depth=1 https://github.com/fatih/vim-go.git ~/.vim/pack/plugins/start/vim-go
 ```
 
@@ -56,13 +56,13 @@ let g:go_highlight_build_constraints = 1
 
 via `vim` with `:GoInstallBinaries`:
 
-```bash
+```sh
 printf ':GoInstallBinaries\n:q\n' | vim -e
 ```
 
 via `bash`:
 
-```bash
+```sh
 # gopls
 go install golang.org/x/tools/gopls
 

--- a/vim-nerdtree/README.md
+++ b/vim-nerdtree/README.md
@@ -42,7 +42,7 @@ README:
 
 Place NerdTree into your `~/.vim/pack/plugins/start`:
 
-```bash
+```sh
 mkdir -p ~/.vim/pack/plugins/start/
 git clone --depth=1 https://github.com/preservim/nerdtree.git ~/.vim/pack/plugins/start/nerdtree
 ```

--- a/vim-prettier/README.md
+++ b/vim-prettier/README.md
@@ -18,7 +18,7 @@ You'll also need to install [`ALE`](https://webinstall.dev/vim-ale) (part of
 
 ### How to install by hand
 
-```bash
+```sh
 git clone --depth=1 https://github.com/prettier/vim-prettier ~/.vim/pack/plugins/start/vim-prettier
 ```
 
@@ -49,12 +49,12 @@ autocmd BufWritePre .babelrc,.eslintrc,.jshintrc,*.js,*.jsx,*.mjs,*.ts,*.tsx,*.c
 
 With `webi`:
 
-```bash
+```sh
 webi prettier
 ```
 
 With `node`:
 
-```bash
+```sh
 npm install -g prettier@2
 ```

--- a/vim-rust/README.md
+++ b/vim-rust/README.md
@@ -19,11 +19,11 @@ You'll also need to install [`ALE`](https://webinstall.dev/vim-ale) (part of
 ### How to install and configure by hand
 
 1. Remove the previous version of rust.vim, if any:
-   ```bash
+   ```sh
    rm -rf ~/.vim/pack/plugins/start/rust.vim
    ```
 2. Install `rust.vim` as a Vim8 package with `git`:
-   ```bash
+   ```sh
    mkdir -p ~/.vim/pack/plugins/start/
    git clone --depth=1 \
        https://github.com/rust-lang/rust.vim \

--- a/vim-sensible/README.md
+++ b/vim-sensible/README.md
@@ -7,7 +7,7 @@ tagline: |
 
 ## Updating `vim-sensible`
 
-```bash
+```sh
 webi vim-sensible
 ```
 

--- a/vim-shfmt/README.md
+++ b/vim-shfmt/README.md
@@ -37,7 +37,7 @@ let g:shfmt_fmt_on_save = 1
 
 1. Clone `vim-shfmt` into your `~/.vim/pack/plugins/start`:
 
-   ```bash
+   ```sh
    mkdir -p ~/.vim/pack/plugins/start/
    git clone --depth=1 https://github.com/CHANGEME/EXAMPLE.git ~/.vim/pack/plugins/start/shfmt
    ```

--- a/vim-syntastic/README.md
+++ b/vim-syntastic/README.md
@@ -7,7 +7,7 @@ tagline: |
 
 ## Updating `vim-syntastic`
 
-```bash
+```sh
 webi vim-syntastic
 ```
 
@@ -19,7 +19,7 @@ webi vim-syntastic
 
 ### How to install manually
 
-```bash
+```sh
 git clone --depth=1 https://github.com/vim-syntastic/syntastic.git ~/.vim/pack/plugins/start/vim-syntastic
 ```
 

--- a/vps-addswap/README.md
+++ b/vps-addswap/README.md
@@ -50,7 +50,7 @@ sequential processing tasks without causing your apps to be slow.
 Typically you should place swap files in `/var`, which is the volume that will
 be optimized for fast writes (on servers that do so).
 
-```bash
+```sh
 sudo fallocate -l 2G /var/swapfile
 sudo chmod 0600 /var/swapfile
 sudo mkswap /var/swapfile
@@ -62,7 +62,7 @@ actually write the file to its full size, and therefore will be instant.
 On an HDD (rotational drive), `dd` may be a better choice, as you need to
 allocate contiguous space all at once.
 
-```bash
+```sh
 sudo dd if=/dev/zero of=/var/swapfile bs=2G count=1
 ```
 
@@ -77,7 +77,7 @@ space in RAM/swap than as a file on disk.
 
 ### How to activate swap space?
 
-```bash
+```sh
 sudo swapon /var/swapfile
 ```
 

--- a/vps-utils/README.md
+++ b/vps-utils/README.md
@@ -16,13 +16,13 @@ tagline: |
 privileged ports, such as 80 (http) and 443 (https) without `root` privileges or
 `sudo`.
 
-```bash
+```sh
 sudo setcap-netbind node
 ```
 
 This is the same as running the full command:
 
-```bash
+```sh
 setcap 'cap_net_bind_service=+ep' $(readlink -f $(which node))
 ```
 
@@ -31,7 +31,7 @@ setcap 'cap_net_bind_service=+ep' $(readlink -f $(which node))
 Will output externally detected IPv4 and IPv6 addresses. See
 <https://webinstall.dev/vps-myip>.
 
-```bash
+```sh
 myip
 ```
 
@@ -45,6 +45,6 @@ IPv6 (AAAA): 2605:a601:a919:9800:f8be:f2c4:9ad7:9763
 Adds and activates permanent swap in `/var/swapfile`. See
 <https://webinstall.dev/vps-addswap>.
 
-```bash
+```sh
 vps-addswap
 ```

--- a/watchexec/README.md
+++ b/watchexec/README.md
@@ -38,7 +38,7 @@ Here's the shortlist of options we've found most useful:
 
 Example: List the directory when any files change.
 
-```bash
+```sh
 watchexec -c -- ls -lah
 ```
 
@@ -46,7 +46,7 @@ watchexec -c -- ls -lah
 
 Here's a "kitchen sink" example.
 
-```bash
+```sh
 watchexec -c -r -s SIGKILL -d 2000 -W --verbose \
     -w ./src -w ./server.js \
     -e js,css,html \
@@ -59,7 +59,7 @@ watchexec -c -r -s SIGKILL -d 2000 -W --verbose \
 These examples show how you might use this for builds, servers, and publishing
 or deploying.
 
-```bash
+```sh
 # Node / npm
 watchexec -W -- npm run build
 watchexec -r -- npm start

--- a/webi/README.md
+++ b/webi/README.md
@@ -7,7 +7,7 @@ tagline: |
 
 ## Updating `webi`
 
-```bash
+```sh
 webi webi
 ```
 
@@ -26,14 +26,14 @@ Since `webi` is just a small helper script, it always updates on each use.
 
 You can install _exactly_ what you need, from memory, via URL:
 
-```bash
+```sh
 curl https://webinstall.dev/node@lts | bash
 ```
 
 Or via `webi`, the tiny `curl | bash` shortcut command that comes with each
 install:
 
-```bash
+```sh
 webi node@lts golang@stable flutter@beta rustlang
 ```
 
@@ -41,13 +41,13 @@ webi node@lts golang@stable flutter@beta rustlang
 
 You can see exactly what PATHs have been edited:
 
-```bash
+```sh
 pathman list
 ```
 
 And where:
 
-```bash
+```sh
 cat ~/.config/envman/PATH.env
 ```
 
@@ -55,7 +55,7 @@ cat ~/.config/envman/PATH.env
 
 These are the files that are installed when you use [webinstall.dev](/):
 
-```bash
+```sh
 # Mac, Linux
 ~/.local/bin/webi
 ~/.local/bin/pathman
@@ -74,7 +74,7 @@ reinstalled.
 
 Additionally, these files may be modified to update your `PATH`:
 
-```bash
+```sh
 ~/.bashrc
 ~/.profile
 ~/.config/fish/config.fish
@@ -97,7 +97,7 @@ just check the Cheat Sheet for any special notes.
 
 Here are some examples:
 
-```bash
+```sh
 # Remove jq
 rm -rf ~/.local/bin/jq
 rm -rf ~/.local/jq-*/

--- a/xz/README.md
+++ b/xz/README.md
@@ -29,20 +29,20 @@ Here's the shortlist of options we've found most useful:
 
 ### How to "Unzip"
 
-```bash
+```sh
 unxz -k example.xz
 ```
 
-```bash
+```sh
 tar xvf example.tar.xz
 ```
 
 ### How to "Zip"
 
-```bash
+```sh
 xz -k ./example
 ```
 
-```bash
+```sh
 tar cvf example.tar.xz ./example
 ```

--- a/yq/README.md
+++ b/yq/README.md
@@ -17,13 +17,13 @@ Usage: `yq e '<selector>' <filepath>`
 
 Works with YAML:
 
-```bash
+```sh
 echo 'name: John' | yq  e '.name' -
 ```
 
 Works with JSON:
 
-```bash
+```sh
 echo '[ { "name": "John" }, { "name": "Jane" } ]' | yq e '.[].name' -
 ```
 

--- a/zig/README.md
+++ b/zig/README.md
@@ -56,14 +56,14 @@ Philosophy:
 You can use
 [Zig as a drop-in C compiler](https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html).
 
-```bash
+```sh
 zig cc -o ./hello main.c
 zig c++ -o ./hello++ main.cpp
 ```
 
 And you can cross-compile effortlessly:
 
-```bash
+```sh
 zig cc -o ./hello.exe main.c -target x86_64-windows-gnu
 zig c++ -o ./hello.exe main.cpp -target x86_64-windows-gnu
 ```
@@ -71,16 +71,16 @@ zig c++ -o ./hello.exe main.cpp -target x86_64-windows-gnu
 ### How to create and compile Zig programs
 
 1. Create a new project directory:
-   ```bash
+   ```sh
    mkdir -p ./zig-hello/
    pushd ./zig-hello/
    ```
 2. Initialize the project with a new `build.zig`
-   ```bash
+   ```sh
    zig init-exe
    ```
 3. Build `hello.exe` for Windows from MacOS or Linux
-   ```bash
+   ```sh
    zig build-exe src/main.zig --name hello -target x86_64-windows-gnu
    zig build-exe src/main.zig --name hello -target x86_64-linux-musl
    zig build-exe src/main.zig --name hello-arm -target aarch64-linux-musl
@@ -90,7 +90,7 @@ zig c++ -o ./hello.exe main.cpp -target x86_64-windows-gnu
 
 ### How to list and use Zig's cross-compile targets
 
-```bash
+```sh
 zig targets | jq -r '.libc[]'
 ```
 
@@ -111,7 +111,7 @@ x86_64-macos-gnu
 
 1. Create a `zig-cc-{ARCH-OS}` and `zig-cpp-{ARCH-OS}` wrappers:
 
-   ```bash
+   ```sh
    cat << EOF >> ~/.local/bin/zig-cc-x86_64-windows-gnu
    #!/bin/sh
    set -e
@@ -122,7 +122,7 @@ x86_64-macos-gnu
    chmod a+x ~/.local/bin/zig-cc
    ```
 
-   ```bash
+   ```sh
    cat << EOF >> ~/.local/bin/zig-cpp-x86_64-windows-gnu
    #!/bin/sh
    set -e
@@ -134,13 +134,13 @@ x86_64-macos-gnu
    ```
 
 2. Set the `CC`, `CPP` and `ZIGTARGET` ENVs. For example:
-   ```bash
+   ```sh
    #export ZIGTARGET="x86_64-windows-gnu"
    export CC="zig-cc-x86_64-windows-gnu"
    export CPP="zig-cpp-x86_64-windows-gnu"
    ```
 3. Install the correpsonding Rust toolchains:
-   ```bash
+   ```sh
    rustup target install x86_64-apple-darwin
    rustup target install x86_64-unknown-linux-musl
    rustup target install aarch64-unknown-linux-musl
@@ -149,7 +149,7 @@ x86_64-macos-gnu
 4. You may need to also specifically set the linker. For example, with Rust's
    `~/.cargo/config.toml`:
 
-   ```bash
+   ```sh
    [target.x86_64-apple-darwin]
    linker = "zig-cc-x86_64-macos-gnu"
 
@@ -165,7 +165,7 @@ x86_64-macos-gnu
 
 `~/.local/bin/zig-create-crossies`:
 
-```bash
+```sh
 #!/bin/bash
 set -e
 set -u


### PR DESCRIPTION
The replacement was done in all README.md files (main README.md and all subfiles in folders that contained '```bash') and in CONTRIBUTING.md.