### PR TITLE
docs(dotenv-linter): Update Cheat Sheet to be compatable with dotenv-linter v3.1

### DIFF
--- a/dotenv-linter/README.md
+++ b/dotenv-linter/README.md
@@ -57,14 +57,22 @@ For the complete usage, see the official
 
 ### How to automatically fix errors
 
-Use the `--fix` flag.
+Use the `fix` subcommand.
 
 ```sh
-dotenv-linter --fix
+dotenv-linter fix
 ```
 
 Backup files in the format of `.env_0000000000` will be created by default. You
 can use `--no-backup` to skip this.
+
+### How to compare two files
+
+Use the `compare` subcommand
+
+```sh
+dotenv-linter compare .env1 .env2
+```
 
 ### How to toggle linter rules
 

--- a/dotenv-linter/README.md
+++ b/dotenv-linter/README.md
@@ -25,9 +25,12 @@ install:
 ```
 
 This will also attempt to install the
-[Microsoft Visual C++ Redistributable](/vcruntime) via `webi vcruntime`. If it
-fails and you get the error _`vcruntime140.dll` was not found_, you'll need to
-[install it manually](https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170).
+[Microsoft Visual C++ Redistributable](../vcruntime/) via `webi vcruntime`. If
+it fails and you get the error _`vcruntime140.dll` was not found_, you'll need
+to [install it manually](msvc-learn).
+
+[msvc-learn]:
+  https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170
 
 ## Cheat Sheet
 
@@ -63,15 +66,22 @@ Use the `fix` subcommand.
 dotenv-linter fix
 ```
 
-Backup files in the format of `.env_0000000000` will be created by default. You
-can use `--no-backup` to skip this.
+Backup files in the format of `.env_0000000000` will be created by default. \
+You can use `--no-backup` to skip this.
 
-### How to compare two files
+### How to compare keys between environements
 
 Use the `compare` subcommand
 
 ```sh
-dotenv-linter compare .env1 .env2
+dotenv-linter compare ./my-dev.env ./my-prod.env
+```
+
+```text
+Comparing my-dev.env
+Comparing my-prod.env
+my-dev.env is missing keys: FOO_API_TOKEN
+my-prod.env is missing keys: BAR_ID, BAR_SECRET
 ```
 
 ### How to toggle linter rules


### PR DESCRIPTION
Updated the Cheat Sheet for dotenv linter as according to https://github.com/webinstall/webi-installers/issues/251
I also changed --skip to shorthand -s which is less verbose but I kept compare verbose (I didn't do dotenv-lint c .env1 .env2)