### PR TITLE
fix(dashd): turn on indexes

### DIFF
--- a/dashcore-utils/dash.example.conf
+++ b/dashcore-utils/dash.example.conf
@@ -1,3 +1,8 @@
+txindex=1
+addressindex=1
+timestampindex=1
+spentindex=1
+
 [main]
 rpcuser=RPCUSER_MAIN
 rpcpassword=RPCPASS_MAIN
@@ -21,6 +26,7 @@ rpcuser=RPCUSER_REGTEST
 rpcpassword=RPCPASS_REGTEST
 bind=127.0.0.1:19899
 rpcbind=127.0.0.1:19898
+rpcallowip=127.0.0.1/16
 zmqpubrawtx=tcp://127.0.0.1:18809
 zmqpubrawtxlock=tcp://127.0.0.1:18809
 

--- a/dashcore-utils/dash.example.conf
+++ b/dashcore-utils/dash.example.conf
@@ -6,8 +6,11 @@ spentindex=1
 [main]
 rpcuser=RPCUSER_MAIN
 rpcpassword=RPCPASS_MAIN
+# to run on multiple interfaces, use multiple config lines
+# ex: bind=127.0.0.1:9999 and bind=10.0.0.100:9999)
 bind=127.0.0.1:9999
 rpcbind=127.0.0.1:9998
+rpcconnect=127.0.0.1:9998
 rpcallowip=127.0.0.1/16
 zmqpubrawtx=tcp://127.0.0.1:28332
 zmqpubrawtxlock=tcp://127.0.0.1:28332
@@ -17,6 +20,7 @@ rpcuser=RPCUSER_TEST
 rpcpassword=RPCPASS_TEST
 bind=127.0.0.1:19999
 rpcbind=127.0.0.1:19998
+rpcconnect=127.0.0.1:19998
 rpcallowip=127.0.0.1/16
 zmqpubrawtx=tcp://127.0.0.1:18009
 zmqpubrawtxlock=tcp://127.0.0.1:18009
@@ -26,6 +30,7 @@ rpcuser=RPCUSER_REGTEST
 rpcpassword=RPCPASS_REGTEST
 bind=127.0.0.1:19899
 rpcbind=127.0.0.1:19898
+rpcconnect=127.0.0.1:19898
 rpcallowip=127.0.0.1/16
 zmqpubrawtx=tcp://127.0.0.1:18809
 zmqpubrawtxlock=tcp://127.0.0.1:18809

--- a/dashd/README.md
+++ b/dashd/README.md
@@ -10,10 +10,10 @@ etc).
 
 ### Recommended Hardware
 
-- 100GB Block Storage
+- 100GB+ Block Storage
 - 8GB RAM
 - 4 vCPUs
-- 4 hours for initial sync
+- **30 hours** for initial sync
 
 ### Files
 
@@ -97,21 +97,27 @@ corrupt the data and require starting over (see below)
 For **mainnet**:
 
 - 100GB Block Storage Volume \
-  (min 40GB as of 2022, plus 4GB/year)
+  - minimum of 40GB (blockchain) + 50GB (indexes) as of 2023
+  - plus 4-8GB per year
 - 8GB RAM \
   (min 4GB RAM + 4GB swap, otherwise it crashes during indexing)
 - 4 vCPUs \
-  (min 2x 2.0GHz vCPUs)
+  (min 2x 2.0GHz vCPUs, higher clock speed is better than more cors)
 - 100 megabit network
-- 4 hours to sync and index in ideal conditions
+- 28-30 hours to sync and index in ideal conditions
+  - minimum of 4 hours to sync
+  - approximately 28 hours to index regardless of sync time
 
 For **testnet**:
 
-- 10GB Block Storage Volume \
-  (min 4GB as of 2022, plus 400MB/year)
+- 20GB Block Storage Volume \
+  - min 4GB (blockchain) + 5 GB (indexes) as of 2022
+  - plus 0.5-1GB/year
 - 2GB RAM
 - 1 vCPU
-- 1 hour to sync and index in ideal conditions
+- 4 hours to sync and index in ideal conditions
+  - 1 hour to sync
+  - about 4 hours to index regardless of sync time
 
 ### How to configure `dash.conf`
 
@@ -130,6 +136,7 @@ rpcuser=alice
 rpcpassword=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 bind=127.0.0.1:9999
 rpcbind=127.0.0.1:9998
+rpcconnect=127.0.0.1:9998
 rpcallowip=127.0.0.1/16
 zmqpubrawtx=tcp://127.0.0.1:28332
 zmqpubrawtxlock=tcp://127.0.0.1:28332
@@ -139,6 +146,7 @@ rpcuser=alice-test
 rpcpassword=yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
 bind=127.0.0.1:19999
 rpcbind=127.0.0.1:19998
+rpcconnect=127.0.0.1:19998
 rpcallowip=127.0.0.1/16
 zmqpubrawtx=tcp://127.0.0.1:18009
 zmqpubrawtxlock=tcp://127.0.0.1:18009

--- a/dashd/README.md
+++ b/dashd/README.md
@@ -79,8 +79,12 @@ dashd \
     -conf="$HOME/.dashcore/dash.conf" \
     -settings="$HOME/.dashcore/settings.json" \
     -walletdir="$HOME/.dashcore/wallets/" \
-    -datadir="/mnt/100gb/dashcore/_data/"
-    -blocksdir="/mnt/100gb/dashcore/_caches/"
+    -datadir="/mnt/100gb/dashcore/_data/" \
+    -blocksdir="/mnt/100gb/dashcore/_caches/" \
+    -addressindex=1 \
+    -timestampindex=1 \
+    -txindex=1 \
+    -spentindex=1
 ```
 
 **Warning**: killing the process with ctrl+c before the first full sync may
@@ -108,6 +112,42 @@ For **testnet**:
 - 2GB RAM
 - 1 vCPU
 - 1 hour to sync and index in ideal conditions
+
+### How to configure `dash.conf`
+
+You can set options for `main`, `test`, and `regtest`.
+
+If you intend to use the various RPCs you must enable indexes.
+
+```ini
+txindex=1
+addressindex=1
+timestampindex=1
+spentindex=1
+
+[main]
+rpcuser=alice
+rpcpassword=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+bind=127.0.0.1:9999
+rpcbind=127.0.0.1:9998
+rpcallowip=127.0.0.1/16
+zmqpubrawtx=tcp://127.0.0.1:28332
+zmqpubrawtxlock=tcp://127.0.0.1:28332
+
+[test]
+rpcuser=alice-test
+rpcpassword=yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+bind=127.0.0.1:19999
+rpcbind=127.0.0.1:19998
+rpcallowip=127.0.0.1/16
+zmqpubrawtx=tcp://127.0.0.1:18009
+zmqpubrawtxlock=tcp://127.0.0.1:18009
+```
+
+See also:
+
+- [dash: examples/dash.conf](https://github.com/dashpay/dash/blob/549e347b742cb4dc63807a292729e658218d7d0f/contrib/debian/examples/dash.conf#L2)
+- [dashd: Indexing Options](https://docs.dash.org/projects/core/en/19.0.0/docs/dashcore/wallet-arguments-and-commands-dashd.html#indexing-options)
 
 ### How to Separate Caches from Data
 


### PR DESCRIPTION
Many of the most important RPCs can't work without indexing turned on.

This will likely increase the system requirements as well.