### PR TITLE
remove vestigial calls and references to bash 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ You can do this **in about 30 seconds**:
 1. Run [`git-config-gpg`](https://webinstall.dev/git-config-gpg) from Webi:
    ```sh
    # On Mac & Linux
-   curl https://webinstall.dev/git-config-gpg | bash
+   curl https://webinstall.dev/git-config-gpg | sh
    ```
 2. Copy the GPG public key (it will be printed to your screen)
 3. Add it to your GitHub profile: <https://github.com/settings/gpg/new>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - in short: no nonsense
 
 ```sh
-curl https://webinstall.dev/webi | bash
+curl https://webinstall.dev/webi | sh
 ```
 
 This repository contains the primary and community-submitted packages for
@@ -42,9 +42,9 @@ More technically:
 4. `<package>/install.sh` may provide functions to override `_webi/template.sh`
 5. Recap:
    - `curl https://webinstall.dev/<pkg>` => `bootstrap-<pkg>.sh`
-   - `bash bootstrap-<pkg>.sh` =>
+   - `sh bootstrap-<pkg>.sh` =>
      `https://webinstall.dev/api/installers/<pkg>@<ver>.sh?formats=zip,tar`
-   - `bash install-<pkg>.sh` => download, unpack, move, link, update PATH
+   - `sh install-<pkg>.sh` => download, unpack, move, link, update PATH
 
 # Philosophy (for package authors / maintainers publishing with webi)
 
@@ -73,7 +73,7 @@ An install consists of 5 parts in 4 files:
 my-new-package/
   - README.md (package info in frontmatter)
   - releases.js
-  - install.sh (bash)
+  - install.sh (POSIX Shell)
   - install.ps1 (PowerShell)
 ```
 
@@ -88,7 +88,7 @@ See these **examples**:
 - https://github.com/webinstall/packages/blob/master/golang/
 
 The `webinstall.dev` server uses the list of releases returned by
-`<your-package>/releases.js` to generate a bash script with most necessary
+`<your-package>/releases.js` to generate a shell script with most necessary
 variables and functions pre-defined.
 
 You just fill in the blanks.
@@ -144,8 +144,8 @@ It looks like this:
 `releases.js`:
 
 ```js
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function(request) {
+  return github(request, owner, repo).then(function(all) {
     // if you need to do something special, you can do it here
     // ...
     return all;

--- a/_npm/README.md
+++ b/_npm/README.md
@@ -20,7 +20,7 @@ npm install -g webi
 Mac & Linux:
 
 ```sh
-curl -fsS https://webinstall.dev/node | bash
+curl -fsS https://webinstall.dev/node | sh
 ```
 
 Windows (includes `curl.exe` and PowerShell by default):

--- a/_npm/scripts/install-webi.js
+++ b/_npm/scripts/install-webi.js
@@ -22,7 +22,7 @@ if (/^win/i.test(os.platform())) {
 }
 
 exec(
-  'curl -fsS https://webinstall.dev/webi | bash',
+  'curl -fsS https://webinstall.dev/webi | sh',
   function (err, stdout, stderr) {
     if (err) {
       console.error(err);

--- a/_webi/bootstrap.sh
+++ b/_webi/bootstrap.sh
@@ -118,7 +118,7 @@ __webi_main() {
 
         (
             cd "\$WEBI_BOOT" 2>&1 > /dev/null
-            bash "\$my_package-bootstrap.sh"
+            sh "\$my_package-bootstrap.sh"
         )
 
         rm -rf "\$WEBI_BOOT"

--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-# shellcheck disable=2001
-# because I prefer to use sed rather than bash replace
-# (there's too little space in my head to learn both syntaxes)
-
 __bootstrap_webi() {
 
     set -e
@@ -259,7 +255,7 @@ __bootstrap_webi() {
 
         # in case pathman was recently installed and the PATH not updated
         mkdir -p "$_webi_tmp"
-        # 'true' to prevent "too few arguments" output on bash
+        # 'true' to prevent "too few arguments" output
         # when there are 0 lines of stdout
         "$HOME/.local/bin/pathman" add "$1" |
             grep "export" 2> /dev/null \

--- a/_webi/test.js
+++ b/_webi/test.js
@@ -131,7 +131,7 @@ Releases.get(path.join(process.cwd(), pkgdir)).then(function (all) {
     console.info('Do the scripts actually work?');
     if (bashFile && bashTxt) {
       fs.writeFileSync(bashFile, bashTxt, 'utf-8');
-      console.info('\tNEEDS MANUAL TEST: bash %s', bashFile);
+      console.info('\tNEEDS MANUAL TEST: sh %s', bashFile);
     }
     if (ps1File && ps1Txt) {
       fs.writeFileSync(ps1File, ps1Txt, 'utf-8');

--- a/archiver/install.sh
+++ b/archiver/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_arc() {
     echo "'archiver@${WEBI_TAG:-stable}' is an alias for 'arc@${WEBI_VERSION:-}'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/arc@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/arc@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_arc

--- a/fish/README.md
+++ b/fish/README.md
@@ -80,26 +80,26 @@ First, `fish` must be installed and in the `PATH`.
 
 ```sh
 # if you don't see a file path as output, fish is not in the path
-which fish
+command -v fish
 ```
 
 Second, fish must be in the system-approved list of shells in `/etc/shells`:
 
 ```sh
-#!/bin/bash
+#!/bin/sh
 
-if ! grep $(which fish) /etc/shells > /dev/null; then
-    sudo bash -c "echo '$(which fish)' >> /etc/shells";
-    echo "added '$(which fish)' to /etc/shells"
+if ! grep $(command -v fish) /etc/shells > /dev/null; then
+    sudo sh -c "echo '$(command -v fish)' >> /etc/shells";
+    echo "added '$(command -v fish)' to /etc/shells"
 fi
 ```
 
 You should use `chsh` to change your shell:
 
 ```sh
-#!/bin/bash
+#!/bin/sh
 
-sudo chsh -s "$(which fish)" "$(whoami)"
+sudo chsh -s "$(command -v fish)" "$(whoami)"
 ```
 
 If vim uses `fish` instead of `bash`, annoying errors will happen.
@@ -116,7 +116,7 @@ You can also set is as the default for a particular Terminal, or for your user.
 Find out where `fish` is:
 
 ```sh
-which fish
+command -v fish
 ```
 
 Then update the Terminal preferences:
@@ -131,7 +131,7 @@ Terminal > Preferences > General > Shells open with:
 Or, you can quit Terminal and change the preferences from the command line:
 
 ```sh
-#!/bin/bash
+#!/bin/sh
 
 defaults write com.apple.Terminal "Shell" -string "$HOME/.local/bin/fish"
 ```
@@ -141,7 +141,7 @@ defaults write com.apple.Terminal "Shell" -string "$HOME/.local/bin/fish"
 Find out where `fish` is:
 
 ```sh
-which fish
+command -v fish
 ```
 
 Then update iTerm2 preferences:
@@ -156,7 +156,7 @@ Custom Shell: /Users/YOUR_USER/.local/bin/fish
 Or, you can quit iTerm2 and change the preferences from the command line:
 
 ```sh
-#!/bin/bash
+#!/bin/sh
 
 /usr/libexec/PlistBuddy -c "SET ':New Bookmarks:0:Custom Command' 'Custom Shell'" \
     ~/Library/Preferences/com.googlecode.iterm2.plist
@@ -194,7 +194,7 @@ shell:
 If you don't yet have an alacritty config, this will do:
 
 ```sh
-#!/bin/bash
+#!/bin/sh
 
 mkdir -p ~/.config/alacritty
 

--- a/git-config-gpg/README.md
+++ b/git-config-gpg/README.md
@@ -110,7 +110,7 @@ Run [gpg-pubkey-id](./gpg-pubkey) to get your GnuPG Public Key ID and then
 update your `~/.gitconfig` to sign with it by default:
 
 ```sh
-#!/bin/bash
+#!/bin/sh
 
 MY_KEY_ID="$(
   gpg-pubkey-id

--- a/git-gpg-init/install.sh
+++ b/git-gpg-init/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_git_config_gpg() {
     echo "'git-gpg-init' is a deprecated alias for 'git-config-gpg'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/git-config-gpg" | bash
+    curl -fsSL "$WEBI_HOST/git-config-gpg" | sh
 }
 
 __redirect_alias_git_config_gpg

--- a/gnupg/install.sh
+++ b/gnupg/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_gpg() {
     echo "'gnupg@${WEBI_TAG:-stable}' is an alias for 'gpg@${WEBI_VERSION:-}'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/gpg@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/gpg@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_gpg

--- a/go/install.sh
+++ b/go/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_golang() {
     echo "'go@${WEBI_TAG:-stable}' is an alias for 'golang@${WEBI_VERSION:-}'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/golang@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/golang@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_golang

--- a/goreleaser/README.md
+++ b/goreleaser/README.md
@@ -210,7 +210,7 @@ From macOS you can easily cross-compile cgo for Windows and Linux.
 Install [brew](https://webinstall.dev/brew), if needed:
 
 ```sh
-curl -sS https://webinstall.dev/brew | bash
+curl -sS https://webinstall.dev/brew | sh
 ```
 
 Install mingw and musl-cross: \

--- a/gpg-pubkey/README.md
+++ b/gpg-pubkey/README.md
@@ -22,7 +22,7 @@ This installs two commands.
 The easiest way to get your GnuPG Public Key:
 
 ```sh
-curl https://webinstall.dev/gpg-pubkey | bash
+curl https://webinstall.dev/gpg-pubkey | sh
 ```
 
 This is what the output of `gpg-pubkey` looks like (except much longer):
@@ -70,7 +70,7 @@ Run `gpg-pubkey-id` to get your GnuPG Public Key ID and then update your
 `~/.gitconfig` to sign with it by default:
 
 ```sh
-#!/bin/bash
+#!/bin/sh
 
 MY_KEY_ID="$(
   gpg-pubkey-id
@@ -107,7 +107,7 @@ Here's a command to list your secret key(s) and get the Public ID (of the first
 one, if you have many):
 
 ```sh
-#!/bin/bash
+#!/bin/sh
 
 MY_KEY_ID="$(
     gpg --list-secret-keys --keyid-format LONG |
@@ -188,7 +188,7 @@ Here's how you can automate creating a key using the same info as what's in your
 `~/.gitconfig`:
 
 ```sh
-#!/bin/bash
+#!/bin/sh
 
 MY_NAME="$( git config --global user.name )"
 MY_HOST="$( hostname )"

--- a/iterm-color-schemes/install.sh
+++ b/iterm-color-schemes/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_iterm2_themes() {
     echo "'iterm-color-schemes@${WEBI_TAG:-stable}' is an alias for 'iterm2-themes@${WEBI_VERSION:-}'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/iterm2-themes@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/iterm2-themes@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_iterm2_themes

--- a/iterm-themes/install.sh
+++ b/iterm-themes/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_iterm2_themes() {
     echo "'iterm-themes@${WEBI_TAG:-stable}' is an alias for 'iterm2-themes@${WEBI_VERSION:-}'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/iterm2-themes@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/iterm2-themes@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_iterm2_themes

--- a/iterm-utils/install.sh
+++ b/iterm-utils/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_iterm2_utils() {
     echo "'iterm-utils@${WEBI_TAG:-stable}' is an alias for 'iterm2-utils@${WEBI_VERSION:-}'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/iterm2-utils@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/iterm2-utils@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_iterm2_utils

--- a/iterm/install.sh
+++ b/iterm/install.sh
@@ -4,4 +4,4 @@ set -u
 
 echo "'iterm@${WEBI_TAG:-stable}' is an alias for 'iterm2@${WEBI_VERSION:-}'"
 WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-curl -fsSL "$WEBI_HOST/iterm2@${WEBI_VERSION:-}" | bash
+curl -fsSL "$WEBI_HOST/iterm2@${WEBI_VERSION:-}" | sh

--- a/iterm2-color-schemes/install.sh
+++ b/iterm2-color-schemes/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_iterm2_themes() {
     echo "'iterm2-color-schemes@${WEBI_TAG:-stable}' is an alias for 'iterm2-themes@${WEBI_VERSION:-}'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/iterm2-themes@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/iterm2-themes@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_iterm2_themes

--- a/koji/README.md
+++ b/koji/README.md
@@ -58,7 +58,7 @@ Just add `koji --hook` to your project's `.git/hooks/prepare-commit-msg`:
 
 ```sh
 echo >> ./.git/hooks/prepare-commit-msg << "EOF"
-#!/bin/bash
+#!/bin/sh
 koji --hook
 EOF
 
@@ -84,7 +84,7 @@ As a git hook:
 `.git/hooks/prepare-commit-msg`:
 
 ```sh
-#!/bin/bash
+#!/bin/sh
 koji --emoji --hook
 ```
 

--- a/nerd-font/install.sh
+++ b/nerd-font/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_nerdfont() {
     echo "'nerd-font' is an alias for 'nerdfont'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/nerdfont@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/nerdfont@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_nerdfont

--- a/postgresql/install.sh
+++ b/postgresql/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_postgres() {
     echo "'postgresql' is an alias for 'postgres'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/postgres@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/postgres@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_postgres

--- a/pwsh/install.sh
+++ b/pwsh/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_powershell() {
     echo "'pwsh@${WEBI_TAG:-stable}' is an alias for 'powershell@${WEBI_VERSION:-}'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/powershell@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/powershell@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_powershell

--- a/python3/install.sh
+++ b/python3/install.sh
@@ -6,7 +6,7 @@ set -u
 __redirect_alias_python() {
     echo "'python@${WEBI_TAG:-stable}' is an alias for 'python@${WEBI_VERSION:-}'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/python@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/python@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_python

--- a/ripgrep/install.sh
+++ b/ripgrep/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_rg() {
     echo "'ripgrep@${WEBI_TAG:-}' (project) is an alias for 'rg@${WEBI_VERSION:-}' (command)"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/rg@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/rg@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_rg

--- a/rust/install.sh
+++ b/rust/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_rustlang() {
     echo "'rust' is an alias for 'rustlang'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/rustlang@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/rustlang@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_rustlang

--- a/ssh-adduser/ssh-adduser.sh
+++ b/ssh-adduser/ssh-adduser.sh
@@ -21,7 +21,7 @@ main() {
         echo "    You must add a key to ~/.ssh/authorized_keys before adding a new ssh user."
         echo ""
         echo "To fix:"
-        echo "    Run 'curl https://webinstall.dev/ssh-pubkey | bash' on your local system, "
+        echo "    Run 'curl https://webinstall.dev/ssh-pubkey | sh' on your local system, "
         echo "    then add that key to ~/.ssh/authorized_keys on this (the remote) system.  "
         echo ""
         exit 1
@@ -45,13 +45,13 @@ main() {
     chown -R "$my_new_user":"$my_new_user" "/home/$my_new_user/.ssh/"
 
     # ensure that 'app' has an SSH Keypair
-    sudo -i -u "$my_new_user" bash -c "ssh-keygen -b 2048 -t rsa -f '/home/$my_new_user/.ssh/id_rsa' -q -N ''"
+    sudo -i -u "$my_new_user" sh -c "ssh-keygen -b 2048 -t rsa -f '/home/$my_new_user/.ssh/id_rsa' -q -N ''"
     chown -R "$my_new_user":"$my_new_user" "/home/$my_new_user/.ssh/"
 
     # Install webi for the new 'app' user
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    sudo -i -u "$my_new_user" bash -c "curl -fsSL '$WEBI_HOST/webi' | bash" ||
-        sudo -i -u "$my_new_user" bash -c "wget -q -O - '$WEBI_HOST/webi' | bash"
+    sudo -i -u "$my_new_user" sh -c "curl -fsSL '$WEBI_HOST/webi' | sh" ||
+        sudo -i -u "$my_new_user" sh -c "wget -q -O - '$WEBI_HOST/webi' | sh"
 
     # TODO ensure that ssh-password login is off
     my_pass="$(grep 'PasswordAuthentication yes' /etc/ssh/sshd_config)"

--- a/ssh-pubkey/README.md
+++ b/ssh-pubkey/README.md
@@ -20,7 +20,7 @@ tagline: |
 The easiest way to get your SSH Public Key:
 
 ```sh
-curl https://webinstall.dev/ssh-pubkey | bash
+curl https://webinstall.dev/ssh-pubkey | sh
 ```
 
 ```txt

--- a/vim-go/README.md
+++ b/vim-go/README.md
@@ -60,7 +60,7 @@ via `vim` with `:GoInstallBinaries`:
 printf ':GoInstallBinaries\n:q\n' | vim -e
 ```
 
-via `bash`:
+via `sh`:
 
 ```sh
 # gopls

--- a/webi/README.md
+++ b/webi/README.md
@@ -27,10 +27,10 @@ Since `webi` is just a small helper script, it always updates on each use.
 You can install _exactly_ what you need, from memory, via URL:
 
 ```sh
-curl https://webinstall.dev/node@lts | bash
+curl https://webinstall.dev/node@lts | sh
 ```
 
-Or via `webi`, the tiny `curl | bash` shortcut command that comes with each
+Or via `webi`, the tiny `curl | sh` shortcut command that comes with each
 install:
 
 ```sh

--- a/ziglang/install.sh
+++ b/ziglang/install.sh
@@ -5,7 +5,7 @@ set -u
 __redirect_alias_zig() {
     echo "'ziglang@${WEBI_TAG:-stable}' is an alias for 'zig@${WEBI_VERSION:-}'"
     WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-    curl -fsSL "$WEBI_HOST/zig@${WEBI_VERSION:-}" | bash
+    curl -fsSL "$WEBI_HOST/zig@${WEBI_VERSION:-}" | sh
 }
 
 __redirect_alias_zig


### PR DESCRIPTION
- Update documentation
- Remove extraneous calls to bash where sh would suffice
  - ` | bash` => ` | sh`
  - `bash -c '...'` => `sh -c '...'`
  - `bash ./x.sh` => `sh ./x.sh`