### PR TITLE
2. fix(windows): install scripts without PATH conflits between .bat and .ps1

### DIFF
--- a/myip/install.ps1
+++ b/myip/install.ps1
@@ -1,7 +1,28 @@
 #!/usr/bin/env pwsh
 
-& curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_HOST/packages/myip/myip.ps1" -o "$Env:USERPROFILE\.local\bin\myip.ps1.part"
-Remove-Item -Path "$Env:USERPROFILE\.local\bin\myip.ps1" -Recurse -ErrorAction Ignore
-& Move-Item "$Env:USERPROFILE\.local\bin\myip.ps1.part" "$Env:USERPROFILE\.local\bin\myip.ps1"
-Set-Content -Path "$Env:USERPROFILE\.local\bin\myip.bat" -Value "@echo off`r`npushd %USERPROFILE%`r`npowershell -ExecutionPolicy Bypass .local\bin\myip.ps1 %1`r`npopd"
-& "$Env:USERPROFILE\.local\bin\myip.bat"
+$ErrorActionPreference = 'stop'
+
+function Install-WebiHostedScript () {
+    Param(
+        [string]$Package,
+        [string]$ScriptName
+    )
+    $PwshName = "_${ScriptName}.ps1"
+    $PwshUrl = "${Env:WEBI_HOST}/packages/${Package}/${ScriptName}.ps1"
+    $PwshPath = "$HOME\.local\bin\${PwshName}"
+    $OldPath = "$HOME\.local\bin\${ScriptName}.ps1"
+
+    $BatPath = "$HOME\.local\bin\${ScriptName}.bat"
+    $PwshExec = "powershell -ExecutionPolicy Bypass"
+    $Bat = "@echo off`r`n$PwshExec %USERPROFILE%\.local\bin\${PwshName} %*"
+
+    Invoke-DownloadUrl -Force -URL $PwshUrl -Path $PwshPath
+    Set-Content -Path $BatPath -Value $Bat
+    Write-Host "    Created alias ${BatPath}"
+    Write-Host "      to run ${PwshPath}"
+
+    # fix for old installs
+    Remove-Item -Path $OldPath -Force -ErrorAction Ignore
+}
+
+Install-WebiHostedScript -Package "myip" -ScriptName "myip"

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -84,18 +84,18 @@ Push-Location $Env:USERPROFILE
 
 # Make paths if needed
 # TODO replace all bin with opt\bin\
-New-Item -Path .local\bin -ItemType Directory -Force | Out-Null
+New-Item -Path "$HOME\.local\bin\" -ItemType Directory -Force | Out-Null
 
 # See note on Set-ExecutionPolicy above
-Set-Content -Path .local\bin\webi.bat -Value "@echo off`r`npowershell -ExecutionPolicy Bypass %USERPROFILE%\.local\bin\webi-pwsh.ps1 %*"
+Set-Content -Path "$HOME\.local\bin\webi.bat" -Value "@echo off`r`npowershell -ExecutionPolicy Bypass %USERPROFILE%\.local\bin\webi-pwsh.ps1 %*"
 # Backwards-compat bugfix: remove old webi-pwsh.ps1 location
-Remove-Item -Path .local\bin\webi.ps1 -Recurse -ErrorAction Ignore
-if (!(Test-Path -Path .local\opt)) {
-    New-Item -Path .local\opt -ItemType Directory -Force | Out-Null
+Remove-Item -Path "$HOME\.local\bin\webi.ps1" -Recurse -ErrorAction Ignore
+if (!(Test-Path -Path "$HOME\.local\opt")) {
+    New-Item -Path "$HOME\.local\opt" -ItemType Directory -Force | Out-Null
 }
 # TODO windows version of mktemp -d
-if (!(Test-Path -Path .local\tmp)) {
-    New-Item -Path .local\tmp -ItemType Directory -Force | Out-Null
+if (!(Test-Path -Path "$HOME\.local\tmp")) {
+    New-Item -Path "$HOME\.local\tmp" -ItemType Directory -Force | Out-Null
 }
 
 ## show help if no params given or help flags are used
@@ -146,7 +146,6 @@ $UrlParams = "formats=zip,exe,tar,git&libc=msvc"
 $PkgInstallPwsh = "$HOME\.local\tmp\$exename.install.ps1"
 Invoke-DownloadUrl -Force -URL $PKG_URL -Params $UrlParams -Path $PkgInstallPwsh
 
-powershell .\.local\tmp\$exename.install.ps1
+& "$HOME\.local\tmp\${exename}.install.ps1"
 
-# Done
 Pop-Location

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -87,7 +87,7 @@ Push-Location $Env:USERPROFILE
 New-Item -Path .local\bin -ItemType Directory -Force | Out-Null
 
 # See note on Set-ExecutionPolicy above
-Set-Content -Path .local\bin\webi.bat -Value "@echo off`r`npushd %USERPROFILE%`r`npowershell -ExecutionPolicy Bypass .local\bin\webi-pwsh.ps1 %1`r`npopd"
+Set-Content -Path .local\bin\webi.bat -Value "@echo off`r`npowershell -ExecutionPolicy Bypass %USERPROFILE%\.local\bin\webi-pwsh.ps1 %*"
 # Backwards-compat bugfix: remove old webi-pwsh.ps1 location
 Remove-Item -Path .local\bin\webi.ps1 -Recurse -ErrorAction Ignore
 if (!(Test-Path -Path .local\opt)) {


### PR DESCRIPTION
- [x] `foo.bat` will call `_foo.ps1` (not `foo.ps1`)
- [x] any existing `foo.ps1` will be deleted