### PR TITLE
fix: remove outdated config on formatters, and detect by file type

### DIFF
--- a/vim-prettier/prettier.vim
+++ b/vim-prettier/prettier.vim
@@ -3,8 +3,15 @@
 " from webinstall.dev/vim-prettier "
 """"""""""""""""""""""""""""""""""""
 
-" format as-you-type is quite annoying, so we turn it off
-let g:prettier#autoformat = 0
+" Change Log
+"
+" 2023-03-06:
+"   - run when filetype matches javascript
+"     (e.g. shebang is #!/usr/bin/env node)
+"   - remove explicit file extension detection
+"     (this now works as expected by default)
 
-" list all of the extensions for which prettier should run
-autocmd BufWritePre .babelrc,.eslintrc,.jshintrc,*.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html PrettierAsync
+augroup RunPrettierByFiletype
+    " run Prettier not just by file extension, but also if the filetype is detected as javascript or typescript
+    autocmd FileType javascript,typescript autocmd BufWritePre <buffer> PrettierAsync
+augroup END

--- a/vim-shfmt/shfmt.vim
+++ b/vim-shfmt/shfmt.vim
@@ -1,9 +1,15 @@
+"""""""""""""""""""""""""""""""""
+"    shfmt-specific defaults    "
+" from webinstall.dev/vim-shfmt "
+"""""""""""""""""""""""""""""""""
+
+" Change Log
+"
+" 2023-03-06:
+"   - remove explicit file extension detection
+"     (this now works as expected by default)
+
+
 " 4 indents, Space between redirects, Indented case statements, Simplified
 let g:shfmt_extra_args = '-i 4 -sr -ci -s'
 let g:shfmt_fmt_on_save = 1
-
-augroup LocalShell
-    autocmd!
-
-    autocmd BufWritePre *.sh,*.bash Shfmt
-augroup END


### PR DESCRIPTION
It looks like the desired behavior now exists upstream, so we can remove our special edits.

~/.vim/pack/plugins/start/vim-shfmt/plugin/shfmt.vim

```vim
" ...
		autocmd BufWritePre *.sh Shfmt
		autocmd FileType sh autocmd BufWritePre <buffer> Shfmt
" ...
```