### PR TITLE
doc(ffmpeg): Add DNS resolution note and example

### DIFF
--- a/ffmpeg/README.md
+++ b/ffmpeg/README.md
@@ -19,3 +19,16 @@ that produce the most similar quality by default.
 ```sh
 ffmpeg -i input.m4a output.mp3
 ```
+
+Important information per https://johnvansickle.com/ffmpeg/release-readme.txt
+ 
+> Notes:  A limitation of statically linking `glibc` is the loss of DNS resolution. Installing `nscd` through your package manager will fix this.
+
+*This is relevant if using ffmpeg to relay to an RTMP server via domain name.*
+
+```sh
+# for example, this will not work without `nscd` installed.
+
+ffmpeg -re -stream_loop -1 -i "FooBar.m4v" -c copy -f flv rtmp://stream.example.com/foo/bar
+```
+


### PR DESCRIPTION
Add note about loss of DNS resolution due to statically linked `glibc`  and example scenario