### PR TITLE
ref!(node): enable musl builds

### DIFF
--- a/_webi/bootstrap.sh
+++ b/_webi/bootstrap.sh
@@ -92,8 +92,13 @@ __webi_main() {
     export WEBI_WGET="\$(command -v wget)"
     set -e
 
+    my_libc=''
+    if ldd /bin/ls 2> /dev/null | grep -q 'musl' 2> /dev/null; then
+        my_libc=' musl-native'
+    fi
+
     export WEBI_HOST="\${WEBI_HOST:-https://webinstall.dev}"
-    export WEBI_UA="\$(uname -s)/\$(uname -r) \$(uname -m)/unknown"
+    export WEBI_UA="\$(uname -s)/\$(uname -r) \$(uname -m)/unknown\${my_libc}"
 
 
     webinstall() {

--- a/_webi/normalize.js
+++ b/_webi/normalize.js
@@ -85,9 +85,11 @@ function normalize(all) {
     }
     // Hacky-doo for musl
     // TODO some sort of glibc vs musl tag?
-    if (!rel._musl) {
-      if (/(\b|\.|_|-)(musl)(\b|\.|_|-)/.test(rel.download)) {
-        rel._musl = true;
+    if (!rel._musl_native) {
+      if (!rel._musl) {
+        if (/(\b|\.|_|-)(musl)(\b|\.|_|-)/.test(rel.download)) {
+          rel._musl = true;
+        }
       }
     }
     supported.oses[rel.os] = true;

--- a/_webi/serve-installer.js
+++ b/_webi/serve-installer.js
@@ -47,12 +47,14 @@ async function serveInstaller(baseurl, ua, pkg, tag, ext, formats) {
   // TODO maybe move package/version/lts/channel detection into getReleases
   var myOs = uaDetect.os(ua);
   var myArch = uaDetect.arch(ua);
+  var myLibc = uaDetect.libc(ua);
   let cfg = await packages.get(pkg);
   let rels = await getReleases({
     pkg: cfg.alias || pkg,
     ver,
     os: myOs,
     arch: myArch,
+    libc: myLibc,
     lts,
     channel,
     formats,

--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -6,6 +6,11 @@ __bootstrap_webi() {
     set -u
     #set -x
 
+    my_libc=''
+    if ldd /bin/ls 2> /dev/null | grep -q 'musl' 2> /dev/null; then
+        my_libc=' musl-native'
+    fi
+
     #WEBI_PKG=
     #PKG_NAME=
     # TODO should this be BASEURL instead?
@@ -30,7 +35,7 @@ __bootstrap_webi() {
     #PKG_OSES=
     #PKG_ARCHES=
     #PKG_FORMATS=
-    WEBI_UA="$(uname -s)/$(uname -r) $(uname -m)/unknown"
+    WEBI_UA="$(uname -s)/$(uname -r) $(uname -m)/unknown${my_libc}"
     WEBI_PKG_DOWNLOAD=""
     WEBI_DOWNLOAD_DIR="${HOME}/Downloads"
     if command -v xdg-user-dir > /dev/null; then
@@ -168,7 +173,11 @@ __bootstrap_webi() {
                 echo >&2 "       '$PKG_NAME' is available for '$PKG_OSES' on '$PKG_ARCHES' as one of '$PKG_FORMATS'"
                 echo >&2 "       (check that the package name and version are correct)"
                 echo >&2 ""
-                echo >&2 "       Double check at $(echo "$WEBI_RELEASES" | sed 's:\?.*::')"
+                my_release_url="$(
+                    echo "$WEBI_RELEASES" |
+                        sed 's:\?.*::'
+                )"
+                echo >&2 "       Double check at ${my_release_url}"
                 echo >&2 ""
                 exit 1
             fi


### PR DESCRIPTION
## Problem

Official node cannot run on `apline`

`musl` node cannot run on `ubuntu`.

We will need to add some sort of detection mechanism to determine whether or not musl is the default libc.

This may do the trick:

```sh
ldd /bin/ls | grep 'musl'
```