### PR TITLE
fix: better (lazier) 'stable' vs 'beta' detection

### DIFF
--- a/_common/github.js
+++ b/_common/github.js
@@ -61,20 +61,32 @@ async function getAllReleases(
   }
 
   function transformReleases(release) {
-    release['assets'].forEach(function (asset) {
+    for (let asset of release['assets']) {
       let name = asset['name'];
+      let date = release['published_at']?.replace(/T.*/, '');
+      let download = asset['browser_download_url'];
+
+      // TODO tags aren't always semver / sensical
+      let version = release['tag_name'];
+      let channel;
+      if (release['prerelease']) {
+        // -rcX, -preview, -beta, etc will be checked in _webi/normalize.js
+        channel = 'beta';
+      }
+      let lts = /(\b|_)(lts)(\b|_)/.test(release['tag_name']);
+
       all.releases.push({
         name: name,
-        version: release['tag_name'], // TODO tags aren't always semver / sensical
-        lts: /(\b|_)(lts)(\b|_)/.test(release['tag_name']),
-        channel: !release['prerelease'] ? 'stable' : 'beta',
-        date: (release['published_at'] || '').replace(/T.*/, ''),
+        version: version,
+        lts: lts,
+        channel: channel,
+        date: date,
         os: '', // will be guessed by download filename
         arch: '', // will be guessed by download filename
         ext: '', // will be normalized
-        download: asset['browser_download_url'],
+        download: download,
       });
-    });
+    }
   }
 
   return all;

--- a/_webi/normalize.js
+++ b/_webi/normalize.js
@@ -72,7 +72,7 @@ function normalize(all) {
     formats: {},
   };
 
-  all.releases.forEach(function (rel) {
+  for (let rel of all.releases) {
     /* jshint maxcomplexity:25 */
     rel.version = rel.version.replace(/^v/i, '');
     if (!rel.name) {
@@ -85,7 +85,7 @@ function normalize(all) {
         }) || 'unknown';
     }
     // Hacky-doo for musl
-    // TODO some sort of glibc vs musl tag?
+    // TODO 'libc' some sort of glibc vs musl tag?
     if (!rel._musl_native) {
       if (!rel._musl) {
         if (/(\b|\.|_|-)(musl)(\b|\.|_|-)/.test(rel.download)) {
@@ -139,10 +139,28 @@ function normalize(all) {
     }
     supported.formats[tarExt || rel.ext] = true;
 
+    if (!rel.channel) {
+      // basically like this: (+.-_)(beta|rc)(0-9)(+.-_)
+      // matches:
+      //   - v1.0-beta
+      //   - v1.0-beta1.1
+      //   - v1.0-beta-11
+      // won't match:
+      //   - v1.0beta
+      //   - v1.0-beta1b
+      let isBetaRe = /(\b|_)(preview|rc|beta|alpha)(\d+)(\b|_)/;
+      let isBeta = isBetaRe.test(rel.name);
+      if (isBeta) {
+        rel.channel = 'beta';
+      } else {
+        rel.channel = 'stable';
+      }
+    }
+
     if (all.download) {
       rel.download = all.download.replace(/{{ download }}/, rel.download);
     }
-  });
+  }
 
   all.oses = Object.keys(supported.oses).filter(function (name) {
     return maps.oses[name];

--- a/_webi/normalize.js
+++ b/_webi/normalize.js
@@ -66,6 +66,7 @@ arches.forEach(function (name) {
 });
 
 function normalize(all) {
+  /* jshint maxcomplexity:26 */
   var supported = {
     oses: {},
     arches: {},
@@ -73,17 +74,27 @@ function normalize(all) {
   };
 
   for (let rel of all.releases) {
-    /* jshint maxcomplexity:25 */
     rel.version = rel.version.replace(/^v/i, '');
+
     if (!rel.name) {
       rel.name = rel.download.replace(/.*\//, '');
     }
+
     if (!rel.os) {
-      rel.os =
-        Object.keys(osMap).find(function (regKey) {
-          return osMap[regKey].test(rel.name || rel.download);
-        }) || 'unknown';
+      rel.os = 'unknown';
+
+      let osNames = Object.keys(osMap);
+      for (let osName of osNames) {
+        let relName = rel.name || rel.download;
+        let osRegExp = osMap[osName];
+        let matches = osRegExp.test(relName);
+        if (matches) {
+          rel.os = osName;
+          break;
+        }
+      }
     }
+
     // Hacky-doo for musl
     // TODO 'libc' some sort of glibc vs musl tag?
     if (!rel._musl_native) {


### PR DESCRIPTION
Re: #696 (see comment about `-rc`)

## Problem

The old default behavior was that if something was _NOT_ tagged as _prerelease_ then it was tagged as _stable_ (`cmake`, `powershell`, etc).

## Solution

This new behavior will consider the name as well:

- if the release channel has NOT _already_ been tagged
- and the release matches similar to `(+.-_)(preview|beta|rc|alpha)(0-9)(+.-_)`
- tag it as `beta`
- otherwise tag it as `stable`

## What could break?

Since this merely delays the `beta` check until later, and no package names conflict with the pattern... hopefully nothing!

Just like some tools start out at version v0.0.1, it's possible we have **something that currently is _always_ beta** because no "stable" release has ever been made... I don't know what would happen in that case.

### Base64 Hashes

In releases with a **base64** tag, it's possible that something like `eGz-rc1F`, of which `-rc1` would match.

I think all our package hashes use hex.

### Package Names

Possible mismatches by tool name:

```sh
ls | rg '(preview|beta|rc|alpha)'
```
```text
arc/       # safe - begins with a letter a-rc
archiver/  # safe - has letters before and after a-rc-hiver
rclone/    # safe - has letters after rc-lone
```

Any program that radically defies these conventions - such as a program with the actual name of `rc++` or `alpha4` or `beta-mail` or `image-preview` - would simply need to be tagged manually rather than automomatically.