### PR TITLE
hotfix(posix): double quote vars that require it

### DIFF
--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -407,7 +407,7 @@ __bootstrap_webi() {
 
     webi_path_add "$HOME/.local/bin"
     if [ -z "${_WEBI_CHILD:-}" ] && [ -f "$_webi_tmp/.PATH.env" ]; then
-        if [ -n $(cat "$_webi_tmp/.PATH.env") ]; then
+        if [ -n "$(cat "$_webi_tmp/.PATH.env")" ]; then
             printf 'PATH.env updated with:\n'
             sort -u "$_webi_tmp/.PATH.env"
             printf "\n"


### PR DESCRIPTION
somehow this got left out or dropped from the commit that should have fixed it