### PR TITLE
style+lint: `webi_download` should always use 2-3 args

### DIFF
--- a/git-config-gpg/install.sh
+++ b/git-config-gpg/install.sh
@@ -6,7 +6,9 @@ __install_git_gpg_init() {
     MY_CMD="git-config-gpg"
 
     rm -f "$HOME/.local/bin/$MY_CMD"
-    webi_download "$WEBI_HOST/packages/$MY_CMD/$MY_CMD.sh" "$HOME/.local/bin/$MY_CMD"
+    webi_download \
+        "$WEBI_HOST/packages/$MY_CMD/$MY_CMD.sh" \
+        "$HOME/.local/bin/$MY_CMD"
     chmod a+x "$HOME/.local/bin/$MY_CMD"
 }
 

--- a/gpg-pubkey/install.sh
+++ b/gpg-pubkey/install.sh
@@ -6,7 +6,9 @@ __install_gpg_pubkey() {
     MY_CMD="gpg-pubkey"
 
     rm -f "$HOME/.local/bin/$MY_CMD"
-    webi_download "$WEBI_HOST/packages/$MY_CMD/$MY_CMD.sh" "$HOME/.local/bin/$MY_CMD"
+    webi_download \
+        "$WEBI_HOST/packages/$MY_CMD/$MY_CMD.sh" \
+        "$HOME/.local/bin/$MY_CMD"
     chmod a+x "$HOME/.local/bin/$MY_CMD"
 }
 
@@ -15,7 +17,9 @@ __install_gpg_pubkey_id() {
     MY_SUBCMD="gpg-pubkey-id"
 
     rm -f "$HOME/.local/bin/$MY_SUBCMD"
-    webi_download "$WEBI_HOST/packages/$MY_CMD/$MY_SUBCMD.sh" "$HOME/.local/bin/$MY_SUBCMD"
+    webi_download \
+        "$WEBI_HOST/packages/$MY_CMD/$MY_SUBCMD.sh" \
+        "$HOME/.local/bin/$MY_SUBCMD"
     chmod a+x "$HOME/.local/bin/$MY_SUBCMD"
 }
 

--- a/gpg/install.sh
+++ b/gpg/install.sh
@@ -12,7 +12,9 @@ _install_gpg() {
 
     # Download the latest LTS
     #curl -fsSL -o ~/Downloads/webi/GnuPG-2.2.32.dmg 'https://sourceforge.net/projects/gpgosx/files/GnuPG-2.2.32.dmg/download'
-    webi_download
+    webi_download \
+        "${WEBI_PKG_URL}" \
+        "${WEBI_PKG_PATH}/${WEBI_PKG_FILE}"
     chmod a-w "${WEBI_PKG_DOWNLOAD}"
 
     # Mount the DMG in /Volumes

--- a/iterm2/install.sh
+++ b/iterm2/install.sh
@@ -16,7 +16,9 @@ _install_iterm2() {
         exit 1
     fi
 
-    webi_download
+    webi_download \
+        "${WEBI_PKG_URL}" \
+        "${WEBI_PKG_PATH}/${WEBI_PKG_FILE}"
     webi_extract
 
     if [ ! -d "${WEBI_TMP}/iTerm.app" ]; then

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -3,7 +3,9 @@ set -e
 set -u
 
 main() {
-    webi_download
+    webi_download \
+        "${WEBI_PKG_URL}" \
+        "${WEBI_PKG_PATH}/${WEBI_PKG_FILE}"
 
     (
         cd ~/Downloads/webi

--- a/myip/install.sh
+++ b/myip/install.sh
@@ -5,7 +5,9 @@ set -u
 __init_myip() {
 
     rm -f "$HOME/.local/bin/myip"
-    webi_download "$WEBI_HOST/packages/myip/myip.sh" "$HOME/.local/bin/myip"
+    webi_download \
+        "$WEBI_HOST/packages/myip/myip.sh" \
+        "$HOME/.local/bin/myip"
     chmod a+x "$HOME/.local/bin/myip"
 
     "$HOME/.local/bin/myip"

--- a/vps-utils/install.sh
+++ b/vps-utils/install.sh
@@ -5,9 +5,15 @@ set -u
 __init_vps_utils() {
 
     rm -f "$HOME/.local/bin/myip" "$HOME/.local/bin/vps-myip" "$HOME/.local/bin/vps-addswap" "$HOME/.local/bin/cap-net-bind"
-    webi_download "$WEBI_HOST/packages/vps-utils/cap-net-bind.sh" "$HOME/.local/bin/cap-net-bind"
-    webi_download "$WEBI_HOST/packages/vps-utils/vps-addswap.sh" "$HOME/.local/bin/vps-addswap"
-    webi_download "$WEBI_HOST/packages/myip/myip.sh" "$HOME/.local/bin/myip"
+    webi_download \
+        "$WEBI_HOST/packages/vps-utils/cap-net-bind.sh" \
+        "$HOME/.local/bin/cap-net-bind"
+    webi_download \
+        "$WEBI_HOST/packages/vps-utils/vps-addswap.sh" \
+        "$HOME/.local/bin/vps-addswap"
+    webi_download \
+        "$WEBI_HOST/packages/myip/myip.sh" \
+        "$HOME/.local/bin/myip"
     ln -s "$HOME/.local/bin/myip" "$HOME/.local/bin/vps-myip"
     chmod a+x "$HOME/.local/bin/cap-net-bind"
     chmod a+x "$HOME/.local/bin/myip"


### PR DESCRIPTION
Simplifying the `webi_download` function and using it consintently.
- separates error check
- easier to grok
- easier to `grep -A 2`