### PR TITLE
docs: add new webi.sh and webi.ms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ You can do this **in about 30 seconds**:
 1. Run [`git-config-gpg`](https://webinstall.dev/git-config-gpg) from Webi:
    ```sh
    # On Mac & Linux
-   curl https://webinstall.dev/git-config-gpg | sh
+   curl https://webi.sh/git-config-gpg | sh
    ```
 2. Copy the GPG public key (it will be printed to your screen)
 3. Add it to your GitHub profile: <https://github.com/settings/gpg/new>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - in short: no nonsense
 
 ```sh
-curl https://webinstall.dev/webi | sh
+curl https://webi.sh/webi | sh
 ```
 
 This repository contains the primary and community-submitted packages for
@@ -41,7 +41,7 @@ More technically:
    - (re-)linking directories
 4. `<package>/install.sh` may provide functions to override `_webi/template.sh`
 5. Recap:
-   - `curl https://webinstall.dev/<pkg>` => `bootstrap-<pkg>.sh`
+   - `curl https://webi.sh/<pkg>` => `bootstrap-<pkg>.sh`
    - `sh bootstrap-<pkg>.sh` =>
      `https://webinstall.dev/api/installers/<pkg>@<ver>.sh?formats=zip,tar`
    - `sh install-<pkg>.sh` => download, unpack, move, link, update PATH
@@ -273,7 +273,7 @@ set WEBI_HOST=https://webinstall.dev
 Windows has curl too!?
 
 ```bat
-curl.exe -sL -A "MS" https://webinstall.dev/node | powershell
+curl.exe -sL https://webi.ms/node | powershell
 ```
 
 And it's easy enough to ignore the execution policy
@@ -286,11 +286,11 @@ And if we want something that looks as complicated as we expect Windows to be,
 historically, we have options:
 
 ```bat
-powershell "Invoke-Expression ( Invoke-WebRequest -UseBasicParsing https://webinstall.dev/node ).Contents"
+powershell "Invoke-Expression ( Invoke-WebRequest -UseBasicParsing https://webi.ms/node ).Contents"
 ```
 
 ```bat
-powershell ( Invoke-WebRequest -UseBasicParsing https://webinstall.dev/node ).Contents | powershell
+powershell ( Invoke-WebRequest -UseBasicParsing https://webi.ms/node ).Contents | powershell
 ```
 
 -->

--- a/_npm/README.md
+++ b/_npm/README.md
@@ -20,13 +20,13 @@ npm install -g webi
 Mac & Linux:
 
 ```sh
-curl -fsS https://webinstall.dev/node | sh
+curl -fsS https://webi.sh/node | sh
 ```
 
 Windows (includes `curl.exe` and PowerShell by default):
 
 ```sh
-curl.exe -fsSA "MS" https://webinstall.dev/node | powershell
+curl.exe -fsSA "MS" https://webi.ms/node | powershell
 ```
 
 ## Example: Switching node versions

--- a/_npm/scripts/install-webi.js
+++ b/_npm/scripts/install-webi.js
@@ -14,27 +14,22 @@ if (/^win/i.test(os.platform())) {
   console.warn("This npm installer doesn't work on windows yet.");
   console.warn('Copy and paste this into cmd.exe or PowerShell instead:');
   console.warn('');
-  console.warn(
-    "    curl.exe -fsSA 'MS' https://webinstall.dev/webi | powershell"
-  );
+  console.warn('    curl.exe -fsS https://webi.ms/webi | powershell');
   console.warn('');
   return;
 }
 
-exec(
-  'curl -fsS https://webinstall.dev/webi | sh',
-  function (err, stdout, stderr) {
-    if (err) {
-      console.error(err);
-    }
-    if (stdout) {
-      console.info(stdout);
-    }
-    if (stderr) {
-      console.error(stderr);
-    }
+exec('curl -fsS https://webi.sh/webi | sh', function(err, stdout, stderr) {
+  if (err) {
+    console.error(err);
   }
-);
+  if (stdout) {
+    console.info(stdout);
+  }
+  if (stderr) {
+    console.error(stderr);
+  }
+});
 /*
   .then(function () {
     // nada

--- a/_webi/bootstrap.ps1
+++ b/_webi/bootstrap.ps1
@@ -1,4 +1,9 @@
 # Download the latest webi, then install {{ exename }}
+# <pre>
+############################################################
+# <h1>Cheat Sheet at CHEATSHEET_URL</h1>
+# <meta http-equiv="refresh" content="3; URL='CHEATSHEET_URL'" />
+############################################################
 New-Item -Path "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
 New-Item -Path "$Env:USERPROFILE\.local\bin" -ItemType Directory -Force | out-null
 IF ($Env:WEBI_HOST -eq $null -or $Env:WEBI_HOST -eq "") { $Env:WEBI_HOST = "https://webinstall.dev" }

--- a/_webi/bootstrap.sh
+++ b/_webi/bootstrap.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+#<pre>
+
+############################################################
+# <h1>Cheat Sheet at CHEATSHEET_URL</h1>
+# <meta http-equiv="refresh" content="3; URL='CHEATSHEET_URL'" />
+############################################################
 
 #set -x
 

--- a/_webi/releases.js
+++ b/_webi/releases.js
@@ -60,6 +60,7 @@ Releases.renderBash = function (
           }
           return (
             tplTxt
+              .replace(/CHEATSHEET_URL/g, `${baseurl}/${pkg}`)
               .replace(/^\s*#?WEBI_PKG=.*/m, `WEBI_PKG='${webiPkg}'`)
               .replace(/^\s*#?WEBI_HOST=.*/m, `WEBI_HOST='${baseurl}'`)
               .replace(/^\s*#?WEBI_OS=.*/m, `WEBI_OS='${os}'`)

--- a/goreleaser/README.md
+++ b/goreleaser/README.md
@@ -210,7 +210,7 @@ From macOS you can easily cross-compile cgo for Windows and Linux.
 Install [brew](https://webinstall.dev/brew), if needed:
 
 ```sh
-curl -sS https://webinstall.dev/brew | sh
+curl -sS https://webi.sh/brew | sh
 ```
 
 Install mingw and musl-cross: \

--- a/gpg-pubkey/README.md
+++ b/gpg-pubkey/README.md
@@ -22,7 +22,7 @@ This installs two commands.
 The easiest way to get your GnuPG Public Key:
 
 ```sh
-curl https://webinstall.dev/gpg-pubkey | sh
+curl https://webi.sh/gpg-pubkey | sh
 ```
 
 This is what the output of `gpg-pubkey` looks like (except much longer):

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -17,7 +17,7 @@ For example, if you wanted to install Node.js with powershell and
 webinstall.dev, you can:
 
 ```cmd
-curl.exe -s -A "MS" https://webinstall.dev/node@lts | powershell
+curl.exe -s https://webi.ms/node@lts | powershell
 ```
 -->
 

--- a/pyenv/README.md
+++ b/pyenv/README.md
@@ -25,7 +25,7 @@ sudo apt update
 sudo apt install -y build-essential zlib1g-dev libssl-dev
 
 # recommended
-sudo apt install -y libreadline-dev libbz2-dev libsqlite3-dev
+sudo apt install -y libreadline-dev libbz2-dev libsqlite3-dev libffi-dev
 ```
 
 ## Cheat Sheet
@@ -40,23 +40,23 @@ pre-requisites above).
 Here's how you can check for the latest version:
 
 ```sh
-pyenv install --list | grep -v -- - | tail -n 1
-#>   3.9.1
+pyenv install --list | grep -E '^\s+[0-9.]+$' | tail -n 1
+#>   3.10.7
 ```
 
 And install it:
 
 ```sh
-pyenv install -v 3.9.1
-#> Installed Python-3.9.1 to ~/.pyenv/versions/3.9.1
+pyenv install -v 3.10.7
+#> Installed Python-3.10.7 to ~/.pyenv/versions/3.10.7
 ```
 
 And use it:
 
 ```sh
-pyenv global 3.9.1
+pyenv global 3.10.7
 python --version
-#> Python 3.9.1
+#> Python 3.10.7
 ```
 
 Revert back to your system python:
@@ -72,7 +72,7 @@ pyenv install --list
 ```
 
 ```txt
-  3.9.1
+  3.10.7
   activepython-3.6.0
   anaconda3-2020.11
   graalpython-20.3.0

--- a/python/install.sh
+++ b/python/install.sh
@@ -17,8 +17,7 @@ __init_python() {
 
     my_latest_python3="$(
         pyenv install --list |
-            grep -v -- - |
-            grep '3\.[0-9]\+\.[0-9]\+$' |
+            grep -E '^\s+3\.[0-9]+\.[0-9]+$' |
             tail -n 1 |
             cut -d' ' -f3
     )"

--- a/python2/install.sh
+++ b/python2/install.sh
@@ -17,8 +17,7 @@ __init_python2() {
 
     my_latest_python2="$(
         pyenv install --list |
-            grep -v -- - |
-            grep '2\.[0-9]\+\.[0-9]\+$' |
+            grep -E '^\s+2\.[0-9]+\.[0-9]+$' |
             tail -n 1 |
             cut -d' ' -f3
     )"

--- a/ssh-pubkey/README.md
+++ b/ssh-pubkey/README.md
@@ -20,7 +20,7 @@ tagline: |
 The easiest way to get your SSH Public Key:
 
 ```sh
-curl https://webinstall.dev/ssh-pubkey | sh
+curl https://webi.sh/ssh-pubkey | sh
 ```
 
 ```txt

--- a/webi/README.md
+++ b/webi/README.md
@@ -27,7 +27,7 @@ Since `webi` is just a small helper script, it always updates on each use.
 You can install _exactly_ what you need, from memory, via URL:
 
 ```sh
-curl https://webinstall.dev/node@lts | sh
+curl https://webi.sh/node@lts | sh
 ```
 
 Or via `webi`, the tiny `curl | sh` shortcut command that comes with each


### PR DESCRIPTION
We now have the domain `webi.sh` for Posix Scripts and `webi.ms` for Microsoft PowerShell.

This update various documentation to use the new domains.

This won't go live yet, but it's ready for approval.