### PR TITLE
hotfix: allow installers without releases

### DIFF
--- a/_webi/releases.js
+++ b/_webi/releases.js
@@ -13,7 +13,9 @@ Releases.get = async function (pkgdir) {
   try {
     get = require(path.join(pkgdir, 'releases.js'));
   } catch (e) {
-    throw new Error('no releases.js for', pkgdir.split(/[\/\\]+/).pop());
+    let err = new Error('no releases.js for', pkgdir.split(/[\/\\]+/).pop());
+    err.code = 'E_NO_RELEASE';
+    throw err;
   }
 
   let all = await get(request);

--- a/_webi/serve-installer.js
+++ b/_webi/serve-installer.js
@@ -11,14 +11,9 @@ var getReleases = require('./transform-releases.js');
 
 var installersDir = path.join(__dirname, '..');
 
-module.exports = async function serveInstaller(
-  baseurl,
-  ua,
-  pkg,
-  tag,
-  ext,
-  formats,
-) {
+serveInstaller.serveInstaller = serveInstaller;
+module.exports = serveInstaller;
+async function serveInstaller(baseurl, ua, pkg, tag, ext, formats) {
   // TODO put some of this in a middleware? or common function?
 
   var ver = tag.replace(/^v/, '');
@@ -89,4 +84,4 @@ module.exports = async function serveInstaller(
     return Releases.renderPowerShell(pkgdir, rel, opts);
   }
   return Releases.renderBash(pkgdir, rel, opts);
-};
+}


### PR DESCRIPTION
In the latest update - which thankfully _didn't_ restart production when it deployed - installers with no `releases.js` all failed to install.

This fixes that.