### PR TITLE
fix: better fallbacks for release info updates

### DIFF
--- a/_webi/releases.js
+++ b/_webi/releases.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
+var fs = require('node:fs');
+var path = require('node:path');
 var request = require('@root/request');
 var _normalize = require('../_webi/normalize.js');
 
@@ -9,22 +9,23 @@ var reInstallTpl = /\s*#?\s*{{ installer }}/;
 
 var Releases = module.exports;
 Releases.get = async function (pkgdir) {
-  var get;
+  let get;
   try {
     get = require(path.join(pkgdir, 'releases.js'));
   } catch (e) {
     throw new Error('no releases.js for', pkgdir.split(/[\/\\]+/).pop());
   }
-  return get(request).then(function (all) {
-    return _normalize(all);
-  });
+
+  let all = await get(request);
+
+  return _normalize(all);
 };
 
 function padScript(txt) {
   return txt.replace(/^/g, '        ');
 }
 
-Releases.renderBash = function (
+Releases.renderBash = async function (
   pkgdir,
   rel,
   { baseurl, pkg, tag, ver, os = '', arch = '', formats },
@@ -153,7 +154,7 @@ Releases.renderBash = function (
     });
 };
 
-Releases.renderBatch = function (
+Releases.renderBatch = async function (
   pkgdir,
   rel,
   { baseurl, pkg, tag, ver, os, arch, formats },
@@ -193,7 +194,7 @@ Releases.renderBatch = function (
     });
 };
 
-Releases.renderPowerShell = function (
+Releases.renderPowerShell = async function (
   pkgdir,
   rel,
   { baseurl, pkg, tag, ver, os, arch, formats },

--- a/_webi/serve-installer.js
+++ b/_webi/serve-installer.js
@@ -52,41 +52,41 @@ module.exports = async function serveInstaller(
   // TODO maybe move package/version/lts/channel detection into getReleases
   var myOs = uaDetect.os(ua);
   var myArch = uaDetect.arch(ua);
-  return packages.get(pkg).then(function (cfg) {
-    return getReleases({
-      pkg: cfg.alias || pkg,
-      ver,
-      os: myOs,
-      arch: myArch,
-      lts,
-      channel,
-      formats,
-      limit: 1,
-    }).then(function (rels) {
-      var rel = rels.releases[0];
-      var pkgdir = path.join(installersDir, pkg);
-      var opts = {
-        baseurl,
-        pkg: cfg.alias || pkg,
-        ver,
-        tag,
-        os: myOs,
-        arch: myArch,
-        lts,
-        channel,
-        formats,
-        limit: 1,
-      };
-      rel.oses = rels.oses;
-      rel.arches = rels.arches;
-      rel.formats = rels.formats;
-      if ('bat' === ext) {
-        return Releases.renderBatch(pkgdir, rel, opts);
-      } else if ('ps1' === ext) {
-        return Releases.renderPowerShell(pkgdir, rel, opts);
-      } else {
-        return Releases.renderBash(pkgdir, rel, opts);
-      }
-    });
+  let cfg = await packages.get(pkg);
+  let rels = await getReleases({
+    pkg: cfg.alias || pkg,
+    ver,
+    os: myOs,
+    arch: myArch,
+    lts,
+    channel,
+    formats,
+    limit: 1,
   });
+
+  var rel = rels.releases[0];
+  var pkgdir = path.join(installersDir, pkg);
+  var opts = {
+    baseurl,
+    pkg: cfg.alias || pkg,
+    ver,
+    tag,
+    os: myOs,
+    arch: myArch,
+    lts,
+    channel,
+    formats,
+    limit: 1,
+  };
+  rel.oses = rels.oses;
+  rel.arches = rels.arches;
+  rel.formats = rels.formats;
+
+  if ('bat' === ext) {
+    return Releases.renderBatch(pkgdir, rel, opts);
+  }
+  if ('ps1' === ext) {
+    return Releases.renderPowerShell(pkgdir, rel, opts);
+  }
+  return Releases.renderBash(pkgdir, rel, opts);
 };


### PR DESCRIPTION
Re: https://github.com/webinstall/webi-installers/issues/534

I want to get to process-level isolation, but looking over this I'm not convinced that that would do any better with just that change - something is going wrong with failed network requests.

This will do a better job at not hard failing.

There may have been a promise deadlock (those are difficult to mentally model, so I can't say for sure), but this removes the conditions that I thought were suspect.