### PR TITLE
Fix curl to support windows aliases in dev

### DIFF
--- a/_webi/curl-pipe-bootstrap.tpl.sh
+++ b/_webi/curl-pipe-bootstrap.tpl.sh
@@ -107,6 +107,8 @@ fn_wget() { (
 
     if ! $cmd_wget "${b_agent}" -c "${a_url}" -O "${a_path}"; then
         echo >&2 "    $(t_err "failed to download (wget)") '$(t_url "${a_url}")'"
+        echo >&2 "    $cmd_wget '${b_agent}' -c '${a_url}' -O '${a_path}'"
+        echo >&2 "    $(wget -V)"
         return 1
     fi
 ); }
@@ -130,6 +132,8 @@ fn_curl() { (
 
     if ! $cmd_curl -A "${b_agent}" "${a_url}" -o "${a_path}"; then
         echo >&2 "    $(t_err "failed to download (curl)") '$(t_url "${a_url}")'"
+        echo >&2 "    $cmd_curl -A '${b_agent}' '${a_url}' -o '${a_path}'"
+        echo >&2 "    $(curl -V)"
         return 1
     fi
 ); }

--- a/archiver/install.ps1
+++ b/archiver/install.ps1
@@ -2,4 +2,4 @@
 
 Write-Output "'archiver@$Env:WEBI_TAG' is an alias for 'arc@$Env:WEBI_VERSION'"
 IF ($null -eq $Env:WEBI_HOST -or $Env:WEBI_HOST -eq "") { $Env:WEBI_HOST = "https://webinstall.dev" }
-curl.exe -fsSL "$Env:WEBI_HOST/arc@$Env:WEBI_VERSION" | powershell
+curl.exe -A MS -fsSL "$Env:WEBI_HOST/arc@$Env:WEBI_VERSION" | powershell

--- a/git-gpg-init/install.ps1
+++ b/git-gpg-init/install.ps1
@@ -2,4 +2,4 @@
 
 Write-Output "'git-gpg-init@$Env:WEBI_TAG' is an alias for 'git-config-gpg@$Env:WEBI_VERSION'"
 IF ($null -eq $Env:WEBI_HOST -or $Env:WEBI_HOST -eq "") { $Env:WEBI_HOST = "https://webinstall.dev" }
-curl.exe -fsSL "$Env:WEBI_HOST/git-config-gpg@$Env:WEBI_VERSION" | powershell
+curl.exe -A MS -fsSL "$Env:WEBI_HOST/git-config-gpg@$Env:WEBI_VERSION" | powershell

--- a/gpg-pubkey/install.ps1
+++ b/gpg-pubkey/install.ps1
@@ -27,7 +27,7 @@ Set-Content -Path "$Env:USERPROFILE\.local\bin\$MY_CMD.bat" -Value "@echo off`r`
 
 $gpg_exists = Get-Command gpg 2> $null
 if (!$gpg_exists) {
-    curl.exe "$Env:WEBI_HOST/gpg" | powershell
+    curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_HOST/api/installers/gpg.ps1?formats=zip,exe,tar&libc=msvc" | powershell
     $gpg_exists = Get-Command gpg 2> $null
     if (!$gpg_exists) {
         Write-Output ""

--- a/ripgrep/install.ps1
+++ b/ripgrep/install.ps1
@@ -1,3 +1,3 @@
 Write-Output "'ripgrep@$Env:WEBI_TAG' is an alias for 'rg@$Env:WEBI_VERSION'"
 IF ($null -eq $Env:WEBI_HOST -or $Env:WEBI_HOST -eq "") { $Env:WEBI_HOST = "https://webinstall.dev" }
-curl.exe -fsSL "$Env:WEBI_HOST/rg@$Env:WEBI_VERSION" | powershell
+curl.exe -A MS -fsSL "$Env:WEBI_HOST/rg@$Env:WEBI_VERSION" | powershell

--- a/trippy/install.ps1
+++ b/trippy/install.ps1
@@ -2,4 +2,4 @@
 
 Write-Output "'trippy@$Env:WEBI_TAG' is an alias for 'trip@$Env:WEBI_VERSION'"
 IF ($null -eq $Env:WEBI_HOST -or $Env:WEBI_HOST -eq "") { $Env:WEBI_HOST = "https://webinstall.dev" }
-curl.exe -fsSL "$Env:WEBI_HOST/trip@$Env:WEBI_VERSION" | powershell
+curl.exe -A MS -fsSL "$Env:WEBI_HOST/trip@$Env:WEBI_VERSION" | powershell

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -103,7 +103,7 @@ if ($exename -eq "-V" -or $exename -eq "--version" -or $exename -eq "version" -o
 $PKG_URL = "$Env:WEBI_HOST/api/installers/$exename.ps1?formats=zip,exe,tar,git&libc=msvc"
 Write-Output "Downloading $PKG_URL"
 # Invoke-WebRequest -UserAgent "Windows amd64" "$PKG_URL" -OutFile ".\.local\tmp\$exename.install.ps1"
-& curl.exe -fsSL -A "$Env:WEBI_UA" "$PKG_URL" -o .\.local\tmp\$exename.install.ps1
+& curl.exe -A MS -fsSL -A "$Env:WEBI_UA" "$PKG_URL" -o .\.local\tmp\$exename.install.ps1
 
 # Run <whatever>.ps1
 powershell .\.local\tmp\$exename.install.ps1

--- a/zig.vim/install.ps1
+++ b/zig.vim/install.ps1
@@ -2,4 +2,4 @@
 
 Write-Output "'zig.vim@$Env:WEBI_TAG' is an alias for 'vim-zig@$Env:WEBI_VERSION'"
 IF ($null -eq $Env:WEBI_HOST -or $Env:WEBI_HOST -eq "") { $Env:WEBI_HOST = "https://webinstall.dev" }
-curl.exe -fsSL "$Env:WEBI_HOST/vim-zig@$Env:WEBI_VERSION" | powershell
+curl.exe -A MS -fsSL "$Env:WEBI_HOST/vim-zig@$Env:WEBI_VERSION" | powershell

--- a/ziglang/install.ps1
+++ b/ziglang/install.ps1
@@ -2,4 +2,4 @@
 
 Write-Output "'ziglang@$Env:WEBI_TAG' is an alias for 'zig@$Env:WEBI_VERSION'"
 IF ($null -eq $Env:WEBI_HOST -or $Env:WEBI_HOST -eq "") { $Env:WEBI_HOST = "https://webinstall.dev" }
-curl.exe -fsSL "$Env:WEBI_HOST/zig@$Env:WEBI_VERSION" | powershell
+curl.exe -A MS -fsSL "$Env:WEBI_HOST/zig@$Env:WEBI_VERSION" | powershell

--- a/zoxide/install.ps1
+++ b/zoxide/install.ps1
@@ -21,7 +21,7 @@ $pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 # Fetch archive
 IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
     Write-Output "Downloading zoxide from $Env:WEBI_PKG_URL to $pkg_download"
-    & curl.exe -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
+    & curl.exe -A MS -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
     & Move-Item "$pkg_download.part" "$pkg_download"
 }
 


### PR DESCRIPTION
Missing `-A MS` and `.ps1` for bootstrapping the os detection.

This part of a batch:
- [x] #740 
- [ ] #741 
- [ ] #739