### PR TITLE
hotfix: fix iTerm2.app install location and pgAdmin 4.app

### DIFF
--- a/iterm2/README.md
+++ b/iterm2/README.md
@@ -5,6 +5,17 @@ tagline: |
   iTerm2: a terminal emulator for macOS that does amazing things.
 ---
 
+To update versions, use iTerm2's built-in software update.
+
+### Files
+
+These are the files / directories that are created and/or modified with this
+install:
+
+```text
+/Applications/iTerm.app/
+```
+
 ## Cheat Sheet
 
 > The only bad thing about iTerm2 is that it's so seamless and intuitive that
@@ -22,7 +33,7 @@ iTerm2 supports a lot of nifty features, including:
 - GPU-accelerated
 
 **Important**: Unlike most packages, iTerm2 will be installed to
-`~/Applications`.
+`/Applications`.
 
 ### How to make the best of iTerm2
 

--- a/iterm2/install.sh
+++ b/iterm2/install.sh
@@ -25,11 +25,11 @@ _install_iterm2() {
         exit 1
     fi
 
-    if [ -d ~/Applications/iTerm.app ]; then
-        mv ~/Applications/iTerm.app "${WEBI_TMP}/iTerm.app-webi.bak"
+    if [ -d /Applications/iTerm.app ]; then
+        mv /Applications/iTerm.app "${WEBI_TMP}/iTerm.app-webi.bak"
     fi
-    mkdir -p ~/Applications/
-    mv "${WEBI_TMP}/iTerm.app" ~/Applications/
+    mkdir -p /Applications/
+    mv "${WEBI_TMP}/iTerm.app" /Applications/
 }
 
 _install_iterm2

--- a/node/README.md
+++ b/node/README.md
@@ -11,6 +11,9 @@ for a specific version)
 
 ### Files
 
+These are the files / directories that are created and/or modified with this
+install:
+
 ```text
 ~/.config/envman/PATH.env
 ~/.local/opt/node/

--- a/postgres/install.sh
+++ b/postgres/install.sh
@@ -28,11 +28,19 @@ pkg_link() {
     # rm -f "$HOME/.local/opt/postgres"
     rm -f "$pkg_dst"
     rm -f "$HOME/Applications/pgAdmin"*.app || true
+    rm -f "/Applications/pgAdmin"*.app || true
 
     # ln -s "$HOME/.local/opt/postgres-v10.13" "$HOME/.local/opt/postgres"
     ln -s "$pkg_src" "$pkg_dst"
-    mkdir -p ~/Applications
-    ln -s "$pkg_src/pgAdmin 4.app" "$HOME/Applications/pgAdmin 4.app" || true
+    if [ "Darwin" = "$(uname -s)" ]; then
+        mkdir -p /Applications
+        ln -s "$pkg_src/pgAdmin 4.app" "/Applications/pgAdmin 4.app" || true
+        if [ -e "$pkg_src/pgAdmin 4.app/Contents/Resources/venv/lib/libpython3.8.dylib" ]; then
+            # a simple patch to fix the bad link in the package
+            rm "$pkg_src/pgAdmin 4.app/Contents/Resources/venv/lib/libpython3.8.dylib"
+            ln -s "../../../Frameworks/Python" "$pkg_src/pgAdmin 4.app/Contents/Resources/venv/lib/libpython3.8.dylib"
+        fi
+    fi
 }
 
 pkg_post_install() {


### PR DESCRIPTION
Installing to `~/Applications` is supported, but there are annoying caveats.

Since `/Applications` doesn't actually require `sudo` or have any of the issues, it was a bad idea to experiment with `~/Applications`. Shouldn't have done it.

Also, the `pgAdmin 4.app` package has a bad link (it should go two parents up, not one). Fixed that too.