### PR TITLE
fix(arm): classify arm as armv6 and arm32 as armv7

### DIFF
--- a/_webi/normalize.js
+++ b/_webi/normalize.js
@@ -50,7 +50,7 @@ var arches = [
 // https://git.com/org/foo/releases/v0.7.9/foo-x86_64-linux-musl.tar.gz
 //
 var archMap = {
-  armv7l: /(\b|_)(armv?7l?)/i,
+  armv7l: /(\b|_)(arm32|armv?7l?)/i,
   //amd64: /(amd.?64|x64|[_\-]64)/i,
   amd64:
     /(\b|_|amd|(dar)?win(dows)?|mac(os)?|linux|osx|x)64([_\-]?bit)?(\b|_)/i,

--- a/_webi/normalize.js
+++ b/_webi/normalize.js
@@ -29,14 +29,14 @@ formats.forEach(function (name) {
 // evaluation order matters
 // (i.e. otherwise x86 and x64 can cross match)
 var arches = [
-  // arm 7 cannot be confused with arm64
-  'armv7l',
-  // amd64 is more likely than arm64
-  'amd64',
-  // arm6 has the same prefix as arm64
-  'armv6l',
-  // arm64 is more likely than arm6, and should be the default
+  // arm64/aarch64 has very high specificity, so it comes first
   'arm64',
+  // arm 7 is also generic aarch/arm/arm32
+  'armv7l',
+  // arm6 can run on armv7
+  'armv6l',
+  // amd64 is more likely and less often specified than arm64
+  'amd64',
   'x86',
   'ppc64le',
   'ppc64',
@@ -50,13 +50,13 @@ var arches = [
 // https://git.com/org/foo/releases/v0.7.9/foo-x86_64-linux-musl.tar.gz
 //
 var archMap = {
-  armv7l: /(\b|_)(arm32|armv?7l?)/i,
+  arm64: /(\b|_)(aarch64|arm64)/i,
+  armv7l: /(\b|_)(arm32|arm[_\-]?v?7l?)/i,
+  armv6l: /(\b|_)(arm|aarch32|arm[_\-]?v?6l?)(\b|_)/i,
   //amd64: /(amd.?64|x64|[_\-]64)/i,
   amd64:
     /(\b|_|amd|(dar)?win(dows)?|mac(os)?|linux|osx|x)64([_\-]?bit)?(\b|_)/i,
   //x86: /(86)(\b|_)/i,
-  armv6l: /(\b|_)(aarch32|armv?6l?)(\b|_)/i,
-  arm64: /(\b|_)((aarch|arm)64|arm)/i,
   x86: /(\b|_|amd|(dar)?win(dows)?|mac(os)?|linux|osx|x)(86|32)([_\-]?bit)(\b|_)/i,
   ppc64le: /(\b|_)(ppc64le)/i,
   ppc64: /(\b|_)(ppc64)(\b|_)/i,

--- a/_webi/transform-releases.js
+++ b/_webi/transform-releases.js
@@ -278,7 +278,16 @@ module.exports = function getReleases({
         console.error(err);
       })
       .then(function (releases) {
-        if (!releases.length) {
+        if (releases.length) {
+          return {
+            oses: all.oses,
+            arches: all.arches,
+            libcs: all.libcs,
+            formats: all.formats,
+            releases: releases,
+          };
+        }
+        if (_count < 1) {
           // Apple Silicon M1 hacky-do workaround fix
           if ('macos' === os && 'arm64' === arch) {
             return getReleases({
@@ -307,23 +316,7 @@ module.exports = function getReleases({
               limit,
             });
           }
-          // Raspberry Pi 3+ on Raspbian x86 (not Ubuntu arm64)
-          if (!_count && 'linux' === os && 'armv7l' === arch) {
-            return getReleases({
-              _count: _count + 1,
-              pkg,
-              ver,
-              os,
-              arch: 'arm64',
-              libc,
-              lts,
-              channel,
-              formats,
-              limit,
-            });
-          }
           // Raspberry Pi 3+ on Ubuntu arm64 (via Bionic?)
-          // (this may be the same as the prior search, that's okay)
           if ('linux' === os && 'arm64' === arch) {
             return getReleases({
               _count: _count + 1,
@@ -338,7 +331,7 @@ module.exports = function getReleases({
               limit,
             });
           }
-          // Raspberry Pi 3+ on Ubuntu arm64 (via Bionic?)
+          // armv7 can run armv6
           if ('linux' === os && 'armv7l' === arch) {
             return getReleases({
               _count: _count + 1,
@@ -353,25 +346,43 @@ module.exports = function getReleases({
               limit,
             });
           }
-          releases = [
-            {
-              name: 'doesntexist.ext',
-              version: '0.0.0',
-              lts: '-',
-              channel: 'error',
-              date: '1970-01-01',
-              os: os || '-',
-              arch: arch || '-',
-              libc: libc || '-',
-              ext: 'err',
-              download: 'https://example.com/doesntexist.ext',
-              comment:
-                'No matches found. Could be bad or missing version info' +
-                ',' +
-                "Check query parameters. Should be something like '/api/releases/{package}@{version}.tab?os={macos|linux|windows|-}&arch={amd64|x86|aarch64|arm64|armv7l|-}&libc={musl|gnu|msvc|libc|static}&limit=10'",
-            },
-          ];
         }
+        if (_count < 2) {
+          // Raspberry Pi 3+ on Raspbian arm7 (not Ubuntu arm64)
+          // hail mary
+          if ('linux' === os && 'armv7l' === arch) {
+            return getReleases({
+              _count: _count + 1,
+              pkg,
+              ver,
+              os,
+              arch: 'arm64',
+              libc,
+              lts,
+              channel,
+              formats,
+              limit,
+            });
+          }
+        }
+        releases = [
+          {
+            name: 'doesntexist.ext',
+            version: '0.0.0',
+            lts: '-',
+            channel: 'error',
+            date: '1970-01-01',
+            os: os || '-',
+            arch: arch || '-',
+            libc: libc || '-',
+            ext: 'err',
+            download: 'https://example.com/doesntexist.ext',
+            comment:
+              'No matches found. Could be bad or missing version info' +
+              ',' +
+              "Check query parameters. Should be something like '/api/releases/{package}@{version}.tab?os={macos|linux|windows|-}&arch={amd64|x86|aarch64|arm64|armv7l|-}&libc={musl|gnu|msvc|libc|static}&limit=10'",
+          },
+        ];
         return {
           oses: all.oses,
           arches: all.arches,

--- a/_webi/ua-detect.js
+++ b/_webi/ua-detect.js
@@ -67,7 +67,7 @@ function getArch(ua) {
 
   if (/aarch64|arm64|arm8|armv8/i.test(ua)) {
     return 'arm64';
-  } else if (/aarch|arm7|armv7/i.test(ua)) {
+  } else if (/aarch|arm7|armv7|arm32/i.test(ua)) {
     return 'armv7l';
   } else if (/arm6|armv6/i.test(ua)) {
     return 'armv6l';

--- a/_webi/ua-detect.js
+++ b/_webi/ua-detect.js
@@ -69,7 +69,7 @@ function getArch(ua) {
     return 'arm64';
   } else if (/aarch|arm7|armv7|arm32/i.test(ua)) {
     return 'armv7l';
-  } else if (/arm6|armv6/i.test(ua)) {
+  } else if (/arm6|armv6|arm(\b|_)/i.test(ua)) {
     return 'armv6l';
   } else if (/ppc64le/i.test(ua)) {
     return 'ppc64le';


### PR DESCRIPTION
Windows refers to armv7 as arm32.

Or at least so says GPT.

In any case, Windows definitely uses the arm32 identifier for their PowerShell builds.

Classification:

```text
arm8 => aarch64
arm64 => aarch64
arm32 => arm7
arm => arm6
aarch => arm6
aarch32 => arm6
```

Fallback behavior:

```sh
aarch64 => arm7 (1) => arm6 (2) => error
arm7 => arm6 (1) => aarch64 (2) => error
```

I don't think this is actually implemented correctly yet, but I also think that the original case for which it was intended largely doesn't exist (most libraries ship aarch64, armv7, and armv6).

All supported:
- https://webinstall.dev/api/releases/zoxide@0.9.json?channel=stable&limit=10&pretty=true&arch=arm64&os=linux&libc=libc
- https://webinstall.dev/api/releases/zoxide@0.9.json?channel=stable&limit=10&pretty=true&arch=arm32&os=linux&libc=libc
- https://webinstall.dev/api/releases/zoxide@0.9.json?channel=stable&limit=10&pretty=true&arch=arm7&os=linux&libc=libc
- https://webinstall.dev/api/releases/zoxide@0.9.json?channel=stable&limit=10&pretty=true&arch=arm6&os=linux&libc=libc
- https://webinstall.dev/api/releases/zoxide@0.9.json?channel=stable&limit=10&pretty=true&arch=arm&os=linux&libc=libc

Not all supported:
- https://webinstall.dev/api/releases/zoxide@0.6.json?channel=stable&limit=10&pretty=true&arch=arm64&os=linux&libc=libc
- https://webinstall.dev/api/releases/zoxide@0.6.json?channel=stable&limit=10&pretty=true&arch=arm32&os=linux&libc=libc
- https://webinstall.dev/api/releases/zoxide@0.6.json?channel=stable&limit=10&pretty=true&arch=arm7&os=linux&libc=libc
- https://webinstall.dev/api/releases/zoxide@0.6.json?channel=stable&limit=10&pretty=true&arch=arm6&os=linux&libc=libc
- https://webinstall.dev/api/releases/zoxide@0.6.json?channel=stable&limit=10&pretty=true&arch=arm&os=linux&libc=libc