### PR TITLE
fix: replace 'uname -a' with 'uname -srm' for OS/Arch detection

### DIFF
--- a/_webi/bootstrap.sh
+++ b/_webi/bootstrap.sh
@@ -15,7 +15,7 @@ __install_webi() {
     export WEBI_HOST
 
     echo ""
-    printf "Thanks for using webi to install '\e[32m%s\e[0m' on '\e[31m%s/%s\e[0m'.\n" "${WEBI_PKG-}" "$(uname -s)" "$(uname -m)"
+    printf "Thanks for using webi to install '\e[32m%s\e[0m' on '\e[31m%s/%s\e[0m'.\n" "${WEBI_PKG-}" "$(uname -s)/$(uname -r)" "$(uname -m)"
     echo "Have a problem? Experience a bug? Please let us know:"
     echo "        https://github.com/webinstall/webi-installers/issues"
     echo ""
@@ -93,7 +93,7 @@ __webi_main() {
     set -e
 
     export WEBI_HOST="\${WEBI_HOST:-https://webinstall.dev}"
-    export WEBI_UA="\$(uname -a)"
+    export WEBI_UA="\$(uname -s)/\$(uname -r) \$(uname -m)/unknown"
 
 
     webinstall() {
@@ -220,7 +220,7 @@ EOF
         echo ""
         echo "Hmm... no WEBI_PKG was specified. This is probably an error in the script."
         echo ""
-        echo "Please open an issue with this information: Package '${WEBI_PKG-}' on '$(uname -s)/$(uname -m)'"
+        echo "Please open an issue with this information: Package '${WEBI_PKG-}' on '$(uname -s)/$(uname -r) $(uname -m)'"
         echo "    https://github.com/webinstall/packages/issues"
         echo ""
     fi

--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -30,7 +30,7 @@ __bootstrap_webi() {
     #PKG_OSES=
     #PKG_ARCHES=
     #PKG_FORMATS=
-    WEBI_UA="$(uname -a)"
+    WEBI_UA="$(uname -s)/$(uname -r) $(uname -m)/unknown"
     WEBI_PKG_DOWNLOAD=""
     WEBI_DOWNLOAD_DIR="${HOME}/Downloads"
     if command -v xdg-user-dir > /dev/null; then

--- a/_webi/ua-detect.js
+++ b/_webi/ua-detect.js
@@ -16,7 +16,7 @@ function getRequest(req) {
   }
 
   return {
-    unix: 'curl -fsSA "$(uname -a)" ' + url,
+    unix: 'curl -fsSA "$(uname -srm)" ' + url,
     windows: 'curl.exe -fsSA "MS $Env:PROCESSOR_ARCHITECTURE" ' + url,
     ua: ua,
     os: uaDetect.os(ua),

--- a/brew/install.sh
+++ b/brew/install.sh
@@ -7,7 +7,7 @@ _install_brew() {
     # Straight from https://brew.sh
     #/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
-    if uname -a | grep -q -i darwin; then
+    if [ "Darwin" = "$(uname -s)" ]; then
         needs_xcode="$(/usr/bin/xcode-select -p > /dev/null 2> /dev/null || echo "true")"
         if [ -n "${needs_xcode}" ]; then
             echo ""

--- a/fish/install.sh
+++ b/fish/install.sh
@@ -2,7 +2,7 @@
 set -e
 set -u
 
-if ! (uname -a | grep -i "darwin" > /dev/null); then
+if [ "Darwin" != "$(uname -s)" ]; then
     echo "No fish installer for Linux yet. Try this instead:"
     echo "    sudo apt install -y fish"
     exit 1

--- a/git/install.sh
+++ b/git/install.sh
@@ -5,7 +5,7 @@ set -u
 __init_git() {
 
     if [ -z "$(command -v git)" ]; then
-        if uname -a | grep -q -i darwin; then
+        if [ "Darwin" = "$(uname -s)" ]; then
             echo >&2 "Error: 'git' not found. You may have to re-install 'git' on Mac after every major update."
             echo >&2 "       for example, try: xcode-select --install"
             # sudo xcodebuild -license accept

--- a/gpg/install.sh
+++ b/gpg/install.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 
 _install_gpg() {
-    if ! (uname -a | grep -i "darwin" > /dev/null); then
+    if [ "Darwin" != "$(uname -s)" ]; then
         echo "No gpg installer for Linux yet. Try this instead:"
         echo "    sudo apt install -y gpg gnupg"
         exit 1


### PR DESCRIPTION
fixes #561, and possibly an old issue with 32-bit vs 64-bit OS on 64-bit Raspberry Pi - we hope :)

## In Theory

| Flag | Meaning | Example |
| ----- | --------------- | -------------------- |
| `-s` | `operating system implementation` | `Darwin` |
| `-r` | `operating system release level` | `22.2.0` <br> (i.e. of Darwin) |
| `-v` | `operating system release version` | `#89-Ubuntu SMP PREEMPT Mon Dec 5 08:38:35 UTC 2022` |
| `-m` | `machine platform` | `arm64` |
| `-p` | *non-standard* <br> `machine processor architecture` | `arm` |

## In Practice

```sh
uname -srm
```

```text
# Mac
Darwin 22.2.0 arm64

# Linux
Linux 5.15.0-50-generic x86_64

# Raspberry Pi (64-bit OS on aarch64)
Linux 5.4.0-1078-raspi aarch64

# Raspberry Pi (32-bit OS on aarch64)
Linux 5.15.32-v7l+ armv7l
```

```sh
uname -v
```

```text
# Mac
Darwin Kernel Version 22.2.0: Fri Nov 11 02:03:51 PST 2022; root:xnu-8792.61.2~4/RELEASE_ARM64_T6000

# Linux
#89-Ubuntu SMP PREEMPT Mon Dec 5 08:38:35 UTC 2022

# Raspberry Pi (64-bit OS on aarch64)
#89-Ubuntu SMP PREEMPT Mon Dec 5 08:38:35 UTC 2022

# Raspberry Pi (32-bit OS on aarch64)
#1538 SMP Thu Mar 31 19:39:41 BST 2022 
```

```sh
uname -srmp
```

```text
# Mac
Darwin 22.2.0 arm64 arm

# Linux
Linux 5.15.0-50-generic x86_64 x86_64

# Raspberry Pi (64-bit OS on aarch64)
Linux 5.4.0-1078-raspi aarch64 aarch64

# Raspberry Pi (32-bit OS on aarch64)
Linux 5.15.32-v7l+ armv7l unknown
```

## Caveat: We need the LIES!

If we _really_ wanted to know the _truth_ on a raspberry pi, we could use `getconf LONG_BIT`.

```sh
getconf LONG_BIT
```

```text
64
```

However, what actually matters is not the _real_ CPU, but the CPU that the OS was built for.