### PR TITLE
fix(vim-ale): show linter and code in a way that works for jshint and shellcheck

### DIFF
--- a/vim-ale/ale.vim
+++ b/vim-ale/ale.vim
@@ -33,4 +33,5 @@ set statusline+=\ %{LinterStatus()}
 " how to show error message
 let g:ale_echo_msg_error_str = 'E'
 let g:ale_echo_msg_warning_str = 'W'
-let g:ale_echo_msg_format = '[%linter%] %s [%severity%]'
+let g:ale_echo_msg_info_str = 'i'
+let g:ale_echo_msg_format = '[%linter%] %code%: %s [%severity%]'


### PR DESCRIPTION
Very simple output change

```text
[jshint] : 'await' is not defined. [E]
```

```text
[shellcheck] SC2154: my_var is referenced but not assigned. [W]
```