### PR TITLE
fix(vim-ale): use ascii rather than utf8

### DIFF
--- a/vim-ale/ale.vim
+++ b/vim-ale/ale.vim
@@ -10,18 +10,19 @@ let g:ale_lint_on_save = 1
 let g:ale_virtualtext_cursor = 'current'
 
 " These emojis go in the sidebar for errors and warnings
-" other considerations: '💥' '☢️' '⚡' '☠' '●' '.'
+" other considerations: '💥' '☢️' '⚡' '☠' '●' '.' '✘' '⚠️'
 " Note: one- and two-byte characters are more compatible
-let g:ale_sign_error = '✘'
-let g:ale_sign_warning = '⚠️'
+let g:ale_sign_error = 'x'
+let g:ale_sign_warning = '!'
 
 " show error count
 function! LinterStatus() abort
     let l:counts = ale#statusline#Count(bufnr(''))
     let l:all_errors = l:counts.error + l:counts.style_error
     let l:all_non_errors = l:counts.total - l:all_errors
+    " \   '%d⨉ %d⚠ ',
     return l:counts.total == 0 ? 'OK' : printf(
-        \   '%d⨉ %d⚠ ',
+        \   '%dx %d! ',
         \   all_non_errors,
         \   all_errors
         \)


### PR DESCRIPTION
A lot of headless images have the locale set to "C" by default. So much so that it makes sense to use ASCII rather than UTF8 for the vim-ale error icon.

## Workaround

```vim
- let g:ale_sign_error = '✘'
- let g:ale_sign_warning = '⚠️'
+ let g:ale_sign_error = 'x'
+ let g:ale_sign_warning = '!'
```

## Error message

```text
Error detected while processing function <SNR>82_VimCloseCallback[11]..<SNR>82_VimExitCallback[22]..function <SN
R>82_VimCloseCallback[11]..<SNR>82_VimExitCallback[15]..<lambda>13[1]..<SNR>77_ExitCallback[28]..<SNR>76_HandleE
xit[30]..ale#engine#HandleLoclist[40]..ale#engine#SetResults:
line   10:
E117: Unknown function: ale#sign#SetSigns
Error detected while processing function <SNR>82_VimCloseCallback:
line   11:
E171: Missing :endif
:
Error detected while processing function <SNR>82_VimCloseCallback[11]..<SNR>82_VimExitCallback[22]..function <SN
R>82_VimCloseCallback[11]..<SNR>82_VimExitCallback[15]..<lambda>15[1]..<SNR>77_ExitCallback[28]..<SNR>76_HandleE
xit[30]..ale#engine#HandleLoclist[40]..ale#engine#SetResults:
line   10:
E117: Unknown function: ale#sign#SetSigns
Error detected while processing function <SNR>82_VimCloseCallback:
line   11:
E171: Missing :endif
```

## Side Note

If you want to use UTF8 error and warning symbols like ❌ and ⚠️, then you need to enable UTF-8 in the locale, and probably reboot:

`/etc/default/locale`:
```diff
- LANG="C"
+ LANG="en_US.UTF-8"
```