### PR TITLE
Fix: cmake on macOS (#696)

### DIFF
--- a/cmake/install.sh
+++ b/cmake/install.sh
@@ -28,7 +28,11 @@ __init_cmake() {
         mkdir -p "$(dirname "${pkg_src_dir}")"
 
         # mv ./cmake-*/ ~/.local/opt/cmake-v3.27.0/
-        mv ./cmake-*/ "${pkg_src_dir}"
+        if test -e ./cmake-*/CMake.app/Contents/; then
+            mv ./cmake-*/CMake.app/Contents/ "${pkg_src_dir}"
+        else
+            mv ./cmake-*/ "${pkg_src_dir}"
+        fi
     }
 
     # pkg_get_current_version is recommended, but not required


### PR DESCRIPTION
Re: #696

On macOS the `cmake` package as a hybrid `./opt/` / `.app` structure that we must account for:

```text
./
└── cmake-3.28.0-rc2-macos-universal/
    └── CMake.app/
        └── Contents/
            ├── _CodeSignature/
            ├── bin/
            ├── doc/
            ├── Frameworks/
            │   ├── QtCore.framework/
            │   ├── QtGui.framework/
            │   ├── QtPrintSupport.framework/
            │   └── QtWidgets.framework/
            ├── MacOS/
            ├── man/
            ├── PlugIns/
            │   ├── platforms/
            │   └── styles/
            ├── Resources/
            └── share/
```