### PR TITLE
fix: don't switch template file name yet

### DIFF
--- a/_webi/releases.js
+++ b/_webi/releases.js
@@ -56,7 +56,7 @@ Releases.renderBash = async function (
   };
   var pkgFile = rel.filename || rel.name;
   let tplTxt = await fs.promises.readFile(
-    path.join(__dirname, 'install-package.tpl.sh'),
+    path.join(__dirname, 'template.sh'),
     'utf8',
   );
   // ex: 'node@lts' or 'node'
@@ -174,7 +174,7 @@ Releases.renderPowerShell = async function (
     };
   */
   let tplTxt = await fs.promises.readFile(
-    path.join(__dirname, 'install-package.tpl.ps1'),
+    path.join(__dirname, 'template.ps1'),
     'utf8',
   );
   var pkgver = pkg + '@' + ver;

--- a/iterm2-utils/install.sh
+++ b/iterm2-utils/install.sh
@@ -4,6 +4,8 @@ set -u
 
 __iterm2_utils() {
     curl -fsSL https://iterm2.com/shell_integration/install_shell_integration_and_utilities.sh | bash
+
+    webi_path_add ~/.iterm2/
 }
 
 __iterm2_utils


### PR DESCRIPTION
Oops! A commit with the new filenames was pulled in by mistake!

This undoes that, which shouldn't come until #736 

Live in `hotfix`.