### PR TITLE
feat(sqlpkg) Add sqlpkg CLI utility for installing SQLite extensions

### DIFF
--- a/sqlpkg/README.md
+++ b/sqlpkg/README.md
@@ -1,0 +1,124 @@
+---
+title: sqlpkg
+homepage: https://sqlpkg.org/
+tagline: |
+  The (unofficial) SQLite package manager
+description: |
+  sqlpkg manages SQLite extensions
+---
+
+To update or switch versions, run `webi sqlpkg@stable` (or `@v1.1`, `@beta`,
+etc).
+
+## Cheat Sheet
+
+> `sqlpkg` manages SQLite extensions, just like `pip` does with Python packages
+> or `brew` does with macOS programs.
+
+```sh
+$ sqlpkg help
+┌────────────────────────────────────────────────┐
+│ sqlpkg is an SQLite package manager.           │
+│ Use it to install or update SQLite extensions. │
+│                                                │
+│ Commands:                                      │
+│ help       Display help                        │
+│ info       Display package information         │
+│ init       Init project scope                  │
+│ install    Install packages                    │
+│ list       List installed packages             │
+│ uninstall  Uninstall package                   │
+│ update     Update installed packages           │
+│ version    Display version                     │
+│ which      Display path to extension file      │
+└────────────────────────────────────────────────┘
+```
+
+### Installing packages
+
+Install a package from the registry:
+
+```sh
+sqlpkg install nalgeon/stats
+```
+
+`nalgeon/stats` is the ID of the extension as shown in the registry.
+
+Install a package from a GitHub repository (it should have a package spec file):
+
+```sh
+sqlpkg install github.com/nalgeon/sqlean
+```
+
+Install a package from a spec file somewhere on the Internet:
+
+```sh
+sqlpkg install https://antonz.org/downloads/stats.json
+```
+
+Install a package from a local spec file:
+
+```sh
+sqlpkg install ./stats.json
+```
+
+### Other commands
+
+`sqlpkg` provides other basic commands you would expect from a package manager.
+
+#### `update`
+
+```sh
+sqlpkg update
+```
+
+Updates all installed packages to the latest versions.
+
+#### `uninstall`
+
+```sh
+sqlpkg uninstall nalgeon/stats
+```
+
+Uninstalls a previously installed package.
+
+#### `list`
+
+```sh
+sqlpkg list
+```
+
+Lists installed packages.
+
+#### `info`
+
+```sh
+sqlpkg info nalgeon/stats
+```
+
+Displays package information. Works with both local and remote packages.
+
+#### `version`
+
+```sh
+sqlpkg version
+```
+
+Displays `sqlpkg` version number.
+
+### Project vs. global scope
+
+By default, `sqlpkg` installs all extensions in the home folder (global scope).
+If you are writing a Python (JavaScript, Go, ...) application — you may prefer
+to put them in the project folder (project scope, like virtual environment in
+Python or `node_modules` in JavaScript).
+
+To do that, run the `init` command:
+
+```sh
+sqlpkg init
+```
+
+It will create an `.sqlpkg` folder in the current directory. After that, all
+other commands run from the same directory will use it instead of the home
+folder.

--- a/sqlpkg/README.md
+++ b/sqlpkg/README.md
@@ -7,118 +7,161 @@ description: |
   sqlpkg manages SQLite extensions
 ---
 
