### PR TITLE
doc(rg) add Files section

### DIFF
--- a/bat/README.md
+++ b/bat/README.md
@@ -8,6 +8,7 @@ tagline: |
 To update or switch versions, run `webi bat@stable` (or `@v0.18`, `@beta`, etc).
 
 ### Files
+
 ```text
 ~/.config/envman/PATH.env
 ~/.config/bat/config
@@ -33,7 +34,8 @@ You need to download and install the
 Use [aliasman](/aliasman):
 
 ```sh
-aliasman cat "bat --style=plain"
+aliasman cat 'bat --style=plain'
+alias cat='bat --style=plain'
 ```
 
 Or place this in `~/.config/envman/alias.env` and manually update your

--- a/bat/install.sh
+++ b/bat/install.sh
@@ -27,6 +27,11 @@ __init_bat() {
 
         # chmod a+x ~/.local/opt/bat-v0.15.4/bin/bat
         chmod a+x "$pkg_src_cmd"
+
+        if ! [ -e ~/.config/bat/config ]; then
+            mkdir -p ~/.config/bat/
+            touch ~/.config/bat/config
+        fi
     }
 }
 

--- a/curlie/README.md
+++ b/curlie/README.md
@@ -20,6 +20,17 @@ etc).
 
 **JSON** (`=`) is the default encoding for `key=value` pairs.
 
+### How to alias as `curl`
+
+Use [aliasman](/aliasman):
+
+```sh
+aliasman curl 'curlie'
+alias curl='curlie'
+```
+
+This will affect the interactive shell, but not scripts.
+
 ### Simple GET
 
 ```sh

--- a/lsd/README.md
+++ b/lsd/README.md
@@ -48,7 +48,20 @@ lsd
 
 ### How to alias as `ls`, `ll`, `la`, etc
 
-Update your `.bashrc`, `.zshrc`, or `.profile`
+This will affect the interactive shell, but not scripts.
+
+Using [aliasman](/aliasman):
+
+```sh
+aliasman ls "lsd -F"
+aliasman la "lsd -AF"
+aliasman ll "lsd -lAF"
+aliasman lg "lsd -F --group-dirs=first"
+```
+
+(and follow the on-screen instructions or restart your shell)
+
+Or manually update your `.bashrc`, `.zshrc`, or `.profile`
 
 ```sh
 alias ls="lsd -F"
@@ -66,7 +79,14 @@ the alias:
 
 ### How to alias as `tree`
 
-Update your `.bashrc`, `.zshrc`, or `.profile`
+Using [aliasman](/aliasman):
+
+```sh
+aliasman tree "lsd -AF --tree"
+alias tree="lsd -AF --tree"
+```
+
+Or manually update your `.bashrc`, `.zshrc`, or `.profile`
 
 ```sh
 alias tree="lsd -AF --tree"

--- a/rg/README.md
+++ b/rg/README.md
@@ -7,6 +7,15 @@ tagline: |
 
 To update or switch versions, run `webi rg@stable` (or `@v13.0`, `@beta`, etc).
 
+### Files
+
+```text
+~/.config/envman/PATH.env
+~/.local/opt/rg/
+~/.local/bin/rg
+~/.ripgreprc
+```
+
 ## Cheat Sheet
 
 > Ripgrep (`rg`) is smart. It's like grep if grep were built for code. It

--- a/rg/install.sh
+++ b/rg/install.sh
@@ -25,6 +25,10 @@ __init_rg() {
 
         # mv ./ripgrep-*/rg ~/.local/opt/rg-v12.1.1/bin/rg
         mv ./ripgrep-*/rg "$pkg_src_cmd"
+
+        if ! [ -e ~/.ripgreprc ]; then
+            touch ~/.ripgreprc
+        fi
     }
 
     # pkg_get_current_version is recommended, but (soon) not required


### PR DESCRIPTION
Added Files section for ripgrep. 

I added the referenced config file from ripgrep's [docs](https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#configuration-file). I don't believe Webi is creating it and honestly, I didn't even know you could have a config file for ripgrep. 