### PR TITLE
ref!: remove 'shmatter' and update 'marked'

### DIFF
--- a/_webi/frontmarker.js
+++ b/_webi/frontmarker.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var fs = require('fs');
-var marked = require('marked');
+var marked = require('marked').marked;
 
 var frontmatter = '---';
 var keyValRe = /(\w+): (.*)/;
@@ -19,11 +19,11 @@ function parseYamlish(txt) {
   }
 
   function unblock() {
-    cfg[block] = marked(cfg[block]);
+    cfg[block] = marked.parse(cfg[block]);
     block = false;
   }
 
-  lines.some(function (line, i) {
+  lines.some(function(line, i) {
     if (frontmatter === line) {
       // end of frontmatter
       end = true;
@@ -68,9 +68,9 @@ function parseYamlish(txt) {
   });
 
   if (block) {
-    cfg[block] = marked(cfg[block]);
+    cfg[block] = marked.parse(cfg[block]);
   }
-  cfg.examples = marked(lines.slice(last).join('\n'));
+  cfg.examples = marked.parse(lines.slice(last).join('\n'));
 
   return cfg;
 }

--- a/_webi/packages.js
+++ b/_webi/packages.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var frontmarker = require('./frontmarker.js');
-var shmatter = require('shmatter');
 var fs = require('fs');
 var path = require('path');
 
@@ -40,7 +39,6 @@ pkgs.create = function (Pkgs, basepath) {
     });
   };
   Pkgs._get = function (node) {
-    var yash = path.join(basepath, node, 'package.yash');
     var curlbash = path.join(basepath, node, 'install.sh');
     var readme = path.join(basepath, node, 'README.md');
     var winstall = path.join(basepath, node, 'install.ps1');
@@ -57,30 +55,14 @@ pkgs.create = function (Pkgs, basepath) {
             console.error(e);
           }
         }),
-      fs.promises
-        .readFile(yash, 'utf-8')
-        .then(function (txt) {
-          return shmatter.parse(txt);
-        })
-        .catch(function (e) {
-          // no yash package description
-          yash = '';
-          if ('ENOENT' !== e.code && 'ENOTDIR' !== e.code) {
-            console.error("failed to parse '" + node + "/package.yash'");
-            console.error(e);
-          }
-          return fs.promises.readFile(curlbash, 'utf-8').then(function (txt) {
-            return shmatter.parse(txt);
-          });
-        })
-        .catch(function (e) {
-          // no *nix installer
-          curlbash = '';
-          if ('ENOENT' !== e.code && 'ENOTDIR' !== e.code) {
-            console.error("failed to parse '" + node + "/install.sh'");
-            console.error(e);
-          }
-        }),
+      fs.promises.access(curlbash).catch(function (e) {
+        // no *nix installer
+        curlbash = '';
+        if ('ENOENT' !== e.code && 'ENOTDIR' !== e.code) {
+          console.error("failed to parse '" + node + "/install.sh'");
+          console.error(e);
+        }
+      }),
       fs.promises.access(winstall).catch(function (e) {
         // no winstaller
         winstall = '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@webinstall/webi-installers",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,17 +15,9 @@
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "marked": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.0.tgz",
-      "integrity": "sha512-EkE7RW6KcXfMHy2PA7Jg0YJE1l8UPEZE8k45tylzmZM30/r1M1MUXWQfJlrSbsTeh7m/XTwHbWUENvAJZpp1YA=="
-    },
-    "shmatter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/shmatter/-/shmatter-1.0.1.tgz",
-      "integrity": "sha512-bBAvHI8640XcMDsShK2HOR8WOkF65hMprXr7Rsqb3z+26/5qna3jZfP7VZScItGoULUYyNeen9isD60KxtD2hQ==",
-      "requires": {
-        "marked": "^1.0.0"
-      }
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
+      "integrity": "sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,12 @@
     "type": "git",
     "url": "git+https://github.com/webinstall/webi-installers.git"
   },
-  "keywords": ["webinstall", "brew", "apt", "chocolately"],
+  "keywords": [
+    "webinstall",
+    "brew",
+    "apt",
+    "chocolately"
+  ],
   "author": "AJ ONeal <coolaj86@gmail.com> (https://coolaj86.com/)",
   "license": "MPL-2.0",
   "bugs": {
@@ -25,6 +30,6 @@
   "dependencies": {
     "@root/request": "^1.6.1",
     "dotenv": "^8.2.0",
-    "shmatter": "^1.0.1"
+    "marked": "^4.1.1"
   }
 }


### PR DESCRIPTION
This removes the dead frontmatter-in-bash (shmatter/yash) that we stopped using a while ago.

It also updates `marked` to v4 due to `npm audit` complaints about potential RegEx DoS. We're not affected (the cheat sheets are trusted and static), but it's a small change and eliminates the warning.