-To update or switch versions, run `webi sqlpkg@stable` (or `@v1.1`, `@beta`,
+To update or switch versions, run `webi sqlpkg@stable` (or `@v0.2.2`, `@beta`,
 etc).
+
+### Files
+
+These are the files / directories that are created and/or modified with this
+install:
+
+```text
+~/.local/envman/PATH.env
+~/.local/bin/sqlpkg
+~/.sqlpkg/
+<PROJECT-DIR>/.sqlpkg/
+```
 
 ## Cheat Sheet
 
 > `sqlpkg` manages SQLite extensions, just like `pip` does with Python packages
 > or `brew` does with macOS programs.
 
+View and search sqlite extensions at <https://sqlpkg.org/>.
+
+Install via `sqlpkg install`:
+
 ```sh
-$ sqlpkg help
-┌────────────────────────────────────────────────┐
-│ sqlpkg is an SQLite package manager.           │
-│ Use it to install or update SQLite extensions. │
-│                                                │
-│ Commands:                                      │
-│ help       Display help                        │
-│ info       Display package information         │
-│ init       Init project scope                  │
-│ install    Install packages                    │
-│ list       List installed packages             │
-│ uninstall  Uninstall package                   │
-│ update     Update installed packages           │
-│ version    Display version                     │
-│ which      Display path to extension file      │
-└────────────────────────────────────────────────┘
+# sqlpkg install <name|git-uri|https-url>
+sqlpkg install nalgeon/stats
 ```
 
-### Installing packages
-
-Install a package from the registry:
+Verify with `sqlpkg list`
 
 ```sh
+sqlpkg
+```
+
+Which then becomes available at `~/.sqlpkg/nalgeon/stats/`
+
+| Command   | Description                    |
+| --------- | ------------------------------ |
+| help      | Display help                   |
+| info      | Display package information    |
+| init      | Init project scope             |
+| install   | Install packages               |
+| list      | List installed packages        |
+| uninstall | Uninstall package              |
+| update    | Update installed packages      |
+| version   | Display version                |
+| which     | Display path to extension file |
+
+### How to initialize a Project
+
+By default, `sqlpkg` installs extensions to `~/.sqlpkg/<extension-name>`.
+
+However, `sqlpkg init` will create a `.sqlpkg` in the current project folder. \
+(just like _virtual environment_ or `node_modules`)
+
+```sh
+sqlpkg init
+```
+
+```text
+✓ created a project scope
+```
+
+### How to Install SQLite Extensions
+
+You can install extensions in various ways:
+
+- SQL Pkg Registry ([sqlpkg.org](https://sqlpkg.org))
+- Git / GitHub URI
+- Spec File URL
+- Local Spec File
+
+#### Registry
+
+```sh
+# sqlpkg install <pkg-name>
+sqlpkg info nalgeon/stats
 sqlpkg install nalgeon/stats
+sqlpkg list | grep stats
 ```
 
 `nalgeon/stats` is the ID of the extension as shown in the registry.
 
-Install a package from a GitHub repository (it should have a package spec file):
+#### Git / GitHub
 
 ```sh
-sqlpkg install github.com/nalgeon/sqlean
+sqlpkg info github.com/riyaz-ali/dns.sql
+sqlpkg install github.com/riyaz-ali/dns.sql
+sqlpkg list | grep dns.sql
 ```
 
-Install a package from a spec file somewhere on the Internet:
+Git repositories must have a package spec file.
+
+#### Spec URL
 
 ```sh
-sqlpkg install https://antonz.org/downloads/stats.json
+sqlpkg info https://raw.githubusercontent.com/riyaz-ali/dns.sql/main/sqlpkg.json
+sqlpkg install https://raw.githubusercontent.com/riyaz-ali/dns.sql/main/sqlpkg.json
+sqlpkg list | grep dns.sql
 ```
 
-Install a package from a local spec file:
+#### Spec File
 
 ```sh
-sqlpkg install ./stats.json
+sqlpkg info ./sqlpkg.json
+sqlpkg install ./sqlpkg.json
+sqlpkg list | grep dns.sql
 ```
 
-### Other commands
+### How to Manage Packages
 
-`sqlpkg` provides other basic commands you would expect from a package manager.
+`sqlpkg` provides other basic commands you would expect from a package manager:
+
+- Info
+- Install
+- Update (one or all)
+- Uninstall
+
+```sh
+sqlpkg <cmd> <pkg-name|git-uri|spec-url|file>
+```
+
+#### `info`
+
+```sh
+sqlpkg info nalgeon/stats
+sqlpkg info github.com/riyaz-ali/dns.sql
+sqlpkg info https://raw.githubusercontent.com/riyaz-ali/dns.sql/main/sqlpkg.json
+sqlpkg info ./sqlpkg.json
+```
+
+#### `install`
+
+```sh
+sqlpkg install nalgeon/stats
+sqlpkg install github.com/riyaz-ali/dns.sql
+sqlpkg install https://raw.githubusercontent.com/riyaz-ali/dns.sql/main/sqlpkg.json
+sqlpkg install ./sqlpkg.json
+```
 
 #### `update`
 
 ```sh
 sqlpkg update
+sqlpkg update nalgeon/stats
 ```
 
-Updates all installed packages to the latest versions.
+**Note**: `update` without a package name will update _ALL_ extensions
+
+**Note**: `update` installs the _latest_ version, not necessarily a
+semver-compatible version
 
 #### `uninstall`
 
 ```sh
 sqlpkg uninstall nalgeon/stats
 ```
-
-Uninstalls a previously installed package.
-
-#### `list`
-
-```sh
-sqlpkg list
-```
-
-Lists installed packages.
-
-#### `info`
-
-```sh
-sqlpkg info nalgeon/stats
-```
-
-Displays package information. Works with both local and remote packages.
-
-#### `version`
-
-```sh
-sqlpkg version
-```
-
-Displays `sqlpkg` version number.
-
-### Project vs. global scope
-
-By default, `sqlpkg` installs all extensions in the home folder (global scope).
-If you are writing a Python (JavaScript, Go, ...) application — you may prefer
-to put them in the project folder (project scope, like virtual environment in
-Python or `node_modules` in JavaScript).
-
-To do that, run the `init` command:
-
-```sh
-sqlpkg init
-```
-
-It will create an `.sqlpkg` folder in the current directory. After that, all
-other commands run from the same directory will use it instead of the home
-folder.

--- a/sqlpkg/install.ps1
+++ b/sqlpkg/install.ps1
@@ -1,8 +1,8 @@
 #!/usr/bin/env pwsh
 
-####################
+##################
 # Install sqlpkg #
-####################
+##################
 
 # Every package should define these variables
 $pkg_cmd_name = "sqlpkg"

--- a/sqlpkg/install.ps1
+++ b/sqlpkg/install.ps1
@@ -1,0 +1,57 @@
+#!/usr/bin/env pwsh
+
+####################
+# Install sqlpkg #
+####################
+
+# Every package should define these variables
+$pkg_cmd_name = "sqlpkg"
+
+$pkg_dst_cmd = "$Env:USERPROFILE\.local\bin\sqlpkg.exe"
+$pkg_dst = "$pkg_dst_cmd"
+
+$pkg_src_cmd = "$Env:USERPROFILE\.local\opt\sqlpkg-v$Env:WEBI_VERSION\bin\sqlpkg.exe"
+$pkg_src_bin = "$Env:USERPROFILE\.local\opt\sqlpkg-v$Env:WEBI_VERSION\bin"
+$pkg_src_dir = "$Env:USERPROFILE\.local\opt\sqlpkg-v$Env:WEBI_VERSION"
+$pkg_src = "$pkg_src_cmd"
+
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | out-null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+
+# Fetch archive
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
+{
+    echo "Downloading sqlpkg from $Env:WEBI_PKG_URL to $pkg_download"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
+    & move "$pkg_download.part" "$pkg_download"
+}
+
+IF (!(Test-Path -Path "$pkg_src_cmd"))
+{
+    echo "Installing sqlpkg"
+
+    # TODO: create package-specific temp directory
+    # Enter tmp
+    pushd .local\tmp
+
+        # Remove any leftover tmp cruft
+        Remove-Item -Path ".\sqlpkg-v*" -Recurse -ErrorAction Ignore
+        Remove-Item -Path ".\sqlpkg.exe" -Recurse -ErrorAction Ignore
+
+        # Unpack archive file into this temporary directory
+        # Windows BSD-tar handles zip. Imagine that.
+        echo "Unpacking $pkg_download"
+        & tar xf "$pkg_download"
+
+        # Settle unpacked archive into place
+        echo "Install Location: $pkg_src_cmd"
+        New-Item "$pkg_src_bin" -ItemType Directory -Force | out-null
+        Move-Item -Path ".\sqlpkg.exe" -Destination "$pkg_src_bin"
+
+    # Exit tmp
+    popd
+}
+
+echo "Copying into '$pkg_dst_cmd' from '$pkg_src_cmd'"
+Remove-Item -Path "$pkg_dst_cmd" -Recurse -ErrorAction Ignore | out-null
+Copy-Item -Path "$pkg_src" -Destination "$pkg_dst" -Recurse

--- a/sqlpkg/install.sh
+++ b/sqlpkg/install.sh
@@ -30,7 +30,10 @@ __init_sqlpkg() {
     }
 
     pkg_get_current_version() {
-        sqlpkg version 2> /dev/null
+        # 'sqlpkg version' has output in this format:
+        #       0.2.2
+        # This makes it resistant to future added lines or columns
+        sqlpkg version 2> /dev/null | head -n 1 | cut -f 1
     }
 
 }

--- a/sqlpkg/install.sh
+++ b/sqlpkg/install.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+__init_sqlpkg() {
+    set -e
+    set -u
+
+    ####################
+    # Install sqlpkg #
+    ####################
+
+    # Every package should define these 6 variables
+    pkg_cmd_name="sqlpkg"
+
+    pkg_dst_cmd="$HOME/.local/bin/sqlpkg"
+    pkg_dst="$pkg_dst_cmd"
+
+    pkg_src_cmd="$HOME/.local/opt/sqlpkg-v$WEBI_VERSION/bin/sqlpkg"
+    pkg_src_dir="$HOME/.local/opt/sqlpkg-v$WEBI_VERSION"
+    pkg_src="$pkg_src_cmd"
+
+    pkg_install() {
+        # $HOME/.local/opt/sqlpkg-v0.2.2/bin
+        mkdir -p "$(dirname "$pkg_src_cmd")"
+
+        # mv ./sqlpkg* "$HOME/.local/opt/sqlpkg-v0.2.2/bin/sqlpkg"
+        mv ./"$pkg_cmd_name"* "$pkg_src_cmd"
+
+        # chmod a+x "$HOME/.local/opt/sqlpkg-v0.2.2/bin/sqlpkg"
+        chmod a+x "$pkg_src_cmd"
+    }
+
+    pkg_get_current_version() {
+        sqlpkg version 2> /dev/null
+    }
+
+}
+
+__init_sqlpkg

--- a/sqlpkg/releases.js
+++ b/sqlpkg/releases.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var github = require('../_common/github.js');
+var owner = 'nalgeon';
+var repo = 'sqlpkg-cli';
+
+module.exports = function (request) {
+  return github(request, owner, repo).then(function (all) {
+    return all;
+  });
+};
+
+if (module === require.main) {
+  module.exports(require('@root/request')).then(function (all) {
+    all = require('../_webi/normalize.js')(all);
+    console.info(JSON.stringify(all, null, 2));
+  });
+}

--- a/test/install.sh
+++ b/test/install.sh
@@ -72,6 +72,7 @@ __rmrf_local() {
                 setcap-netbind \
                 shellcheck \
                 shfmt \
+                sqlpkg \
                 ssh-pubkey \
                 ssh-utils \
                 syncthing \
@@ -166,6 +167,7 @@ __rmrf_local() {
                 setcap-netbind \
                 shellcheck \
                 shfmt \
+                sqlpkg \
                 ssh-pubkey \
                 ssh-utils \
                 syncthing \
@@ -265,6 +267,7 @@ __test() {
         setcap-netbind \
         shellcheck \
         shfmt \
+        sqlpkg \
         ssh-pubkey \
         ssh-utils \
         syncthing \


### PR DESCRIPTION
`sqlpkg` is a package manager for SQLite extensions. It currently supports ~62 extensions. The [command-line utility](https://github.com/nalgeon/sqlpkg-cli) provides easy access to the library of extensions, and handles installations across environments. The library of extensions can be explored here: https://sqlpkg.org/

I want to make it easy for applications and projects to add this utility so that they can then easily add SQLite extensions for their database.