### PR TITLE
feat: add rudimentry --list and --info flags + minor cleanup

### DIFF
--- a/_common/github.js
+++ b/_common/github.js
@@ -3,8 +3,7 @@
 require('dotenv').config();
 
 /**
- * Gets the releases for 'ripgrep'. This function could be trimmed down and made
- * for use with any github release.
+ * Lists GitHub Releases (w/ uploaded assets)
  *
  * @param request
  * @param {string} owner

--- a/_webi/bootstrap.sh
+++ b/_webi/bootstrap.sh
@@ -42,8 +42,11 @@ set -u
 
 __webi_main() {
 
-    export WEBI_TIMESTAMP="\$(date +%F_%H-%M-%S)"
-    export _webi_tmp="\${_webi_tmp:-\$(mktemp -d -t webi-\$WEBI_TIMESTAMP.XXXXXXXX)}"
+    my_date="\$(date +%F_%H-%M-%S)"
+    export WEBI_TIMESTAMP="\${my_date}"
+    export _webi_tmp="\${_webi_tmp:-\$(
+        mktemp -d -t "webi-\$WEBI_TIMESTAMP.XXXXXXXX"
+    )}"
 
     if [ -n "\${_WEBI_PARENT:-}" ]; then
         export _WEBI_CHILD=true
@@ -90,8 +93,10 @@ __webi_main() {
     ##
 
     set +e
-    export WEBI_CURL="\$(command -v curl)"
-    export WEBI_WGET="\$(command -v wget)"
+    WEBI_CURL="\$(command -v curl)"
+    export WEBI_URL
+    WEBI_WGET="\$(command -v wget)"
+    export WEBI_WGET
     set -e
 
     my_libc=''
@@ -100,8 +105,15 @@ __webi_main() {
     fi
 
     export WEBI_HOST="\${WEBI_HOST:-https://webinstall.dev}"
-    export WEBI_UA="\$(uname -s)/\$(uname -r) \$(uname -m)/unknown\${my_libc}"
 
+    # ex: Darwin or Linux
+    my_sys="\$(uname -s)"
+    # ex: 22.6.0
+    my_rev="\$(uname -r)"
+    # ex: arm64
+    my_machine="\$(uname -m)"
+
+    export WEBI_UA="\${my_sys}/\${my_rev} \${my_machine}/unknown \${my_libc}"
 
     webinstall() {
 
@@ -112,7 +124,10 @@ __webi_main() {
             exit 1
         fi
 
-        export WEBI_BOOT="\$(mktemp -d -t "\$my_package-bootstrap.\$WEBI_TIMESTAMP.XXXXXXXX")"
+        WEBI_BOOT="\$(
+            mktemp -d -t "\$my_package-bootstrap.\$WEBI_TIMESTAMP.XXXXXXXX"
+        )"
+        export WEBI_BOOT
 
         my_installer_url="\$WEBI_HOST/api/installers/\$my_package.sh?formats=\$my_ext"
         if [ -n "\$WEBI_CURL" ]; then

--- a/_webi/releases.js
+++ b/_webi/releases.js
@@ -108,7 +108,7 @@ Releases.renderBash = async function (
               )
               .replace(
                 /^\s*#?WEBI_VERSION=.*/m,
-                'WEBI_VERSION=' + JSON.stringify(rel.version),
+                "WEBI_VERSION='" + rel.version + "'",
               )
               .replace(/^\s*#?WEBI_MAJOR=.*/m, 'WEBI_MAJOR=' + v.major)
               .replace(/^\s*#?WEBI_MINOR=.*/m, 'WEBI_MINOR=' + v.minor)

--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -560,7 +560,13 @@ __bootstrap_webi() {
 
         pkg_cmd_name="${pkg_cmd_name:-$PKG_NAME}"
 
-        if [ -n "$WEBI_SINGLE" ]; then
+        pkg_no_exec="${pkg_no_exec:-}"
+
+        if [ -n "${pkg_no_exec}" ]; then
+            pkg_dst_cmd="${pkg_dst}"
+            pkg_src="${pkg_dst}"
+            pkg_src_cmd="${pkg_dst}"
+        elif [ -n "${WEBI_SINGLE}" ]; then
             pkg_dst_cmd="${pkg_dst_cmd:-$HOME/.local/bin/$pkg_cmd_name}"
             pkg_dst="$pkg_dst_cmd"
 
@@ -598,7 +604,9 @@ __bootstrap_webi() {
 
         webi_link
 
-        _webi_enable_exec
+        if test -z "${pkg_no_exec}"; then
+            _webi_enable_exec
+        fi
         (
             cd "$WEBI_TMP"
             if [ -n "$(command -v pkg_post_install)" ]; then pkg_post_install; else webi_post_install; fi

--- a/gh/README.md
+++ b/gh/README.md
@@ -9,7 +9,8 @@ To update or switch versions, run `webi gh@stable` (or `@v1`, `@beta`, etc).
 
 ### Files
 
-These are the files / directories that are created and/or modified with this install:
+These are the files / directories that are created and/or modified with this
+install:
 
 ```text
 ~/.config/envman/PATH.env


### PR DESCRIPTION
Re: #698, #708 

Also:
- [x] lint & fmt
- [x] unexpand $HOME in printed output
- [x] guard xattr 

## --list

```sh
webi --list
```

```text
[warn] the format of --list output may change

atomicparsley
awless
archiver
# ...
watchexec
zoxide
yq
```

## --info

```sh
webi --info ssh-pubkey
webi --info node
```

```text
'ssh-pubkey' is a special case that does not have releases
```

```json5
// Stable 'node' releases:
[
  {
    "name": "node-v20.9.0-aix-ppc64.tar.gz",
    "version": "20.9.0",
    "lts": true,
    "channel": "stable",
    "date": "2023-10-24",
    "os": "aix",
    "arch": "ppc64",
    "ext": "tar.gz",
    "download": "https://nodejs.org/download/release/v20.9.0/node-v20.9.0-aix-ppc64.tar.gz"
  }
]
```