### PR TITLE
hotfix: another fix for github releases error responses

### DIFF
--- a/_common/github.js
+++ b/_common/github.js
@@ -38,8 +38,14 @@ async function getAllReleases(
   }
 
   let resp = await request(req);
-  const gHubResp = resp.body;
-  const all = {
+  if (!resp.ok) {
+    console.error('Bad Resp Headers:', resp.headers);
+    console.error('Bad Resp Body:', resp.body);
+    throw new Error('the elusive releases BOOGEYMAN strikes again');
+  }
+
+  let gHubResp = resp.body;
+  let all = {
     releases: [],
     // todo make this ':baseurl' + ':releasename'
     download: '',
@@ -49,8 +55,8 @@ async function getAllReleases(
     gHubResp.forEach(transformReleases);
   } catch (e) {
     console.error(e.message);
-    console.error('Headers:', resp.headers);
-    console.error('Body:', resp.body);
+    console.error('Error Headers:', resp.headers);
+    console.error('Error Body:', resp.body);
     throw e;
   }
 

--- a/_webi/transform-releases.js
+++ b/_webi/transform-releases.js
@@ -3,8 +3,10 @@
 var path = require('path');
 var Releases = require('./releases.js');
 var cache = {};
-var staleAge = 5 * 1000;
-var expiredAge = 15 * 1000;
+//var staleAge = 5 * 1000;
+//var expiredAge = 15 * 1000;
+var staleAge = 5 * 60 * 1000;
+var expiredAge = 15 * 60 * 1000;
 
 let installerDir = path.join(__dirname, '..');
 


### PR DESCRIPTION
- fixed `staleAge = 5 * 60 * 1000` (had left out the 60 for local debug last time)
- always respond when usable data is available
- light readability update around fresh/stale/expired cache times