### PR TITLE
fix+chore: replace leftover `pathman add`

### DIFF
--- a/gpg/install.sh
+++ b/gpg/install.sh
@@ -34,7 +34,7 @@ _install_gpg() {
     rm -rf ~/.local/opt/gnupg
     ln -s gnupg-"${WEBI_VERSION}" ~/.local/opt/gnupg
 
-    pathman add ~/.local/opt/gnupg/bin
+    webi_path_add ~/.local/opt/gnupg/bin
     export PATH="$HOME/.local/opt/gnupg/bin:$PATH"
     export PATH="$HOME/.local/opt/gnupg/bin/pinentry-mac.app/Contents/MacOS:$PATH"
 

--- a/pyenv/README.md
+++ b/pyenv/README.md
@@ -7,9 +7,25 @@ tagline: |
 
 To update run `pyenv update`.
 
+### Files
+
+These are the files / directories that are created and/or modified with this
+install:
+
+```sh
+~/.config/envman/PATH.env
+~/.pyenv/bin/
+~/.pyenv/shims/
+
+# pyenv also loads shell hooks via
+~/.bashrc
+~/.config/fish/config.fish
+~/.zshrc
+```
+
 ### How to Install pyenv on macOS
 
-Make sure that you already have Xcode tools installed:
+Install Xcode tools first:
 
 ```sh
 xcode-select --install
@@ -25,7 +41,8 @@ sudo apt update
 sudo apt install -y build-essential zlib1g-dev libssl-dev
 
 # recommended
-sudo apt install -y libreadline-dev libbz2-dev libsqlite3-dev libffi-dev
+sudo apt install -y libreadline-dev libsqlite3-dev \
+                    libffi-dev libbz2-dev liblzma-dev
 ```
 
 ## Cheat Sheet

--- a/pyenv/install.sh
+++ b/pyenv/install.sh
@@ -45,10 +45,10 @@ __init_pyenv() {
     fi
 
     mkdir -p ~/.pyenv/bin
-    pathman add ~/.pyenv/bin
+    webi_path_add ~/.pyenv/bin
 
     mkdir -p ~/.pyenv/shims
-    pathman add ~/.pyenv/shims
+    webi_path_add ~/.pyenv/shims
 
     echo "NOTE: You may also need to CLOSE and RE-OPEN your terminal for pyenv to take effect."
 }

--- a/python/README.md
+++ b/python/README.md
@@ -7,15 +7,29 @@ tagline: |
 
 To update or switch versions, run `pyenv install -v 3` (or `3.10`, etc).
 
+### Files
+
+These are the files / directories that are created and/or modified with this
+install:
+
+```sh
+~/.config/envman/PATH.env
+~/.pyenv/bin/
+~/.pyenv/shims/
+
+# pyenv also loads shell hooks via
+~/.bashrc
+~/.config/fish/config.fish
+~/.zshrc
+```
+
 ### How to Install python3 on macOS
 
-Make sure that you already have Xcode tools installed:
+Install Xcode tools first:
 
 ```sh
 xcode-select --install
 ```
-
-You may also need to install Xcode proper from the App Store.
 
 ### How to Install python3 on Linux
 
@@ -27,18 +41,8 @@ sudo apt update
 sudo apt install -y build-essential zlib1g-dev libssl-dev
 
 # recommended
-sudo apt install -y libreadline-dev libbz2-dev libsqlite3-dev
-```
-
-### Files
-
-These are the files / directories that are created and/or modified with this
-install:
-
-```text
-~/.bashrc (or your shell's equivalent)
-~/.config/envman/PATH.env
-~/.pyenv
+sudo apt install -y libreadline-dev libsqlite3-dev \
+                    libffi-dev libbz2-dev liblzma-dev
 ```
 
 ## Cheat Sheet

--- a/python2/README.md
+++ b/python2/README.md
@@ -7,15 +7,29 @@ tagline: |
 
 To update or switch versions, run `pyenv install -v 2` (or `2.6`, etc).
 
+### Files
+
+These are the files / directories that are created and/or modified with this
+install:
+
+```sh
+~/.config/envman/PATH.env
+~/.pyenv/bin/
+~/.pyenv/shims/
+
+# pyenv also loads shell hooks via
+~/.bashrc
+~/.config/fish/config.fish
+~/.zshrc
+```
+
 ### How to Install python2 on macOS
 
-Make sure that you already have Xcode tools installed:
+Install Xcode tools first:
 
 ```sh
 xcode-select --install
 ```
-
-You may also need to install Xcode proper from the App Store.
 
 ### How to Install python2 on Linux
 
@@ -27,19 +41,10 @@ sudo apt update
 sudo apt install -y build-essential zlib1g-dev libssl-dev
 
 # recommended
-sudo apt install -y libreadline-dev libbz2-dev libsqlite3-dev
+sudo apt install -y libreadline-dev libsqlite3-dev \
+                    libffi-dev libbz2-dev liblzma-dev
 ```
 
-### Files
-
-These are the files / directories that are created and/or modified with this
-install:
-
-```text
-~/.bashrc (or your shell's equivalent)
-~/.config/envman/PATH.env
-~/.pyenv
-```
 
 ## Cheat Sheet
 

--- a/python3/README.md
+++ b/python3/README.md
@@ -8,4 +8,4 @@ description: |
   See https://webinstall.dev/python
 ---
 
-Alias for https://webinstall.dev/python
+Alias for [python](../python/).

--- a/rustlang/install.sh
+++ b/rustlang/install.sh
@@ -9,7 +9,7 @@ __install_rust() {
     # Straight from https://rustup.rs/
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
-    pathman add "$HOME/.cargo/bin"
+    webi_path_add "$HOME/.cargo/bin"
 }
 
 __install_rust

--- a/webi/README.md
+++ b/webi/README.md
@@ -39,9 +39,10 @@ webi node@lts golang@stable flutter@beta rustlang
 
 ### webi PATHs
 
-You can see exactly what PATHs have been edited:
+You can see exactly what PATHs have been edited with [`pathman`](../pathman/):
 
 ```sh
+webi pathman
 pathman list
 ```
 
@@ -58,17 +59,14 @@ These are the files that are installed when you use [webinstall.dev](/):
 ```sh
 # Mac, Linux
 ~/.local/bin/webi
-~/.local/bin/pathman
-~/.local/opt/pathman-*
 
 # Windows
 ~/.local/bin/webi.bat
 ~/.local/bin/webi-pwsh.ps1
 ```
 
-Assuming that you don't use `pathman` for anything else, you can safely remove
-all of them. If you use [webinstall.dev](/) again in the future they will be
-reinstalled.
+You can safely remove all of them. If you use [webinstall.dev](/) again in the
+future they will be reinstalled.
 
 Additionally, these files may be modified to update your `PATH`:
 


### PR DESCRIPTION
Re: https://github.com/webinstall/webi-installers/issues/697
- [x] nix `pathman add` in favor of `webi_path_add` \
       these were missed last time (and broken)
- [x] update pyenv docs