### PR TITLE
3. feat(ssh-authorize): powershell edition for Windows

### DIFF
--- a/_webi/install-package.tpl.ps1
+++ b/_webi/install-package.tpl.ps1
@@ -1,8 +1,6 @@
 #!/usr/bin/env pwsh
 #350 check if windows user run as admin
 
-$OriginalPath = $Env:Path
-
 # this allows us to call ps1 files, which allows us to have spaces in filenames
 # ('powershell "$Env:USERPROFILE\test.ps1" foo' will fail if it has a space in
 # the path but '& "$Env:USERPROFILE\test.ps1" foo' will work even with a space)
@@ -115,7 +113,7 @@ function webi_path_add($pathname) {
     $my_pathname = $my_pathname -ireplace $my_home_re, "%USERPROFILE%"
 
     $all_user_paths = [Environment]::GetEnvironmentVariable("Path", "User")
-    $user_paths = $all_user_paths -Split (';')
+    $user_paths = "${all_user_paths}".Trim(';').Split(';')
     $exists_in_path = $false
     foreach ($user_path in $user_paths) {
         # C:\Users\me\bin => %USERPROFILE%/bin
@@ -127,42 +125,18 @@ function webi_path_add($pathname) {
         }
     }
     if (-Not $exists_in_path) {
-        $all_user_paths = $pathname + ";" + $all_user_paths
+        $all_user_paths = "${pathname};${all_user_paths}".Trim(';')
         [Environment]::SetEnvironmentVariable("Path", $all_user_paths, "User")
         $null = Sync-EnvPath
     }
 }
 
