### PR TITLE
fix(busybox): remove extraneous regex escape

### DIFF
--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -170,7 +170,7 @@ __bootstrap_webi() {
         echo >&2 ""
         my_release_url="$(
             echo "$WEBI_RELEASES" |
-                sed 's:\?.*::'
+                sed 's:?.*::'
         )"
         echo >&2 "       Double check at ${my_release_url}"
         echo >&2 ""


### PR DESCRIPTION
Those backslashes... they'll getcha!

This only affected error messages on BusyBox sed

![XKCD 1638](https://github.com/webinstall/webi-installers/assets/122831/b20e8297-d2a1-43e3-b4a1-afd519ea9c5c)

(and the backslash for the escape you thought you needed, but didn't, of course)