### PR TITLE
Hotfix: various minor updates already in prod

### DIFF
--- a/_webi/install-package.tpl.ps1
+++ b/_webi/install-package.tpl.ps1
@@ -69,7 +69,7 @@ function Invoke-DownloadUrl {
         Write-Host "        ?$Params"
         $URL = "${URL}?${Params}"
     }
-    curl.exe '-#' --fail-with-body -sS -A $Env:WEBI_UA $URL | Out-File $TmpPath
+    curl.exe '-#' --fail-with-body -sS -A $Env:WEBI_UA -L $URL | Out-File $TmpPath
 
     Remove-Item -Path $Path -Force -ErrorAction Ignore
     Move-Item $TmpPath $Path

--- a/_webi/normalize.js
+++ b/_webi/normalize.js
@@ -29,14 +29,14 @@ formats.forEach(function (name) {
 // evaluation order matters
 // (i.e. otherwise x86 and x64 can cross match)
 var arches = [
-  // arm 7 cannot be confused with arm64
-  'armv7l',
-  // amd64 is more likely than arm64
-  'amd64',
-  // arm6 has the same prefix as arm64
-  'armv6l',
-  // arm64 is more likely than arm6, and should be the default
+  // arm64/aarch64 has very high specificity, so it comes first
   'arm64',
+  // arm 7 is also generic aarch/arm/arm32
+  'armv7l',
+  // arm6 can run on armv7
+  'armv6l',
+  // amd64 is more likely and less often specified than arm64
+  'amd64',
   'x86',
   'ppc64le',
   'ppc64',
@@ -50,13 +50,13 @@ var arches = [
 // https://git.com/org/foo/releases/v0.7.9/foo-x86_64-linux-musl.tar.gz
 //
 var archMap = {
-  armv7l: /(\b|_)(arm32|armv?7l?)/i,
+  arm64: /(\b|_)(aarch64|arm64)/i,
+  armv7l: /(\b|_)(arm32|arm[_\-]?v?7l?)/i,
+  armv6l: /(\b|_)(arm|aarch32|arm[_\-]?v?6l?)(\b|_)/i,
   //amd64: /(amd.?64|x64|[_\-]64)/i,
   amd64:
     /(\b|_|amd|(dar)?win(dows)?|mac(os)?|linux|osx|x)64([_\-]?bit)?(\b|_)/i,
   //x86: /(86)(\b|_)/i,
-  armv6l: /(\b|_)(aarch32|armv?6l?)(\b|_)/i,
-  arm64: /(\b|_)((aarch|arm)64|arm)/i,
   x86: /(\b|_|amd|(dar)?win(dows)?|mac(os)?|linux|osx|x)(86|32)([_\-]?bit)(\b|_)/i,
   ppc64le: /(\b|_)(ppc64le)/i,
   ppc64: /(\b|_)(ppc64)(\b|_)/i,

--- a/_webi/transform-releases.js
+++ b/_webi/transform-releases.js
@@ -278,7 +278,16 @@ module.exports = function getReleases({
         console.error(err);
       })
       .then(function (releases) {
-        if (!releases.length) {
+        if (releases.length) {
+          return {
+            oses: all.oses,
+            arches: all.arches,
+            libcs: all.libcs,
+            formats: all.formats,
+            releases: releases,
+          };
+        }
+        if (_count < 1) {
           // Apple Silicon M1 hacky-do workaround fix
           if ('macos' === os && 'arm64' === arch) {
             return getReleases({
@@ -307,23 +316,7 @@ module.exports = function getReleases({
               limit,
             });
           }
-          // Raspberry Pi 3+ on Raspbian x86 (not Ubuntu arm64)
-          if (!_count && 'linux' === os && 'armv7l' === arch) {
-            return getReleases({
-              _count: _count + 1,
-              pkg,
-              ver,
-              os,
-              arch: 'arm64',
-              libc,
-              lts,
-              channel,
-              formats,
-              limit,
-            });
-          }
           // Raspberry Pi 3+ on Ubuntu arm64 (via Bionic?)
-          // (this may be the same as the prior search, that's okay)
           if ('linux' === os && 'arm64' === arch) {
             return getReleases({
               _count: _count + 1,
@@ -338,7 +331,7 @@ module.exports = function getReleases({
               limit,
             });
           }
-          // Raspberry Pi 3+ on Ubuntu arm64 (via Bionic?)
+          // armv7 can run armv6
           if ('linux' === os && 'armv7l' === arch) {
             return getReleases({
               _count: _count + 1,
@@ -353,25 +346,43 @@ module.exports = function getReleases({
               limit,
             });
           }
-          releases = [
-            {
-              name: 'doesntexist.ext',
-              version: '0.0.0',
-              lts: '-',
-              channel: 'error',
-              date: '1970-01-01',
-              os: os || '-',
-              arch: arch || '-',
-              libc: libc || '-',
-              ext: 'err',
-              download: 'https://example.com/doesntexist.ext',
-              comment:
-                'No matches found. Could be bad or missing version info' +
-                ',' +
-                "Check query parameters. Should be something like '/api/releases/{package}@{version}.tab?os={macos|linux|windows|-}&arch={amd64|x86|aarch64|arm64|armv7l|-}&libc={musl|gnu|msvc|libc|static}&limit=10'",
-            },
-          ];
         }
+        if (_count < 2) {
+          // Raspberry Pi 3+ on Raspbian arm7 (not Ubuntu arm64)
+          // hail mary
+          if ('linux' === os && 'armv7l' === arch) {
+            return getReleases({
+              _count: _count + 1,
+              pkg,
+              ver,
+              os,
+              arch: 'arm64',
+              libc,
+              lts,
+              channel,
+              formats,
+              limit,
+            });
+          }
+        }
+        releases = [
+          {
+            name: 'doesntexist.ext',
+            version: '0.0.0',
+            lts: '-',
+            channel: 'error',
+            date: '1970-01-01',
+            os: os || '-',
+            arch: arch || '-',
+            libc: libc || '-',
+            ext: 'err',
+            download: 'https://example.com/doesntexist.ext',
+            comment:
+              'No matches found. Could be bad or missing version info' +
+              ',' +
+              "Check query parameters. Should be something like '/api/releases/{package}@{version}.tab?os={macos|linux|windows|-}&arch={amd64|x86|aarch64|arm64|armv7l|-}&libc={musl|gnu|msvc|libc|static}&limit=10'",
+          },
+        ];
         return {
           oses: all.oses,
           arches: all.arches,

--- a/_webi/ua-detect.js
+++ b/_webi/ua-detect.js
@@ -69,7 +69,7 @@ function getArch(ua) {
     return 'arm64';
   } else if (/aarch|arm7|armv7|arm32/i.test(ua)) {
     return 'armv7l';
-  } else if (/arm6|armv6/i.test(ua)) {
+  } else if (/arm6|armv6|arm(\b|_)/i.test(ua)) {
     return 'armv6l';
   } else if (/ppc64le/i.test(ua)) {
     return 'ppc64le';

--- a/flutter/releases.js
+++ b/flutter/releases.js
@@ -23,8 +23,7 @@ module.exports = function (request) {
             map[asset.channel] = true;
           }
           all.releases.push({
-            // nix leading 'v'
-            version: asset.version.replace(/v/, ''),
+            version: asset.version,
             lts: false,
             channel: asset.channel,
             date: asset.release_date.replace(/T.*/, ''),

--- a/gitea/install.ps1
+++ b/gitea/install.ps1
@@ -18,6 +18,12 @@ $pkg_src = "$pkg_src_cmd"
 New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | Out-Null
 $pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
+Write-Output "Checking for Git..."
+IF (-Not (Get-Command -Name "git" -ErrorAction Silent)) {
+    & "$HOME\.local\bin\webi-pwsh.ps1" git
+    $null = Sync-EnvPath
+}
+
 # Fetch archive
 IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
     Write-Output "Downloading gitea from $Env:WEBI_PKG_URL to $pkg_download"

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -71,7 +71,7 @@ function Invoke-DownloadUrl {
         Write-Host "        ?$Params"
         $URL = "${URL}?${Params}"
     }
-    curl.exe '-#' --fail-with-body -sS -A $Env:WEBI_UA $URL | Out-File $TmpPath
+    curl.exe '-#' --fail-with-body -sS -A $Env:WEBI_UA -L $URL | Out-File $TmpPath
 
     Remove-Item -Path $Path -Force -ErrorAction Ignore
     Move-Item $TmpPath $Path

--- a/zig/releases.js
+++ b/zig/releases.js
@@ -11,6 +11,7 @@ module.exports = function (request) {
     let refs = Object.keys(versions);
     refs.forEach(function (ref) {
       let pkgs = versions[ref];
+      let version = pkgs.version || ref;
 
       // "platform" = arch + os combo
       let platforms = Object.keys(pkgs);
@@ -36,7 +37,7 @@ module.exports = function (request) {
         }
 
         let p = {
-          version: ref,
+          version: version,
           date: pkgs.date,
           channel: 'stable',
           // linux, macos, windows


### PR DESCRIPTION
In prep for #756 

Critical fixes:
- classify `arm32` as `armv7`
- classify `arm` as `armv6` (though armv7 would do)
- use `-L` with curl in PowerShell because some GitHub downloads use redirects

Important fixes:
- use zig version rather than `master` for nightlies
- install `git` to install `gitea` on Windows

Included some chores as well
- `chmod a+x ./webi/webi.sh`
- show machine info in the welcome message in PowerShell