### PR TITLE
feat+fix: explicit libc detection for musl, gnu, libc/none/static

### DIFF
--- a/_webi/bootstrap.sh
+++ b/_webi/bootstrap.sh
@@ -14,9 +14,18 @@ __install_webi() {
     #WEBI_HOST=https://webinstall.dev
     export WEBI_HOST
 
+    my_libc=''
+    if ldd /bin/ls 2> /dev/null | grep -q 'musl' 2> /dev/null; then
+        my_libc='musl'
+    elif uname -o | grep -q 'GNU' || uname -s | grep -q 'Linux'; then
+        my_libc='gnu'
+    else
+        my_libc='libc'
+    fi
+
     if test -z "$WEBI_WELCOME"; then
         echo ""
-        printf "Thanks for using webi to install '\e[32m%s\e[0m' on '\e[33m%s/%s\e[0m'.\n" "${WEBI_PKG-}" "$(uname -s)/$(uname -r)" "$(uname -m)"
+        printf "Thanks for using webi to install '\e[32m%s\e[0m' on '\e[33m%s (%s) %s\e[0m'.\n" "${WEBI_PKG:-"Unknown Package"}" "$(uname -s)" "${my_libc:-"Unknown Libc"}" "$(uname -m)"
         echo "Have a problem? Experience a bug? Please let us know:"
         printf "        \e[2m\e[36mhttps://github.com/webinstall/webi-installers/issues\e[0m\n"
         echo ""
@@ -104,7 +113,11 @@ __webi_main() {
 
     my_libc=''
     if ldd /bin/ls 2> /dev/null | grep -q 'musl' 2> /dev/null; then
-        my_libc=' musl-native'
+        my_libc='musl'
+    elif uname -o | grep -q 'GNU' || uname -s | grep -q 'Linux'; then
+        my_libc='gnu'
+    else
+        my_libc='libc'
     fi
 
     export WEBI_HOST="\${WEBI_HOST:-https://webinstall.dev}"

--- a/_webi/releases.js
+++ b/_webi/releases.js
@@ -30,7 +30,7 @@ function padScript(txt) {
 Releases.renderBash = async function (
   pkgdir,
   rel,
-  { baseurl, pkg, tag, ver, os = '', arch = '', formats },
+  { baseurl, pkg, tag, ver, os = '', arch = '', libc = '', formats },
 ) {
   if (!Array.isArray(formats)) {
     formats = [];
@@ -70,6 +70,7 @@ Releases.renderBash = async function (
       .replace(/^\s*#?WEBI_HOST=.*/m, `WEBI_HOST='${baseurl}'`)
       .replace(/^\s*#?WEBI_OS=.*/m, `WEBI_OS='${os}'`)
       .replace(/^\s*#?WEBI_ARCH=.*/m, `WEBI_ARCH='${arch}'`)
+      .replace(/^\s*#?WEBI_LIBC=.*/m, `WEBI_LIBC='${libc}'`)
       .replace(/^\s*#?WEBI_TAG=.*/m, `WEBI_TAG='${tag}'`)
       .replace(
         /^\s*#?WEBI_RELEASES=.*/m,
@@ -83,6 +84,8 @@ Releases.renderBash = async function (
           rel.os +
           '&arch=' +
           rel.arch +
+          '&libc=' +
+          rel.libc +
           '&formats=' +
           formats.join(',') +
           '&pretty=true' +
@@ -143,6 +146,10 @@ Releases.renderBash = async function (
         "PKG_ARCHES='" + ((rel && rel.arches) || []).join(',') + "'",
       )
       .replace(
+        /^\s*#?PKG_LIBCS=.*/m,
+        "PKG_LIBCS='" + ((rel && rel.libcs) || []).join(',') + "'",
+      )
+      .replace(
         /^\s*#?PKG_FORMATS=.*/m,
         "PKG_FORMATS='" + ((rel && rel.formats) || []).join(',') + "'",
       )
@@ -157,7 +164,7 @@ Releases.renderBash = async function (
 Releases.renderPowerShell = async function (
   pkgdir,
   rel,
-  { baseurl, pkg, tag, ver, os, arch, formats },
+  { baseurl, pkg, tag, ver, os, arch, libc = '', formats },
 ) {
   if (!Array.isArray(formats)) {
     formats = [];
@@ -189,6 +196,10 @@ Releases.renderPowerShell = async function (
   var pkgver = pkg + '@' + ver;
   return (
     tplTxt
+      .replace(
+        /^(#)?\$Env:WEBI_LIBC\s*=.*/im,
+        "$Env:WEBI_LIBC = '" + libc + "'",
+      )
       .replace(
         /^(#)?\$Env:WEBI_HOST\s*=.*/im,
         "$Env:WEBI_HOST = '" + baseurl + "'",

--- a/_webi/serve-installer.js
+++ b/_webi/serve-installer.js
@@ -9,11 +9,28 @@ var Releases = require('./releases.js');
 // handlers caching and transformation, probably should be broken down
 var getReleases = require('./transform-releases.js');
 
-var installersDir = path.join(__dirname, '..');
-
 serveInstaller.serveInstaller = serveInstaller;
+serveInstaller.INSTALLERS_DIR = path.join(__dirname, '..');
 module.exports = serveInstaller;
 async function serveInstaller(baseurl, ua, pkg, tag, ext, formats, libc) {
+  let [rel, opts] = await serveInstaller.helper({
+    ua,
+    pkg,
+    tag,
+    formats,
+    libc,
+  });
+  Object.assign(opts, {
+    baseurl,
+  });
+
+  var pkgdir = path.join(serveInstaller.INSTALLERS_DIR, pkg);
+  if ('ps1' === ext) {
+    return Releases.renderPowerShell(pkgdir, rel, opts);
+  }
+  return Releases.renderBash(pkgdir, rel, opts);
+}
+serveInstaller.helper = async function ({ ua, pkg, tag, formats, libc }) {
   // TODO put some of this in a middleware? or common function?
 
   // TODO maybe move package/version/lts/channel detection into getReleases
@@ -76,9 +93,7 @@ async function serveInstaller(baseurl, ua, pkg, tag, ext, formats, libc) {
   let rels = await getReleases(releaseQuery);
 
   var rel = rels.releases[0];
-  var pkgdir = path.join(installersDir, pkg);
   var opts = {
-    baseurl,
     pkg: cfg.alias || pkg,
     ver,
     tag,
@@ -100,8 +115,5 @@ async function serveInstaller(baseurl, ua, pkg, tag, ext, formats, libc) {
     rel,
   );
 
-  if ('ps1' === ext) {
-    return Releases.renderPowerShell(pkgdir, rel, opts);
-  }
-  return Releases.renderBash(pkgdir, rel, opts);
-}
+  return [rel, opts];
+};

--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -8,13 +8,18 @@ __bootstrap_webi() {
 
     my_libc=''
     if ldd /bin/ls 2> /dev/null | grep -q 'musl' 2> /dev/null; then
-        my_libc=' musl-native'
+        my_libc='musl'
+    elif uname -o | grep -q 'GNU' || uname -s | grep -q 'Linux'; then
+        my_libc='gnu'
+    else
+        my_libc='libc'
     fi
 
     #WEBI_PKG=
     #PKG_NAME=
     #WEBI_OS=
     #WEBI_ARCH=
+    #WEBI_LIBC=
     #WEBI_HOST=
     #WEBI_RELEASES=
     #WEBI_CSV=
@@ -35,8 +40,9 @@ __bootstrap_webi() {
     #WEBI_PKG_PATHNAME=
     #PKG_OSES=
     #PKG_ARCHES=
+    #PKG_LIBCS=
     #PKG_FORMATS=
-    WEBI_UA="$(uname -s)/$(uname -r) $(uname -m)/unknown${my_libc}"
+    WEBI_UA="$(uname -s)/$(uname -r) $(uname -m)/unknown ${my_libc}"
     WEBI_PKG_DOWNLOAD=""
     WEBI_DOWNLOAD_DIR="${HOME}/Downloads"
     if command -v xdg-user-dir > /dev/null; then
@@ -164,15 +170,20 @@ __bootstrap_webi() {
             return 0
         fi
 
-        echo >&2 "Error: no '$PKG_NAME' release for '${WEBI_OS-}' on '$WEBI_ARCH' as one of '$WEBI_FORMATS' by the tag '${WEBI_TAG-}'"
-        echo >&2 "       '$PKG_NAME' is available for '$PKG_OSES' on '$PKG_ARCHES' as one of '$PKG_FORMATS'"
+        echo >&2 "Error: no '${PKG_NAME:-"Unknown Package"}@${WEBI_TAG:-"Unknown Tag"}' release for '${WEBI_OS:-"Unknown OS"}' (${WEBI_LIBC:-"Unknown Libc"}) on '${WEBI_ARCH:-"Unknown CPU"}' as one of '${WEBI_FORMATS:-"Unknown File Type"}'"
+        echo >&2 "       '$PKG_NAME' is available for '$PKG_OSES' ($PKG_LIBCS) on '$PKG_ARCHES' as one of '$PKG_FORMATS'"
         echo >&2 "       (check that the package name and version are correct)"
         echo >&2 ""
         my_release_url="$(
             echo "$WEBI_RELEASES" |
                 sed 's:?.*::'
         )"
+        my_release_params="$(
+            echo "$WEBI_RELEASES" |
+                sed 's:.*?:?:'
+        )"
         echo >&2 "       Double check at ${my_release_url}"
+        echo >&2 "           ${my_release_params}"
         echo >&2 ""
 
         exit 1
@@ -548,7 +559,7 @@ __bootstrap_webi() {
 
     if [ -z "${WEBI_WELCOME-}" ]; then
         echo ""
-        printf "Thanks for using webi to install '\e[32m%s\e[0m' on '\e[33m%s/%s\e[0m'.\n" "${WEBI_PKG-}" "$(uname -s)" "$(uname -m)"
+        printf "Thanks for using webi to install '\e[32m%s\e[0m' on '\e[33m%s (%s) %s\e[0m'.\n" "${WEBI_PKG:-"Unknown Package"}" "$(uname -s)" "${WEBI_LIBC:-"Unknown Libc"}" "$(uname -m)"
         echo "Have a problem? Experience a bug? Please let us know:"
         printf "        \e[2m\e[36mhttps://github.com/webinstall/webi-installers/issues\e[0m\n"
         echo ""

--- a/_webi/test.js
+++ b/_webi/test.js
@@ -66,6 +66,7 @@ Releases.get(path.join(process.cwd(), pkgdir)).then(function (all) {
   var pkgname = path.basename(pkgdir.replace(/\/$/, ''));
   var osrel = os.platform() + '-' + os.release();
   var arch = os.arch();
+  var libc = 'libc';
   var formats = ['exe', 'xz', 'tar', 'zip', 'git'];
 
   var rel;
@@ -85,6 +86,13 @@ Releases.get(path.join(process.cwd(), pkgdir)).then(function (all) {
     if (_rel.os !== '*') {
       let curOs = uaDetect.os(osrel);
       if (_rel.os !== curOs) {
+        continue;
+      }
+    }
+
+    if (_rel.libc !== 'none') {
+      let curLibc = uaDetect.libc(libc);
+      if (_rel.libc !== curLibc) {
         continue;
       }
     }
@@ -118,9 +126,15 @@ Releases.get(path.join(process.cwd(), pkgdir)).then(function (all) {
     return;
   }
 
-  rel.oses = all.oses;
-  rel.arches = all.arches;
-  rel.formats = all.formats;
+  rel = Object.assign(
+    {
+      oses: all.oses,
+      arches: all.arches,
+      libcs: all.libcs,
+      formats: all.formats,
+    },
+    rel,
+  );
 
   console.info('');
   console.info('Found release matching current os, arch, and tag:');
@@ -169,5 +183,9 @@ Releases.get(path.join(process.cwd(), pkgdir)).then(function (all) {
       console.info('\tNEEDS MANUAL TEST: powershell.exe %s', ps1File);
     }
     console.info('');
+    setTimeout(function () {
+      console.warn(`[warn] dangling event loop handle`);
+      process.exit(0);
+    }, 300).unref();
   });
 });

--- a/_webi/webi-pwsh.ps1
+++ b/_webi/webi-pwsh.ps1
@@ -28,7 +28,7 @@ IF ($my_arch -eq "AMD64") {
     }
 }
 
-$Env:WEBI_UA = "Windows/10 $my_arch"
+$Env:WEBI_UA = "Windows/10+ $my_arch msvc"
 $exename = $args[0]
 
 # Switch to userprofile
@@ -100,7 +100,7 @@ if ($exename -eq "-V" -or $exename -eq "--version" -or $exename -eq "version" -o
 
 # Fetch <whatever>.ps1
 # TODO detect formats
-$PKG_URL = "$Env:WEBI_HOST/api/installers/$exename.ps1?formats=zip,exe,tar,git"
+$PKG_URL = "$Env:WEBI_HOST/api/installers/$exename.ps1?formats=zip,exe,tar,git&libc=msvc"
 Write-Output "Downloading $PKG_URL"
 # Invoke-WebRequest -UserAgent "Windows amd64" "$PKG_URL" -OutFile ".\.local\tmp\$exename.install.ps1"
 & curl.exe -fsSL -A "$Env:WEBI_UA" "$PKG_URL" -o .\.local\tmp\$exename.install.ps1

--- a/atomicparsley/releases.js
+++ b/atomicparsley/releases.js
@@ -8,10 +8,13 @@ let targets = {
   x86win: {
     os: 'windows',
     arch: 'x86',
+    libc: 'msvc',
   },
   x64win: {
     os: 'windows',
     arch: 'amd64',
+    // https://github.com/wez/atomicparsley/issues/6#issuecomment-1364523028
+    libc: 'msvc',
   },
   x64mac: {
     os: 'macos',
@@ -20,11 +23,12 @@ let targets = {
   x64lin: {
     os: 'linux',
     arch: 'amd64',
+    libc: 'gnu',
   },
   x64musl: {
     os: 'linux',
     arch: 'amd64',
-    _musl_native: true,
+    libc: 'musl',
   },
 };
 

--- a/cmake/install.ps1
+++ b/cmake/install.ps1
@@ -8,19 +8,19 @@
 $pkg_cmd_name = "cmake"
 
 $pkg_dst_cmd = "$Env:USERPROFILE\.local\opt\cmake\bin\cmake.exe"
+$pkg_dst_bin = "$Env:USERPROFILE\.local\opt\cmake\bin"
 $pkg_dst_dir = "$Env:USERPROFILE\.local\opt\cmake"
-$pkg_dst = "$pkg_dst_cmd"
+$pkg_dst = "$pkg_dst_dir"
 
 $pkg_src_cmd = "$Env:USERPROFILE\.local\opt\cmake-v$Env:WEBI_VERSION\bin\cmake.exe"
-$pkg_src_bin = "$Env:USERPROFILE\.local\opt\cmake-v$Env:WEBI_VERSION\bin"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\cmake-v$Env:WEBI_VERSION"
-$pkg_src = "$pkg_src_cmd"
+$pkg_src = "$pkg_src_dir"
 
 New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | Out-Null
 $pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
+IF (!(Test-Path -Path "$pkg_download")) {
     Write-Output "Downloading cmake from $Env:WEBI_PKG_URL to $pkg_download"
     & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
     & Move-Item "$pkg_download.part" "$pkg_download"
@@ -49,6 +49,8 @@ IF (!(Test-Path -Path "$pkg_src_dir")) {
     Pop-Location
 }
 
-Write-Output "Copying into '$pkg_dst_cmd' from '$pkg_src_cmd'"
-Remove-Item -Path "$pkg_dst_cmd" -Recurse -ErrorAction Ignore | Out-Null
+Write-Output "Copying into '$pkg_dst' from '$pkg_src'"
+Remove-Item -Path "$pkg_dst" -Recurse -ErrorAction Ignore | Out-Null
 Copy-Item -Path "$pkg_src" -Destination "$pkg_dst" -Recurse
+webi_path_add "$pkg_dst_bin"
+& "$pkg_dst_cmd" --version

--- a/cmake/releases.js
+++ b/cmake/releases.js
@@ -6,6 +6,35 @@ var repo = 'CMake';
 
 module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
+    for (let rel of all.releases) {
+      {
+        let linuxRe = /(\b|_)(linux|gnu)(\b|_)/i;
+        let isLinux = linuxRe.test(rel.download) || linuxRe.test(rel.name);
+
+        if (isLinux) {
+          let muslRe = /(\b|_)(musl|alpine)(\b|_)/i;
+          let isMusl = muslRe.test(rel.download) || muslRe.test(rel.name);
+          if (isMusl) {
+            rel.libc = 'musl';
+          } else {
+            rel.libc = 'gnu';
+          }
+          continue;
+        }
+      }
+
+      {
+        let windowsRe = /(\b|_)(win\d*|windows\d*)(\b|_)/i;
+        let isWindows =
+          windowsRe.test(rel.download) || windowsRe.test(rel.name);
+
+        if (isWindows) {
+          rel.libc = 'msvc';
+          continue;
+        }
+      }
+    }
+
     return all;
   });
 };

--- a/node/releases.js
+++ b/node/releases.js
@@ -119,6 +119,7 @@ async function getAllReleases(request) {
         let os = osMap[osPart];
         let archPart = fileParts[1];
         let arch = archMap[archPart];
+        let libc = '';
         let pkgPart = fileParts[2];
         let pkgs = pkgMap[pkgPart];
         if (!pkgPart) {
@@ -133,13 +134,16 @@ async function getAllReleases(request) {
         if (fileParts[2] === 'musl') {
           extra = '-musl';
           muslNative = true;
+          libc = 'musl';
+        } else if (os === 'linux') {
+          libc = 'gnu';
+        }
+
+        if (osPart === 'osx') {
+          osPart = 'darwin';
         }
 
         pkgs.forEach(function (pkg) {
-          if (osPart === 'osx') {
-            osPart = 'darwin';
-          }
-
           let filename = `node-${build.version}-${osPart}-${archPart}${extra}.${pkg}`;
           if ('msi' === pkg) {
             filename = `node-${build.version}-${archPart}${extra}.${pkg}`;
@@ -156,7 +160,7 @@ async function getAllReleases(request) {
             arch: arch,
             ext: pkg,
             download: downloadUrl,
-            _musl_native: muslNative,
+            libc: libc,
           };
 
           all.releases.push(release);


### PR DESCRIPTION
re #728 

This change ended up being larger in scope than I thought.

It's definitely more of a "manually test" than "just look at the code".

## How to Test

### Comment Below with Results

### macOS, Linux, Alpine

```sh
mv ~/.local/ ~/.local.1.old/

# This should fail gracefully on Alpine
curl -sS https://next.webinstall.dev/cmake | sh

# All of these should work
curl -sS https://next.webinstall.dev/node | sh
curl -sS https://next.webinstall.dev/atomicparsley | sh
curl -sS https://next.webinstall.dev/bat | sh
curl -sS https://next.webinstall.dev/jq | sh
curl -sS https://next.webinstall.dev/yq | sh
curl -sS https://next.webinstall.dev/ffmpeg | sh

source ~/.config/envman/PATH.env

node --version
AtomicParsley --version
bat -V
jq -V
yq -V
ffmpeg -version
```

```sh
mv ~/.local/ ~/.local.2.old/

curl -sS https://next.webinstall.dev/ | sh
export WEBI_HOST='https://next.webinstall.dev'

webi cmake
webi node atomicparsley bat jq yq ffmpeg
```

### Windows

```pwsh
curl.exe -A MS https://next.webinstall.dev/cmake | powershell
curl.exe -A MS https://next.webinstall.dev/node | powershell
curl.exe -A MS https://next.webinstall.dev/atomicparsley | powershell
curl.exe -A MS https://next.webinstall.dev/bat | powershell
curl.exe -A MS https://next.webinstall.dev/jq | powershell
curl.exe -A MS https://next.webinstall.dev/yq | powershell
curl.exe -A MS https://next.webinstall.dev/ffmpeg | powershell
```

## Test Matrix

- All should correctly detect libc version
- All except ❌s are expected to install
- Everything that installs should be able to run `xxxx --version` or `xxxx --help`

✅ - should work without special considerations
🐧 - GNU build (Linux, and maybe Windows)
💪 - Musl build (must work on Alpine, may work on GNU)
🪟 - MSVC build
❌ - expected to fail early
⚡️ - no libc

|                            | Linux        | Alpine           | macOS | Windows |
| --------------- | ---------- | ------------ | ------- | --------- |
| cmake                |  🐧             |  ❌                 | ✅         | ✅             |
| node                  |   🐧             |  💪                 | ✅         | ✅             |
| AtomicParsley   |   🐧             |  💪                 | ✅         | ✅             |
| bat                     |   💪             |  💪                 | ✅         | 🪟             |
| jq                       |   ⚡️             |  ⚡️                 | ✅         | ✅             |
| yq                       |   ⚡️             |  ⚡️                 | ✅         | ✅             |
| ffmpeg               |   ⚡️             |  ⚡️                 | ✅         | ✅             |