### PR TITLE
fix(vim-essentials): install bins last in case they fail (looking at you sudo'd npm)

### DIFF
--- a/vim-essentials/install.sh
+++ b/vim-essentials/install.sh
@@ -12,12 +12,12 @@ __init_vim_essentials() {
         vim-smartcase \
         vim-spell \
         vim-ale \
+        vim-whitespace \
+        vim-shfmt \
+        vim-prettier \
         shellcheck \
         shfmt \
-        vim-shfmt \
-        prettier \
-        vim-prettier \
-        vim-whitespace
+        prettier
     # done
 
     printf '\n'


### PR DESCRIPTION
Some people have node that was installed via `apt` which, of course, doesn't work for anything. \
(thanks Ubuntu...)

So we make `prettier` last.

We should probably have some sort of check in the `jshint` and `prettier` installers so that they don't succeed if node is in a system location.