-function webi_path_add_followup($pathname) {
-    $UpdateUserPath = "`$UserPath = [Environment]::GetEnvironmentVariable('Path', 'User')"
-    $UpdateMachinePath = "`$MachinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')"
-
-    Write-Host ''
-    Write-Host '***********************************' -ForegroundColor yellow -BackgroundColor black
-    Write-Host '*      IMPORTANT -- READ ME       *' -ForegroundColor yellow -BackgroundColor black
-    Write-Host '*  (run the PATH commands below)  *' -ForegroundColor yellow -BackgroundColor black
-    Write-Host '***********************************' -ForegroundColor yellow -BackgroundColor black
-    Write-Host ''
-    Write-Host ""
-    Write-Host "Copy, paste, and run the appropriate commands to update your PATH:"
-    Write-Host ""
-    Write-Host "cmd.exe:"
-    Write-Host "    (close and reopen the terminal)" -ForegroundColor yellow -BackgroundColor black
-    Write-Host ""
-    Write-Host "PowerShell:"
-    Write-Host "    $UpdateUserPath" -ForegroundColor yellow -BackgroundColor black
-    Write-Host "    $UpdateMachinePath" -ForegroundColor yellow -BackgroundColor black
-    Write-Host "    `$Env:Path = `"`${UserPath};`${MachinePath}`"" -ForegroundColor yellow -BackgroundColor black
-    Write-Host "    (or close and reopen the terminal, or reboot)"
-    Write-Host ""
-}
-
 function Sync-EnvPath {
-    $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
-    $MachinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
-    $null = [Environment]::SetEnvironmentVariable("Path", "${UserPath};${MachinePath}")
+    $UserPath = [Environment]::GetEnvironmentVariable("Path", "User").Trim(';')
+    $MachinePath = [Environment]::GetEnvironmentVariable("Path", "Machine").Trim(';')
     $Env:Path = "${UserPath};${MachinePath}"
-    "${UserPath};${MachinePath}"
+    [Environment]::SetEnvironmentVariable("Path", $Env:Path)
+    $Env:Path
 }
 
 $Env:WEBI_UA = Get-UserAgent
@@ -176,11 +150,6 @@ webi_path_add ~/.local/bin
 # {{ installer }}
 
 webi_path_add ~/.local/bin
-
-$CurrentPath = Sync-EnvPath
-IF ($OriginalPath -ne $CurrentPath) {
-    webi_path_add_followup
-}
 
 # Done
 Pop-Location

--- a/_webi/install-package.tpl.ps1
+++ b/_webi/install-package.tpl.ps1
@@ -3,18 +3,6 @@
 
 $OriginalPath = $Env:Path
 
-function Confirm-IsElevated {
-    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
-    $p = New-Object System.Security.Principal.WindowsPrincipal($id)
-    if ($p.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator))
-    { Write-Output $true }
-    else
-    { Write-Output $false }
-}
-
-if (Confirm-IsElevated)
-{ throw "Webi MUST NOT be run with elevated privileges. Please run again as a normal user, NOT as administrator." }
-
 # this allows us to call ps1 files, which allows us to have spaces in filenames
 # ('powershell "$Env:USERPROFILE\test.ps1" foo' will fail if it has a space in
 # the path but '& "$Env:USERPROFILE\test.ps1" foo' will work even with a space)

--- a/ssh-authorize/README.md
+++ b/ssh-authorize/README.md
@@ -14,6 +14,9 @@ install:
 ~/.config/envman/PATH.env
 ~/.local/bin/ssh-authorize
 ~/.ssh/authorized_keys
+
+# Windows
+$Env:ProgramData\ssh\administrators_authorized_keys
 ```
 
 ## Cheat Sheet
@@ -48,7 +51,7 @@ LOCAL IDENTIFY FILES
     /home/app/.ssh/id_rsa.pub
 ```
 
-### How to Add Manually
+### How to Add SSH Public Keys Manually
 
 For the simplest case it seems almost silly to even have a utility for this:
 
@@ -64,9 +67,20 @@ curl https://github.com/me.keys >> ~/.ssh/authorized_keys
 
 but... tedium, error checking... things are never as simple as they seem.
 
-### But really, why?
+### How to use on Windows
+
+You will need to run from an Elevated PowerShell, or use the
+[Windows sudo](../sudo/).
+
+### Why use ssh-authorize at all?
+
+At first blush it seems easy enough to just add download or add files to
+`~/.ssh/authorized_keys`, but there are complexities (especially on _Windows_).
+
+This just adds a layer of convenience, and a few benefits:
 
 - handles arbitrary files and URLs, failing bad key lines
-- sets permissions correctly, even if they were incorrect
+- sets permissions correctly, even if they were incorrect \
+  (which almost no one will to do successfully by hand on Windows on the first try)
 - works `curl` (macOS, Ubuntu) or `wget` (Docker, Alpine)
 - enforces `https`

--- a/ssh-authorize/install.ps1
+++ b/ssh-authorize/install.ps1
@@ -1,0 +1,28 @@
+#!/usr/bin/env pwsh
+
+$ErrorActionPreference = 'stop'
+
+function Install-WebiHostedScript () {
+    Param(
+        [string]$Package,
+        [string]$ScriptName
+    )
+    $PwshName = "_${ScriptName}.ps1"
+    $PwshUrl = "${Env:WEBI_HOST}/packages/${Package}/${ScriptName}.ps1"
+    $PwshPath = "$HOME\.local\bin\${PwshName}"
+    $OldPath = "$HOME\.local\bin\${ScriptName}.ps1"
+
+    $BatPath = "$HOME\.local\bin\${ScriptName}.bat"
+    $PwshExec = "powershell -ExecutionPolicy Bypass"
+    $Bat = "@echo off`r`n$PwshExec %USERPROFILE%\.local\bin\${PwshName} %*"
+
+    Invoke-DownloadUrl -Force -URL $PwshUrl -Path $PwshPath
+    Set-Content -Path $BatPath -Value $Bat
+    Write-Host "    Created alias ${BatPath}"
+    Write-Host "      to run ${PwshPath}"
+
+    # fix for old installs
+    Remove-Item -Path $OldPath -Force -ErrorAction Ignore
+}
+
+Install-WebiHostedScript -Package "ssh-authorize" -ScriptName "ssh-authorize"

--- a/ssh-authorize/ssh-authorize.ps1
+++ b/ssh-authorize/ssh-authorize.ps1
@@ -1,0 +1,260 @@
+#!/usr/bin/env pwsh
+
+# set -e
+$ErrorActionPreference = "Stop"
+
+# set -x
+#Set-PSDebug -Trace 2
+#$VerbosePreference="Continue"
+
+$AdminAuthorizedKeys = "${Env:ProgramData}\ssh\administrators_authorized_keys"
+
+function Repair-AuthorizedKeyPermission {
+    Write-Verbose "Setting ssh file permissions ..."
+    Repair-AdminAuthorizedKeyPermission
+    Repair-UserAuthorizedKeyPermission
+    Write-Verbose "All permissions set."
+}
+
+function Repair-AdminAuthorizedKeyPermission {
+    Write-Verbose "Setting permissions on `$Env:ProgramData\ssh\ ..."
+
+    # add self for the purposes of this script
+    icacls.exe "${Env:ProgramData}\ssh\" `
+        /t /grant "${Env:UserName}:(F)"
+
+    # Create whitelist for 'sudoer' authorized keys
+    IF (-Not (Test-Path -Path $AdminAuthorizedKeys)) {
+        $null = New-Item -Path $AdminAuthorizedKeys -Type 'File'
+    }
+
+    # chmod -R go-rwx /etc/ssh/
+    # (remove inherited acls)
+    icacls.exe "${Env:ProgramData}\ssh\" /t /inheritance:r
+    icacls.exe "${Env:ProgramData}\ssh\" /remove "Authenticated Users"
+
+    # chown -R root:wheel
+    # (add admins and system back with perms to inherit new files)
+    icacls.exe "${Env:ProgramData}\ssh\" `
+        /grant "Administrators:(OI)(CI)(F)" `
+        /grant "SYSTEM:(OI)(CI)(F)"
+    icacls.exe $AdminAuthorizedKeys `
+        /grant "Administrators:(F)" `
+        /grant "SYSTEM:(F)"
+    icacls.exe "${Env:ProgramData}\ssh\logs" `
+        /grant "Administrators:(F)" `
+        /grant "SYSTEM:(F)"
+
+    # (explicitly add public access to special files)
+    icacls.exe "${Env:ProgramData}\ssh\" `
+        /grant "Authenticated Users:(RX)"
+    icacls.exe "${Env:ProgramData}\ssh\sshd.pid" `
+        /grant "Administrators:(F)" `
+        /grant "SYSTEM:(F)" `
+        /grant "Authenticated Users:(RX)"
+    icacls.exe "${Env:ProgramData}\ssh\sshd_config" `
+        /grant "Administrators:(F)" `
+        /grant "SYSTEM:(F)" `
+        /grant "Authenticated Users:(RX)"
+
+    # add self for the purposes of this script
+    icacls.exe "${Env:ProgramData}\ssh\" /t /remove "${Env:UserName}"
+
+    Write-Verbose "System permissions set."
+}
+
+function Repair-UserAuthorizedKeyPermission {
+    Write-Verbose "Setting permissions on `$HOME\.ssh\ ..."
+
+    # mkdir -p ~/.ssh/
+    $null = New-Item -Type Directory -Force -Path "$HOME\.ssh\"
+
+    # touch ~/.ssh/authorized_keys
+    IF (-Not (Test-Path -Path "$HOME\.ssh\authorized_keys")) {
+        $null = New-Item -Type 'File' -Path "$HOME\.ssh\authorized_keys"
+    }
+
+    # chown -R "$(id -u -n)":"$(id -u -n)"
+    # (add yourself as a non-inherited user)
+    icacls.exe "$HOME\.ssh\" /t /grant "${Env:UserName}:(F)"
+
+    # chmod -R go-rwx ~/.ssh/
+    # (remove inherited acls)
+    icacls.exe "$HOME\.ssh\" /t /inheritance:r
+
+    Write-Verbose "User permissions set."
+}
+
+# Clean up non-key lines, preserving comments and newlines
+function Repair-AuthorizedKeyFile($Path) {
+    Write-Verbose "Filtering invalid keys entries from ${Path} ...";
+
+    $HasBadLine = $false;
+    $FixedPath = "${Path}.fixed.txt";
+
+    # truncates or creates the file
+    $null = New-Item -Type 'File' -Force -Path $FixedPath
+    foreach ($Line in [System.IO.File]::ReadLines($Path)) {
+        $Line = $Line.Trim()
+        IF ($Line.Length -eq 0) {
+            $null = Add-Content -Path $FixedPath -Value $Line
+            continue
+        }
+        IF ($Line.StartsWith('#')) {
+            $null = Add-Content -Path $FixedPath -Value $Line
+            continue
+        }
+        IF ($Line.StartsWith('ssh-')) {
+            $null = Add-Content -Path $FixedPath -Value $Line
+            continue
+        }
+        IF ($Line.StartsWith('ecdsa-')) {
+            $null = Add-Content -Path $FixedPath -Value $Line
+            continue
+        }
+        if (-Not $HasBadLine) {
+            $HasBadLine = $true
+            Write-Host "Skipping lines that do not begin with ssh-, ecdsa- or #:" -ForegroundColor Red -BackgroundColor Black
+        }
+        Write-Host "    $Line" -ForegroundColor Yellow -BackgroundColor Black
+    }
+
+    IF ($HasBadLine) {
+        Write-Host "Unrecognized line formats were filtered out."
+
+        $FixedPath
+        Return
+    }
+
+    Write-Verbose "No invalid keys were filtered out."
+    $null = Remove-Item -Path $FixedPath -Force -ErrorAction Ignore
+
+    $Path
+}
+
+function Add-AuthorizedKeyFile($Path) {
+    # Give yourself permission to the admin authorized_keys file
+    icacls.exe $AdminAuthorizedKeys /grant "${Env:UserName}:(F)"
+
+    Get-Content $Path | Add-Content -Path $AdminAuthorizedKeys
+
+    # Remove your permission to the admin authorized_keys file
+    icacls.exe $AdminAuthorizedKeys /remove $Env:UserName | Out-Null
+
+    Get-Content $Path | Add-Content -Path "$HOME\.ssh\authorized_keys"
+}
+
+function Add-AuthorizedKey($UrlOrPath) {
+    Write-Verbose "Inspecting ${UrlOrPath}..."
+
+    $IsHttp = $UrlOrPath.StartsWith("HTTP://", 'CurrentCultureIgnoreCase')
+    $IsHttps = $UrlOrPath.StartsWith("HTTPS://", 'CurrentCultureIgnoreCase')
+
+    IF (Test-Path -Path $UrlOrPath -Type 'Leaf') {
+        $FixedPath = Repair-AuthorizedKeyFile $UrlOrPath
+        $null = Add-AuthorizedKeyFile $FixedPath
+
+        $IsTmp = $UrlOrPath.EndsWith(".TMP.TXT", 'CurrentCultureIgnoreCase')
+        IF ($IsTmp) {
+            $null = Remove-Item -Path "${TmpKeys}.tmp.txt" -Force -ErrorAction Ignore
+        }
+        Return
+    }
+    IF (-Not ($IsHttps -Or $IsHttp)) {
+        throw "'$UrlOrPath' does not exist as a file and doesn't look like a URL (no https://)"
+    }
+
+    $TmpKeys = "new_authorized_keys.tmp.txt"
+
+    curl.exe --fail-with-body -sS $UrlOrPath | Out-File -Force "${TmpKeys}.partial"
+    $null = Move-Item -Force "${TmpKeys}.partial" $TmpKeys
+
+    IF ($IsHttp) {
+        Write-Host ""
+        Write-Host "Error: Cowardly refusing to add file downloaded over plain http" -ForegroundColor Yellow -BackgroundColor black
+        Write-Host ""
+        Write-Host "Please manually inspect ${TmpKeys} and then run"
+        Write-Host "    ssh-authorize ${TmpKeys}" -ForegroundColor Yellow -BackgroundColor black
+        Write-Host ""
+        1
+        Return
+    }
+
+    $FixedPath = Repair-AuthorizedKeyFile $TmpKeys
+    $null = Add-AuthorizedKeyFile $FixedPath
+    $null = Remove-Item -Path $TmpKeys -Force -ErrorAction Ignore
+    $null = Remove-Item -Path $FixedPath -Force -ErrorAction Ignore
+}
+
+function Debug-AuthorizedKeyPermission {
+    Write-Verbose "Showing ssh file permissions ..."
+
+    # ls -lA /etc/sshd/
+    icacls.exe "${Env:ProgramData}\ssh\" /t | Write-Host
+
+    # ls -lA ~/.ssh/
+    icacls.exe "$HOME\.ssh\" /t | Write-Host
+
+    # if you really mess things up you can
+    # move the 'ssh' and '.ssh' folders into
+    # '$HOME\AppData\Local\Temp' and reboot
+
+    Write-Verbose "All ssh file permissions shown."
+}
+
+function Show-Help() {
+    Write-Host ""
+    Write-Host "USAGE"
+    Write-Host "    ssh-authorize <url-or-path>" -ForegroundColor Yellow -BackgroundColor black
+    Write-Host ""
+    Write-Host "EXAMPLES"
+    Write-Host "    ssh-authorize https://github.com/johndoe.keys"
+    Write-Host "    ssh-authorize http://192.168.1.101:3000/authorized_keys"
+    Write-Host "    ssh-authorize ./alice.pub.txt ./bob.pub.txt"
+    Write-Host ""
+    Write-Host "LOCAL IDENTIFY FILES"
+    $Pubs = Get-ChildItem -Path "$HOME\.ssh\" -Filter '*.pub'
+    IF ($Pubs.Length -eq 0) {
+        Write-Host "    (no files match ~/.ssh/*.pub)"
+    }
+    foreach ($Pub in $Pubs) {
+        $RelPath = [System.IO.Path]::GetRelativePath($HOME, $Pub.FullName)
+        Write-Host "    ${RelPath}"
+    }
+}
+
+function Main($Paths) {
+    $null = Repair-AuthorizedKeyPermission
+    #Debug-AuthorizedKeyPermission | Write-Host
+
+    if ($Paths.Length -eq 0 -Or $Paths[0] -eq "help" -Or $Paths[0] -eq "--help") {
+        Show-Help | Write-Host
+
+        Write-Host ""
+        IF ($Paths.Length -eq 0) {
+            1
+            Return
+        }
+
+        0
+        Return
+    }
+    $Uri = $Paths[0]
+
+    Write-Host ""
+    Write-Host "Fetching keys from ${Uri}"
+
+    $null = Add-AuthorizedKey $Uri
+
+    Write-Host ""
+    Write-Host "Successfully copied the given ssh keys into:"
+    Write-Host "    `$HOME\.ssh\authorized_keys"
+    Write-Host "    `${Env:ProgramData}\ssh\administrators_authorized_keys"
+    Write-Host ""
+
+    0
+    Return
+}
+
+$Status = Main $Args
+Exit $Status

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -201,6 +201,12 @@ Invoke-DownloadUrl -Force -URL $PKG_URL -Params $UrlParams -Path $PkgInstallPwsh
 powershell $HOME\.local\tmp\${exename}.install.ps1
 
 IF ($IsWebiParent) {
+    Write-Host ""
+    Write-Host "Checking for updates to Webi ..."
+    $WebiUrl = "${Env:WEBI_HOST}/packages/webi/webi-pwsh.ps1"
+    $WebiPath = "$HOME\.local\bin\webi-pwsh.ps1"
+    Invoke-DownloadUrl -Force -URL $WebiUrl -Path $WebiPath
+
     $UserPath = [Environment]::GetEnvironmentVariable("Path", "User").Trim(';')
     $MachinePath = [Environment]::GetEnvironmentVariable("Path", "Machine").Trim(';')
     $Env:Path = "${UserPath};${MachinePath}"

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -168,6 +168,6 @@ $UrlParams = "formats=zip,exe,tar,git&libc=msvc"
 $PkgInstallPwsh = "$HOME\.local\tmp\$exename.install.ps1"
 Invoke-DownloadUrl -Force -URL $PKG_URL -Params $UrlParams -Path $PkgInstallPwsh
 
-& "$HOME\.local\tmp\${exename}.install.ps1"
+powershell $HOME\.local\tmp\${exename}.install.ps1
 
 Pop-Location

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -24,6 +24,28 @@ $TCmd = "${Esc}[2m${Esc}[35m"
 $TDim = "${Esc}[2m"
 $TReset = "${Esc}[0m"
 
+$OriginalPath = $Env:Path
+$IsWebiParent = -Not (Test-Path Env:IsWebiChild)
+$Env:IsWebiChild = $true
+
+function Confirm-IsElevated {
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $p = New-Object System.Security.Principal.WindowsPrincipal($id)
+    if ($p.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator))
+    { Write-Output $true }
+    else
+    { Write-Output $false }
+}
+
+IF (Confirm-IsElevated) {
+    IF ($IsWebiParent) {
+        Write-Host ""
+        Write-Host "Running Webi with elevated privileges is unsupported." -ForegroundColor Magenta -BackgroundColor black
+        Write-Host "Please run Webi as a normal user, NOT as administrator." -ForegroundColor Magenta -BackgroundColor black
+        Write-Host ""
+    }
+}
+
 function Invoke-DownloadUrl {
     Param (
         [string]$URL,

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -182,6 +182,12 @@ if ($exename -eq "-V" -or $exename -eq "--version" -or $exename -eq "version" -o
 
 $Env:WEBI_UA = Get-UserAgent
 
+IF ($IsWebiParent) {
+    Write-Host ""
+    Write-Host "${TName}Welcome to${TReset} ${TTask}Webi${TReset}${TName}!${TReset} - Instant Installs, Easy to Remember URLs"
+    Write-Host ""
+}
+
 Write-Host ""
 Write-Host "${TTask}Installing${TReset} ${TName}${exename}${TReset}"
 Write-Host "    ${TDim}Fetching install script ...${TReset}"

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -101,6 +101,30 @@ function Get-UserAgent {
     "PowerShell+curl Windows/10+ $my_arch msvc"
 }
 
+function Show-HowToUpdateEnv {
+    $UpdateUserPath = "`$UserPath = [Environment]::GetEnvironmentVariable('Path', 'User')"
+    $UpdateMachinePath = "`$MachinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')"
+
+    Write-Host ''
+    Write-Host '***********************************' -ForegroundColor yellow -BackgroundColor black
+    Write-Host '*      IMPORTANT -- READ ME       *' -ForegroundColor yellow -BackgroundColor black
+    Write-Host '*  (run the PATH commands below)  *' -ForegroundColor yellow -BackgroundColor black
+    Write-Host '***********************************' -ForegroundColor yellow -BackgroundColor black
+    Write-Host ''
+    Write-Host ""
+    Write-Host "Copy, paste, and run the appropriate commands to update your PATH:"
+    Write-Host ""
+    Write-Host "cmd.exe:"
+    Write-Host "    (close and reopen the terminal)" -ForegroundColor yellow -BackgroundColor black
+    Write-Host ""
+    Write-Host "PowerShell:"
+    Write-Host "    $UpdateUserPath" -ForegroundColor yellow -BackgroundColor black
+    Write-Host "    $UpdateMachinePath" -ForegroundColor yellow -BackgroundColor black
+    Write-Host "    `$Env:Path = `"`${UserPath};`${MachinePath}`"" -ForegroundColor yellow -BackgroundColor black
+    Write-Host "    (or close and reopen the terminal)"
+    Write-Host ""
+}
+
 # Switch to userprofile
 Push-Location $Env:USERPROFILE
 
@@ -169,5 +193,14 @@ $PkgInstallPwsh = "$HOME\.local\tmp\$exename.install.ps1"
 Invoke-DownloadUrl -Force -URL $PKG_URL -Params $UrlParams -Path $PkgInstallPwsh
 
 powershell $HOME\.local\tmp\${exename}.install.ps1
+
+IF ($IsWebiParent) {
+    $UserPath = [Environment]::GetEnvironmentVariable("Path", "User").Trim(';')
+    $MachinePath = [Environment]::GetEnvironmentVariable("Path", "Machine").Trim(';')
+    $Env:Path = "${UserPath};${MachinePath}"
+    IF ($OriginalPath -ne $Env:Path) {
+        Show-HowToUpdateEnv
+    }
+}
 
 Pop-Location


### PR DESCRIPTION
So. Much. Work.

But it works! On Windows!

## How install `ssh-authorize` on Windows

Once this PR is pulled in:

```pwsh
curl.exe https://webi.ms/ssh-authorize | powershell
```

## How to Set Permissions and add SSH Public Keys for Windows

Just running the command with no arguments will correctly set the permissions:

```sh
ssh-authorize
```

## How to Quickly Add Authorized SSH Keys on Windows

Like this:

```sh
ssh-authorize https://github.com/johndoe.keys
```

Or this:

```sh
ssh-authorize ./johndoe.pub
```

It adds them to both of
- `$HOME\.ssh\authorized_keys`
- `${Env:ProgramData}\ssh\administrators_authorized_keys`

And uses `icacls.exe` to properly shift the permissions around so that `sshd` will run without complaining (and without disabling authorized keys).

This DOES NOT require `Repair-AuthorizedKeyPermission` from `OpenSSHUtils`, but if you'd like to see how it's done we have our own `Repair-UserAuthorizedKeyPermission` and `Repair-AdminAuthorizedKeyPermission`:

https://github.com/webinstall/webi-installers/pull/743/files#diff-2049d699094d380ddb32e50b937ce7f239980b4070fec2df8ef4c046f1fa5697R19-R86