### PR TITLE
Add MSVC Runtime (VC Redist) (vcruntime140.dll)

### DIFF
--- a/msvc-runtime
+++ b/msvc-runtime
@@ -1,0 +1,1 @@
+vcruntime

--- a/msvcruntime
+++ b/msvcruntime
@@ -1,0 +1,1 @@
+vcruntime

--- a/vc-redist
+++ b/vc-redist
@@ -1,0 +1,1 @@
+vcruntime

--- a/vc-runtime
+++ b/vc-runtime
@@ -1,0 +1,1 @@
+vcruntime

--- a/vc_redist
+++ b/vc_redist
@@ -1,0 +1,1 @@
+vcruntime

--- a/vcredist
+++ b/vcredist
@@ -1,0 +1,1 @@
+vcruntime

--- a/vcruntime/README.md
+++ b/vcruntime/README.md
@@ -1,0 +1,40 @@
+---
+title: Microsoft Visual C++ Redistributable
+homepage: https://learn.microsoft.com/search/?terms=redist
+tagline: |
+  MSVC Runtime: The 25mb of Windows that Microsoft just won't install for you.
+---
+
+## Cheat Sheet
+
+> execution cannot proceed run because `vcruntime140.dll` was not found
+
+You pretty much can't run any freely available programs on Windows without the
+MSVC Runtime and yet, for some reason, Microsoft won't include it for you, and
+won't make it easy for those developers to understand how, or
+[whether or not they're even allowed](https://learn.microsoft.com/en-us/cpp/windows/redistributing-visual-cpp-files?view=msvc-170#redistributable-files-and-licensing),
+to actually redistribute it with their applications.
+
+### How to Install the MSVC Runtime Manually
+
+https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170
+
+1. Download the official MSVC Runtime:
+
+   ```pwsh
+   # For Legacy x86_64 (amd64) systems:
+   curl.exe -o vcredist.exe -L https://aka.ms/vs/17/release/vc_redist.x64.exe
+
+   # For modern ARM64 systems:
+   curl.exe -o vcredist.exe -L https://aka.ms/vs/17/release/vc_redist.arm64.exe
+   ```
+
+2. Install the redistributable
+   ```pwsh
+   vcredist.exe /install /quiet /passive /norestart
+   ```
+
+If you prefer to see a visual progress bar you can remove `/quiet`, and if you
+prefer to click next a few times for good 'ol times' sake you can remove
+`/passive`, and if you prefer the nostalgia of rebooting your computer after
+every install, remove the `/norestart`.

--- a/vcruntime/install.ps1
+++ b/vcruntime/install.ps1
@@ -1,0 +1,39 @@
+# This is the canonical CPU arch when the process is emulated
+$my_arch = "$Env:PROCESSOR_ARCHITEW6432"
+IF ($my_arch -eq $null -or $my_arch -eq "") {
+  # This is the canonical CPU arch when the process is native
+  $my_arch = "$Env:PROCESSOR_ARCHITECTURE"
+}
+IF ($my_arch -eq "AMD64") {
+    # Because PowerShell isn't ARM yet.
+    # See https://oofhours.com/2020/02/04/powershell-on-windows-10-arm64/
+    $my_os_arch = wmic os get osarchitecture
+
+    # Using -clike because of the trailing newline
+    IF ($my_os_arch -clike "ARM 64*") {
+        $my_arch = "ARM64"
+    }
+}
+# See also https://github.com/microsoft/winget-pkgs/issues/55576#issuecomment-1529331106
+
+if (-not (Test-Path "$Env:USERPROFILE\Downloads\webi\vcredist.exe")) {
+    IF ($my_arch -eq "ARM64") {
+        curl.exe -o "$Env:USERPROFILE\Downloads\webi\vcredist.exe.part" -L https://aka.ms/vs/17/release/vc_redist.arm64.exe
+    } ELSE {
+        curl.exe -o "$Env:USERPROFILE\Downloads\webi\vcredist.exe.part" -L https://aka.ms/vs/17/release/vc_redist.x64.exe
+    }
+    & move "$Env:USERPROFILE\Downloads\webi\vcredist.exe.part" "$Env:USERPROFILE\Downloads\webi\vcredist.exe"
+}
+
+# TODO How to use CSIDL_SYSTEM?
+# (https://learn.microsoft.com/en-us/windows/deployment/usmt/usmt-recognized-environment-variables)
+if (-not (Test-Path "\Windows\System32\vcruntime140.dll")) {
+    echo ""
+    echo "Installing Microsoft Visual C++ Redistributable (vcruntime140.dll)..."
+    echo ""
+    & "$Env:USERPROFILE\Downloads\webi\vcredist.exe" /install /quiet /passive /norestart
+} ELSE {
+    echo ""
+    echo "Found Microsoft Visual C++ Redistributable (vcruntime140.dll)"
+    echo ""
+}

--- a/vcruntime/install.sh
+++ b/vcruntime/install.sh
@@ -1,0 +1,2 @@
+echo >&2 "vcruntime140.dll is only for Windows"
+exit 1

--- a/vcruntime140
+++ b/vcruntime140
@@ -1,0 +1,1 @@
+vcruntime


### PR DESCRIPTION
Many of the Windows programs are compiled with MSVC, which requires the 25mb of Windows that Microsoft just won't install for you.

This makes that simpler.