### PR TITLE
minor cleanup and fixes (discovered during #718)

### DIFF
--- a/_webi/template.ps1
+++ b/_webi/template.ps1
@@ -84,27 +84,31 @@ function webi_path_add($pathname) {
         }
     }
 
-    if (-Not $in_session_path) {
-        $my_cmd = 'PATH ' + "$pathname" + ';%PATH%'
-        $my_pwsh = '$Env:Path = "' + "$pathname" + ';$Env:Path"'
-
-        Write-Host ''
-        Write-Host '**********************************' -ForegroundColor red -BackgroundColor white
-        Write-Host '*      IMPORTANT -- READ ME      *' -ForegroundColor red -BackgroundColor white
-        Write-Host '*  (run the PATH command below)  *' -ForegroundColor red -BackgroundColor white
-        Write-Host '**********************************' -ForegroundColor red -BackgroundColor white
-        Write-Host ''
-        Write-Output ""
-        Write-Output "Copy, paste, and run the appropriate command to update your PATH:"
-        Write-Output "(or close and reopen the terminal, or reboot)"
-        Write-Output ""
-        Write-Output "cmd.exe:"
-        Write-Output "    $my_cmd"
-        Write-Output ""
-        Write-Output "PowerShell:"
-        Write-Output "    $my_pwsh"
-        Write-Output ""
+    if (-Not ($in_session_path)) {
+        webi_path_add_followup $pathname
     }
+}
+
+function webi_path_add_followup($pathname) {
+    $my_cmd = 'PATH ' + "$pathname" + ';%PATH%'
+    $my_pwsh = '$Env:Path = "' + "$pathname" + ';$Env:Path"'
+
+    Write-Host ''
+    Write-Host '**********************************' -ForegroundColor yellow -BackgroundColor black
+    Write-Host '*      IMPORTANT -- READ ME      *' -ForegroundColor yellow -BackgroundColor black
+    Write-Host '*  (run the PATH command below)  *' -ForegroundColor yellow -BackgroundColor black
+    Write-Host '**********************************' -ForegroundColor yellow -BackgroundColor black
+    Write-Host ''
+    Write-Output ""
+    Write-Output "Copy, paste, and run the appropriate command to update your PATH:"
+    Write-Output "(or close and reopen the terminal, or reboot)"
+    Write-Output ""
+    Write-Output "cmd.exe:"
+    Write-Host "    $my_cmd" -ForegroundColor yellow -BackgroundColor black
+    Write-Output ""
+    Write-Output "PowerShell:"
+    Write-Host "    $my_pwsh" -ForegroundColor yellow -BackgroundColor black
+    Write-Output ""
 }
 
 #$has_local_bin = echo "$Env:PATH" | Select-String -Pattern '\.local.bin'

--- a/xcaddy/install.ps1
+++ b/xcaddy/install.ps1
@@ -23,6 +23,12 @@ $pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 Write-Output "Checking for Go compiler..."
 IF (-Not (Get-Command -Name "go" -ErrorAction Silent)) {
     & "$Env:USERPROFILE\.local\bin\webi-pwsh.ps1" go
+    $Env:Path = "$HOME\.local\opt\go\bin;$Env:Path"
+    $Env:Path = "$HOME\go\bin;$Env:Path"
+    [System.Environment]::SetEnvironmentVariable(
+        "Path",
+        $env:Path,
+        [System.EnvironmentVariableTarget]::User)
 }
 
 # Fetch archive

--- a/xcaddy/install.ps1
+++ b/xcaddy/install.ps1
@@ -21,7 +21,7 @@ $pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch Go compiler
 Write-Output "Checking for Go compiler..."
-IF (-not (Test-Path "$Env:USERPROFILE\.local\opt\go")) {
+IF (-Not (Get-Command -Name "go" -ErrorAction Silent)) {
     & "$Env:USERPROFILE\.local\bin\webi-pwsh.ps1" go
 }
 


### PR DESCRIPTION
While I was doing #718 I discovered that:
- xcaddy should not rely on a specific `go` path
- PowerShell should also reserve red text for errors