### PR TITLE
style+lint: simplify `test`s to use exit code & file size rather than output/contents

### DIFF
--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -78,7 +78,7 @@ __bootstrap_webi() {
             return 0
         fi
 
-        if [ -n "$(command -v pkg_format_cmd_version)" ]; then
+        if command -v pkg_format_cmd_version > /dev/null; then
             my_versioned_name="'$(pkg_format_cmd_version "$WEBI_VERSION")'"
         else
             my_versioned_name="'$pkg_cmd_name v$WEBI_VERSION'"
@@ -88,14 +88,13 @@ __bootstrap_webi() {
     }
 
     # Update symlinks as per $HOME/.local/opt and $HOME/.local/bin install paths.
-    # shellcheck disable=2120
     webi_link() {
-        if [ -n "$(command -v pkg_link)" ]; then
+        if command -v pkg_link > /dev/null; then
             pkg_link
             return 0
         fi
 
-        if [ -n "$WEBI_SINGLE" ] || [ "single" = "${1-}" ]; then
+        if test -n "${WEBI_SINGLE}"; then
             rm -rf "$pkg_dst_cmd"
             ln -s "$pkg_src_cmd" "$pkg_dst_cmd"
         else
@@ -489,7 +488,7 @@ __bootstrap_webi() {
     }
 
     _webi_enable_exec() {
-        if [ -n "$(command -v spctl)" ] && [ -n "$(command -v xattr)" ]; then
+        if command -v spctl > /dev/null && command -v xattr > /dev/null; then
             # note: some packages contain files that cannot be affected by xattr
             xattr -r -d com.apple.quarantine "$pkg_src" || true
             return 0
@@ -585,7 +584,7 @@ __bootstrap_webi() {
         # shellcheck disable=SC2034 # used in ${WEBI_PKG}/install.sh
         pkg_dst_bin="$(dirname "$pkg_dst_cmd")"
 
-        if [ -n "$(command -v pkg_pre_install)" ]; then pkg_pre_install; else webi_pre_install; fi
+        if command -v pkg_pre_install > /dev/null; then pkg_pre_install; else webi_pre_install; fi
 
         (
             cd "$WEBI_TMP"
@@ -609,12 +608,12 @@ __bootstrap_webi() {
         fi
         (
             cd "$WEBI_TMP"
-            if [ -n "$(command -v pkg_post_install)" ]; then pkg_post_install; else webi_post_install; fi
+            if command -v pkg_post_install > /dev/null; then pkg_post_install; else webi_post_install; fi
         )
 
         (
             cd "$WEBI_TMP"
-            if [ -n "$(command -v pkg_done_message)" ]; then pkg_done_message; else _webi_done_message; fi
+            if command -v pkg_done_message > /dev/null; then pkg_done_message; else _webi_done_message; fi
         )
 
         echo ""
@@ -622,7 +621,7 @@ __bootstrap_webi() {
 
     webi_path_add "$HOME/.local/bin"
     if [ -z "${_WEBI_CHILD-}" ] && [ -f "$_webi_tmp/.PATH.env" ]; then
-        if [ -n "$(cat "$_webi_tmp/.PATH.env")" ]; then
+        if test -s "$_webi_tmp/.PATH.env"; then
             printf 'PATH.env updated with:\n'
             sort -u "$_webi_tmp/.PATH.env" | while read -r my_new_path; do
                 echo "        ${my_new_path}"

--- a/git/install.sh
+++ b/git/install.sh
@@ -4,20 +4,21 @@ set -u
 
 __init_git() {
 
-    if [ -z "$(command -v git)" ]; then
-        if [ "Darwin" = "$(uname -s)" ]; then
-            echo >&2 "Error: 'git' not found. You may have to re-install 'git' on Mac after every major update."
-            echo >&2 "       for example, try: xcode-select --install"
-            # sudo xcodebuild -license accept
-        else
-            echo >&2 "Error: to install 'git' on Linux use the built-in package manager."
-            echo >&2 "       for example, try: sudo apt install -y git"
-        fi
-        exit 1
-    else
+    if command -v git > /dev/null; then
         echo "'git' already installed"
+        return 0
     fi
 
+    if [ "Darwin" = "$(uname -s)" ]; then
+        echo >&2 "Error: 'git' not found. You may have to re-install 'git' on Mac after every major update."
+        echo >&2 "       for example, try: xcode-select --install"
+        # sudo xcodebuild -license accept
+    else
+        echo >&2 "Error: to install 'git' on Linux use the built-in package manager."
+        echo >&2 "       for example, try: sudo apt install -y git"
+    fi
+
+    exit 1
 }
 
 __init_git

--- a/pyenv/install.sh
+++ b/pyenv/install.sh
@@ -17,7 +17,7 @@ __init_pyenv() {
         } >> ~/.bashrc
     fi
 
-    if [ -n "$(command -v zsh)" ]; then
+    if command -v zsh > /dev/null; then
         touch ~/.zshrc
         if ! grep -q 'pyenv init' ~/.zshrc; then
             {
@@ -31,7 +31,7 @@ __init_pyenv() {
         fi
     fi
 
-    if [ -n "$(command -v fish)" ]; then
+    if command -v fish > /dev/null; then
         mkdir -p ~/.config/fish
         touch ~/.config/fish/config.fish
         if ! grep -q 'pyenv init' ~/.config/fish/config.fish; then

--- a/setcap-netbind/setcap-netbind.sh
+++ b/setcap-netbind/setcap-netbind.sh
@@ -5,13 +5,13 @@ set -u
 main() {
     my_bin="${1}"
     # ex: node
-    if [ -z "$(command -v "${my_bin}")" ]; then
+    if ! command -v "${my_bin}" > /dev/null; then
         echo "setcap-netbind: '${my_bin}' not found"
         exit 1
     fi
 
     my_sudo=""
-    if [ -n "$(command -v sudo)" ]; then
+    if command -v sudo > /dev/null; then
         my_sudo=sudo
     fi
 

--- a/sudo/install.sh
+++ b/sudo/install.sh
@@ -4,14 +4,20 @@ set -u
 
 __init_sudo() {
 
-    if [ -z "$(command -v sudo)" ]; then
-        echo >&2 "Error: on Linux and BSD you should install sudo via the native package manager"
-        echo >&2 "       for example: apt install -y sudo"
-        exit 1
-    else
+    if command -v sudo > /dev/null; then
         echo "'sudo' already installed"
+        exit 0
     fi
 
+    echo >&2 "Error: on Linux & BSD use the native package manager to install sudo:"
+    echo >&2 "    For Ubuntu / Debian:"
+    echo >&2 "       apt install -y sudo"
+    echo >&2 ""
+    echo >&2 "    For Alpine / Docker:"
+    echo >&2 "       apk add sudo"
+    echo >&2 ""
+
+    exit 1
 }
 
 __init_sudo

--- a/vim-beyondcode/install.sh
+++ b/vim-beyondcode/install.sh
@@ -22,7 +22,7 @@ __init_vim_beyondcode() {
         nerdfont \
         vim-devicons
 
-    if [ -n "$(command -v go)" ]; then
+    if command -v go > /dev/null; then
         "$HOME/.local/bin/webi" vim-go
     fi
     # done

--- a/vim-prettier/install.sh
+++ b/vim-prettier/install.sh
@@ -8,7 +8,7 @@ __init_vim_prettier() {
     rm -rf "$HOME/.vim/pack/plugins/start/vim-prettier"
     git clone --depth=1 https://github.com/prettier/vim-prettier.git "$HOME/.vim/pack/plugins/start/vim-prettier"
 
-    if [ -z "$(command -v node)" ]; then
+    if ! command -v node > /dev/null; then
         export PATH="$HOME/.local/opt/node/bin:$HOME/.local/bin:${PATH}"
         "$HOME/.local/bin/webi" node
     fi

--- a/vim-shfmt/install.sh
+++ b/vim-shfmt/install.sh
@@ -9,10 +9,10 @@ __init_vim_shfmt() {
     git clone --depth=1 https://github.com/z0mbix/vim-shfmt.git "$HOME/.vim/pack/plugins/start/vim-shfmt"
 
     export PATH="$HOME/.local/bin:${PATH}"
-    if [ -z "$(command -v shfmt)" ]; then
+    if ! command -v shfmt > /dev/null; then
         "$HOME/.local/bin/webi" shfmt
     fi
-    if [ -z "$(command -v shellcheck)" ]; then
+    if ! command -v shellcheck > /dev/null; then
         "$HOME/.local/bin/webi" shellcheck
     fi
 


### PR DESCRIPTION
Cleaning up a few things I've found along the way while preparing #718.

- `[ -n "$(command -v foo)"]` => `command -v foo > /dev/null`
- `[ -n "$(cat ./foo.txt)" ]` => `test -s ./foo.txt`
- `echo $(foo) | cut -d' ' -f2` => `foo | tr -s ' ' | cut -d' ' -f2`

The number and complexity of these changes were right in that middling number where I decided not to automate it, but I have triple checked each line of change to make sue the `-z` vs `-n` and `!` were all transitioned correctly.