### PR TITLE
ref(vim-essentials): use vim-ale's built-in prettier support

### DIFF
--- a/beyond-shell/README.md
+++ b/beyond-shell/README.md
@@ -59,7 +59,6 @@ recommended.
   - [vim-smartcase](/vim-smartcase)
   - [vim-spell](/vim-spell)
   - [vim-ale](/vim-ale)
-  - [vim-prettier](/vim-prettier)
   - [vim-shfmt](/vim-shfmt)
   - [vim-whitespace](/vim-whitespace)
 - Commandline Tools

--- a/vim-ale/ale.vim
+++ b/vim-ale/ale.vim
@@ -3,8 +3,10 @@ syntax on
 
 " don't check immediately on open (or quit)
 let g:ale_lint_on_enter = 0
+let g:ale_fix_on_enter = 0
 " check on save
 let g:ale_lint_on_save = 1
+let g:ale_fix_on_save = 1
 
 " don't spam the virtual text ('disable' to disable)
 let g:ale_virtualtext_cursor = 'current'

--- a/vim-beyondcode/README.md
+++ b/vim-beyondcode/README.md
@@ -23,4 +23,3 @@ It includes many of the vim plugins available on webinstall.dev such as:
 - [vim-lastplace](/vim-lastplace)
 - [vim-viminfo](/vim-viminfo)
 - [vim-ale](/vim-ale)
-- [vim-prettier](/vim-prettier)

--- a/vim-beyondcode/install.sh
+++ b/vim-beyondcode/install.sh
@@ -12,7 +12,6 @@ __init_vim_beyondcode() {
         vim-lastplace \
         vim-spell \
         vim-ale \
-        vim-prettier \
         vim-whitespace
 
     # requires special hardware (mouse) or software (nerdfont)

--- a/vim-essentials/README.md
+++ b/vim-essentials/README.md
@@ -42,7 +42,6 @@ It includes many of the vim plugins available on webinstall.dev such as:
   - [shellcheck](/shellcheck)
   - [shfmt](/shfmt)
 - [vim-ale](/vim-ale)
-- [vim-prettier](/vim-prettier)
   - [prettier](/prettier)
 - [vim-whitespace](/vim-whitespace)
 

--- a/vim-essentials/install.sh
+++ b/vim-essentials/install.sh
@@ -14,7 +14,6 @@ __init_vim_essentials() {
         vim-ale \
         vim-whitespace \
         vim-shfmt \
-        vim-prettier \
         shellcheck \
         shfmt \
         prettier

--- a/vim-prettier/README.md
+++ b/vim-prettier/README.md
@@ -27,9 +27,23 @@ installed.
 > `vim-prettier` is a vim plugin wrapper for prettier, pre-configured with
 > custom default prettier settings.
 
-You'll also need to install [`ALE`](https://webinstall.dev/vim-ale) (part of
-[`vim-essentials`](https://webinstall.dev/vim-essentials)) or
-[`syntastic`](https://webinstall.dev/vim-syntastic) first.
+### You may not need vim-prettier
+
+If you have [`ALE`](https://webinstall.dev/vim-ale) (part of
+[`vim-essentials`](https://webinstall.dev/vim-essentials)), you don't need
+vim-prettier.
+
+Instead just check that the built-in prettier support is enabled in one of:
+
+- `~/.vimrc`
+- `~/.vim/plugins/ale.vim`
+
+```vim
+" don't reformat on open
+let g:ale_fix_on_enter = 0
+" do reformat on save
+let g:ale_fix_on_save = 1
+```
 
 ### How to install by hand
 


### PR DESCRIPTION
So it turns out we haven't needed `vim-prettier` since `vim-ale`.

We just needed to update `~/.vim/plugins/ale.vim` with `let g:ale_fix_on_save = 1`.