### PR TITLE
1.5 fix old typo xbin => bin

### DIFF
--- a/bat/install.ps1
+++ b/bat/install.ps1
@@ -35,13 +35,13 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\bin\$VERNAME")) {
 
     # Settle unpacked archive into place
     Write-Output "New Name: $VERNAME"
-    Write-Output "New Location: $Env:USERPROFILE\.local\xbin\$VERNAME"
+    Write-Output "New Location: $Env:USERPROFILE\.local\bin\$VERNAME"
     Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\bin"
 
     # Exit tmp
     Pop-Location
 }
 
-Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\xbin\$VERNAME'"
+Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\bin\$VERNAME'"
 Remove-Item -Path "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse -ErrorAction Ignore
 Copy-Item -Path "$Env:USERPROFILE\.local\bin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse

--- a/bat/install.ps1
+++ b/bat/install.ps1
@@ -15,7 +15,7 @@ IF (-not (Test-Path "\Windows\System32\vcruntime140.dll")) {
     & "$Env:USERPROFILE\.local\bin\webi-pwsh.ps1" vcruntime
 }
 
-IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
+IF (!(Test-Path -Path "$Env:USERPROFILE\.local\bin\$VERNAME")) {
     Write-Output "Installing $Env:PKG_NAME"
     # TODO: temp directory
 
@@ -36,7 +36,7 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
     # Settle unpacked archive into place
     Write-Output "New Name: $VERNAME"
     Write-Output "New Location: $Env:USERPROFILE\.local\xbin\$VERNAME"
-    Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\xbin"
+    Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\bin"
 
     # Exit tmp
     Pop-Location
@@ -44,4 +44,4 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
 
 Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\xbin\$VERNAME'"
 Remove-Item -Path "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse -ErrorAction Ignore
-Copy-Item -Path "$Env:USERPROFILE\.local\xbin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse
+Copy-Item -Path "$Env:USERPROFILE\.local\bin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse

--- a/bat/install.sh
+++ b/bat/install.sh
@@ -19,7 +19,7 @@ __init_bat() {
     }
 
     pkg_install() {
-        # ~/.local/xbin
+        # ~/.local/bin
         mkdir -p "$pkg_src_bin"
 
         # mv ./bat-*/bat ~/.local/opt/bat-v0.15.4/bin/bat

--- a/curlie/install.ps1
+++ b/curlie/install.ps1
@@ -9,7 +9,7 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
     & Move-Item "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 }
 
-IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
+IF (!(Test-Path -Path "$Env:USERPROFILE\.local\bin\$VERNAME")) {
     Write-Output "Installing $Env:PKG_NAME"
     # TODO: temp directory
 
@@ -30,7 +30,7 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
     # Settle unpacked archive into place
     Write-Output "New Name: $VERNAME"
     Write-Output "New Location: $Env:USERPROFILE\.local\xbin\$VERNAME"
-    Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\xbin"
+    Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\bin"
 
     # Exit tmp
     Pop-Location
@@ -38,4 +38,4 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
 
 Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\xbin\$VERNAME'"
 Remove-Item -Path "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse -ErrorAction Ignore
-Copy-Item -Path "$Env:USERPROFILE\.local\xbin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse
+Copy-Item -Path "$Env:USERPROFILE\.local\bin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse

--- a/curlie/install.ps1
+++ b/curlie/install.ps1
@@ -29,13 +29,13 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\bin\$VERNAME")) {
 
     # Settle unpacked archive into place
     Write-Output "New Name: $VERNAME"
-    Write-Output "New Location: $Env:USERPROFILE\.local\xbin\$VERNAME"
+    Write-Output "New Location: $Env:USERPROFILE\.local\bin\$VERNAME"
     Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\bin"
 
     # Exit tmp
     Pop-Location
 }
 
-Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\xbin\$VERNAME'"
+Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\bin\$VERNAME'"
 Remove-Item -Path "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse -ErrorAction Ignore
 Copy-Item -Path "$Env:USERPROFILE\.local\bin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse

--- a/curlie/install.sh
+++ b/curlie/install.sh
@@ -19,7 +19,7 @@ __init_curlie() {
     }
 
     pkg_install() {
-        # $HOME/.local/xbin
+        # $HOME/.local/bin
         mkdir -p "$pkg_src_bin"
 
         # mv ./curlie* "$HOME/.local/opt/curlie-v1.3.1/bin/curlie"

--- a/deno/install.sh
+++ b/deno/install.sh
@@ -23,13 +23,13 @@ pkg_get_current_version() {
 }
 
 pkg_install() {
-    # $HOME/.local/xbin
+    # $HOME/.local/bin
     mkdir -p "$pkg_src_bin"
 
-    # mv ./deno* "$HOME/.local/xbin/deno-v1.1.0"
+    # mv ./deno* "$HOME/.local/bin/deno-v1.1.0"
     mv ./"$pkg_cmd_name"* "$pkg_src_cmd"
 
-    # chmod a+x "$HOME/.local/xbin/deno-v1.1.0"
+    # chmod a+x "$HOME/.local/bin/deno-v1.1.0"
     chmod a+x "$pkg_src_cmd"
 }
 
@@ -37,6 +37,6 @@ pkg_link() {
     # rm -f "$HOME/.local/bin/deno"
     rm -f "$pkg_dst_cmd"
 
-    # ln -s "$HOME/.local/xbin/deno-v1.1.0" "$HOME/.local/bin/deno"
+    # ln -s "$HOME/.local/bin/deno-v1.1.0" "$HOME/.local/bin/deno"
     ln -s "$pkg_src_cmd" "$pkg_dst_cmd"
 }

--- a/fd/install.ps1
+++ b/fd/install.ps1
@@ -9,7 +9,7 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
     & Move-Item "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 }
 
-IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
+IF (!(Test-Path -Path "$Env:USERPROFILE\.local\bin\$VERNAME")) {
     Write-Output "Installing $Env:PKG_NAME"
     # TODO: temp directory
 
@@ -30,7 +30,7 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
     # Settle unpacked archive into place
     Write-Output "New Name: $VERNAME"
     Write-Output "New Location: $Env:USERPROFILE\.local\xbin\$VERNAME"
-    Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\xbin"
+    Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\bin"
 
     # Exit tmp
     Pop-Location
@@ -38,4 +38,4 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
 
 Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\xbin\$VERNAME'"
 Remove-Item -Path "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse -ErrorAction Ignore
-Copy-Item -Path "$Env:USERPROFILE\.local\xbin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse
+Copy-Item -Path "$Env:USERPROFILE\.local\bin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse

--- a/fd/install.ps1
+++ b/fd/install.ps1
@@ -29,13 +29,13 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\bin\$VERNAME")) {
 
     # Settle unpacked archive into place
     Write-Output "New Name: $VERNAME"
-    Write-Output "New Location: $Env:USERPROFILE\.local\xbin\$VERNAME"
+    Write-Output "New Location: $Env:USERPROFILE\.local\bin\$VERNAME"
     Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\bin"
 
     # Exit tmp
     Pop-Location
 }
 
-Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\xbin\$VERNAME'"
+Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\bin\$VERNAME'"
 Remove-Item -Path "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse -ErrorAction Ignore
 Copy-Item -Path "$Env:USERPROFILE\.local\bin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse

--- a/fzf/install.ps1
+++ b/fzf/install.ps1
@@ -9,7 +9,7 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
     & Move-Item "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 }
 
-IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
+IF (!(Test-Path -Path "$Env:USERPROFILE\.local\bin\$VERNAME")) {
     Write-Output "Installing $Env:PKG_NAME"
     # TODO: temp directory
 
@@ -30,7 +30,7 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
     # Settle unpacked archive into place
     Write-Output "New Name: $VERNAME"
     Write-Output "New Location: $Env:USERPROFILE\.local\xbin\$VERNAME"
-    Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\xbin"
+    Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\bin"
 
     # Exit tmp
     Pop-Location
@@ -38,4 +38,4 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
 
 Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\xbin\$VERNAME'"
 Remove-Item -Path "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse -ErrorAction Ignore
-Copy-Item -Path "$Env:USERPROFILE\.local\xbin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse
+Copy-Item -Path "$Env:USERPROFILE\.local\bin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse

--- a/fzf/install.ps1
+++ b/fzf/install.ps1
@@ -29,13 +29,13 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\bin\$VERNAME")) {
 
     # Settle unpacked archive into place
     Write-Output "New Name: $VERNAME"
-    Write-Output "New Location: $Env:USERPROFILE\.local\xbin\$VERNAME"
+    Write-Output "New Location: $Env:USERPROFILE\.local\bin\$VERNAME"
     Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\bin"
 
     # Exit tmp
     Pop-Location
 }
 
-Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\xbin\$VERNAME'"
+Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\bin\$VERNAME'"
 Remove-Item -Path "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse -ErrorAction Ignore
 Copy-Item -Path "$Env:USERPROFILE\.local\bin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse

--- a/jq/install.ps1
+++ b/jq/install.ps1
@@ -26,13 +26,13 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\bin\$VERNAME")) {
     # Settle unpacked archive into place
     Write-Output "New Name: $VERNAME"
     Get-ChildItem "$Env:PKG_NAME-v*" | Select-Object -f 1 | Rename-Item -NewName "$VERNAME"
-    Write-Output "New Location: $Env:USERPROFILE\.local\xbin\$VERNAME"
+    Write-Output "New Location: $Env:USERPROFILE\.local\bin\$VERNAME"
     Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\bin"
 
     # Exit tmp
     Pop-Location
 }
 
-Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\xbin\$VERNAME'"
+Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\bin\$VERNAME'"
 Remove-Item -Path "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse -ErrorAction Ignore
 Copy-Item -Path "$Env:USERPROFILE\.local\bin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse

--- a/jq/install.ps1
+++ b/jq/install.ps1
@@ -9,7 +9,7 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
     & Move-Item "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 }
 
-IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
+IF (!(Test-Path -Path "$Env:USERPROFILE\.local\bin\$VERNAME")) {
     Write-Output "Installing $Env:PKG_NAME"
     # TODO: temp directory
 
@@ -27,7 +27,7 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
     Write-Output "New Name: $VERNAME"
     Get-ChildItem "$Env:PKG_NAME-v*" | Select-Object -f 1 | Rename-Item -NewName "$VERNAME"
     Write-Output "New Location: $Env:USERPROFILE\.local\xbin\$VERNAME"
-    Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\xbin"
+    Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\bin"
 
     # Exit tmp
     Pop-Location
@@ -35,4 +35,4 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\.local\xbin\$VERNAME")) {
 
 Write-Output "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\xbin\$VERNAME'"
 Remove-Item -Path "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse -ErrorAction Ignore
-Copy-Item -Path "$Env:USERPROFILE\.local\xbin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse
+Copy-Item -Path "$Env:USERPROFILE\.local\bin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -35,7 +35,7 @@ $exename = $args[0]
 Push-Location $Env:USERPROFILE
 
 # Make paths if needed
-# TODO replace all xbin with opt\bin\
+# TODO replace all bin with opt\bin\
 New-Item -Path .local\bin -ItemType Directory -Force | Out-Null
 
 # See note on Set-ExecutionPolicy above

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -35,9 +35,8 @@ $exename = $args[0]
 Push-Location $Env:USERPROFILE
 
 # Make paths if needed
-New-Item -Path .local\bin -ItemType Directory -Force | Out-Null
 # TODO replace all xbin with opt\bin\
-New-Item -Path .local\xbin -ItemType Directory -Force | Out-Null
+New-Item -Path .local\bin -ItemType Directory -Force | Out-Null
 
 # See note on Set-ExecutionPolicy above
 Set-Content -Path .local\bin\webi.bat -Value "@echo off`r`npushd %USERPROFILE%`r`npowershell -ExecutionPolicy Bypass .local\bin\webi-pwsh.ps1 %1`r`npopd"


### PR DESCRIPTION
Long ago I was testing something (I think) or for whatever reason I chose to use the name `.local\xbin`. That got copied and pasted in multiple places, which I don't think is what I intended.

And to this day, those things install in the wrong place.

This fixes that.

The fix will cause bug #747, but it's not workflow breaking, I think it's worth it for the future.