### PR TITLE
cleanup release.js files

### DIFF
--- a/aliasman/releases.js
+++ b/aliasman/releases.js
@@ -17,6 +17,7 @@ module.exports = function (request) {
   ];
   let oses = ['freebsd', 'linux', 'macos', 'posix'];
   return githubSource(request, owner, repo, oses, arches).then(function (all) {
+    all._names = ['aliasman', 'legacy'];
     return all;
   });
 };

--- a/arc/releases.js
+++ b/arc/releases.js
@@ -6,6 +6,7 @@ var repo = 'archiver';
 
 module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
+    all._names = ['archiver', 'arc'];
     return all;
   });
 };

--- a/atomicparsley/releases.js
+++ b/atomicparsley/releases.js
@@ -65,6 +65,7 @@ module.exports = function (request) {
         continue;
       }
     }
+    all._names = ['AtomicParsley', 'atomicparsley'];
     return all;
   });
 };

--- a/bun/releases.js
+++ b/bun/releases.js
@@ -8,10 +8,17 @@ module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
     all.releases = all.releases
       .filter(function (r) {
-        let isDebug = /-profile/.test(r.name);
-        if (!isDebug) {
-          return true;
+        let isDebug = r.name.includes('-profile');
+        if (isDebug) {
+          return false;
         }
+
+        let isAncient = r.name.includes('-baseline');
+        if (isAncient) {
+          return false;
+        }
+
+        return true;
       })
       .map(function (r) {
         // bun-v0.5.1 => v0.5.1

--- a/caddy/releases.js
+++ b/caddy/releases.js
@@ -8,7 +8,12 @@ module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
     // remove checksums and .deb
     all.releases = all.releases.filter(function (rel) {
-      return !/(\.txt)|(\.deb)$/i.test(rel.name);
+      let isOneOffAsset = rel.download.includes('buildable-artifact');
+      if (isOneOffAsset) {
+        return false;
+      }
+
+      return true;
     });
     return all;
   });

--- a/comrak/releases.js
+++ b/comrak/releases.js
@@ -4,8 +4,28 @@ var github = require('../_common/github.js');
 var owner = 'kivikakk';
 var repo = 'comrak';
 
+var ODDITIES = ['-musleabihf.1-'];
+
 module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
+    let builds = [];
+
+    loopBuilds: for (let build of all.releases) {
+      let isOddity;
+      for (let oddity of ODDITIES) {
+        isOddity = build.name.includes(oddity);
+        if (isOddity) {
+          break;
+        }
+      }
+      if (isOddity) {
+        continue;
+      }
+
+      builds.push(build);
+    }
+
+    all.releases = builds;
     return all;
   });
 };

--- a/curlie/releases.js
+++ b/curlie/releases.js
@@ -6,6 +6,7 @@ var repo = 'curlie';
 
 module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
+    all._names = ['curlie', 'curl-httpie'];
     return all;
   });
 };

--- a/dashcore/releases.js
+++ b/dashcore/releases.js
@@ -14,6 +14,7 @@ module.exports = function (request) {
         rel.os = 'macos';
       }
     });
+    all._names = ['dashd', 'dashcore'];
     return all;
   });
 };

--- a/deno/releases.js
+++ b/deno/releases.js
@@ -11,7 +11,12 @@ module.exports = function (request) {
     // remove checksums and .deb
     all.releases = all.releases
       .filter(function (rel) {
-        return !/(\.txt)|(\.deb)$/i.test(rel.name);
+        let isMeta = rel.name.endsWith('.d.ts');
+        if (isMeta) {
+          return false;
+        }
+
+        return true;
       })
       .map(function (rel) {
         var ext;

--- a/duckdns.sh/releases.js
+++ b/duckdns.sh/releases.js
@@ -17,6 +17,7 @@ module.exports = function (request) {
   ];
   let oses = ['freebsd', 'linux', 'macos', 'posix'];
   return githubSource(request, owner, repo, oses, arches).then(function (all) {
+    all._names = ['DuckDNS.sh', 'duckdns.sh', 'legacy'];
     return all;
   });
 };

--- a/ffmpeg/releases.js
+++ b/ffmpeg/releases.js
@@ -10,6 +10,11 @@ module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
     all.releases = all.releases
       .filter(function (rel) {
+        let isFfmpeg = rel.name.includes('ffmpeg');
+        if (!isFfmpeg) {
+          return;
+        }
+
         // remove README and LICENSE
         return !['.README', '.LICENSE'].includes(path.extname(rel.name));
       })

--- a/fish/releases.js
+++ b/fish/releases.js
@@ -4,10 +4,19 @@ var github = require('../_common/github.js');
 var owner = 'fish-shell';
 var repo = 'fish-shell';
 
+var ODDITIES = ['bundledpcre'];
+
 module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
     all.releases = all.releases
       .map(function (rel) {
+        for (let oddity of ODDITIES) {
+          let isOddity = rel.name.includes(oddity);
+          if (isOddity) {
+            return;
+          }
+        }
+
         // We can extract the macos bins from the .app
         if (/\.app\.zip$/.test(rel.name)) {
           rel.os = 'macos';

--- a/flutter/releases.js
+++ b/flutter/releases.js
@@ -1,55 +1,99 @@
 'use strict';
 
-var map = {};
+var FLUTTER_OSES = ['macos', 'linux', 'windows'];
 
-module.exports = function (request) {
-  var all = {
+// stable, beta, dev
+var channelMap = {};
+
+// This can be spot-checked against
+// https://docs.flutter.dev/release/archive?tab=windows
+
+// The release URLs are
+// - https://storage.googleapis.com/flutter_infra_release/releases/releases_macos.json
+// - https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json
+// - https://storage.googleapis.com/flutter_infra_release/releases/releases_windows.json
+// The old release URLs are
+// - https://storage.googleapis.com/flutter_infra/releases/releases_macos.json
+// - https://storage.googleapis.com/flutter_infra/releases/releases_linux.json
+// - https://storage.googleapis.com/flutter_infra/releases/releases_windows.json
+
+// The data looks like
+// {
+//   "base_url": "https://storage.googleapis.com/flutter_infra/releases",
+//   "current_release": {
+//     "beta": "b22742018b3edf16c6cadd7b76d9db5e7f9064b5",
+//     "dev": "fa5883b78e566877613ad1ccb48dd92075cb5c23",
+//     "stable": "02c026b03cd31dd3f867e5faeb7e104cce174c5f"
+//   },
+//   "releases": [
+//     {
+//       "hash": "fa5883b78e566877613ad1ccb48dd92075cb5c23",
+//       "channel": "dev",
+//       "version": "2.3.0-16.0.pre",
+//       "release_date": "2021-05-27T23:58:47.683121Z",
+//       "archive": "dev/macos/flutter_macos_2.3.0-16.0.pre-dev.zip",
+//       "sha256": "f572b42d36714e6c58a3ed170b93bb414e2ced3ca4bde5094fbe18061cbcba6c"
+//     },
+//     {
+//       "hash": "02c026b03cd31dd3f867e5faeb7e104cce174c5f",
+//       "channel": "stable",
+//       "version": "2.2.1",
+//       "release_date": "2021-05-27T23:06:07.243882Z",
+//       "archive": "stable/macos/flutter_macos_2.2.1-stable.zip",
+//       "sha256": "6373d39ec563c337600baf42a42b258420208e4523d85479373e113d61d748df"
+//     },
+//     {
+//       "hash": "b22742018b3edf16c6cadd7b76d9db5e7f9064b5",
+//       "channel": "beta",
+//       "version": "2.2.0",
+//       "release_date": "2021-05-19T21:14:59.281482Z",
+//       "archive": "beta/macos/flutter_macos_2.2.0-beta.zip",
+//       "sha256": "31ab530e708f8d1274712211253a27a4ce7d676f139d30f2ec021df22382f052"
+//     }
+//   ]
+// }
+
+module.exports = async function (request) {
+  let all = {
     download: '',
     releases: [],
+    channels: [],
   };
-  return Promise.all(
-    ['macos', 'linux', 'windows'].map(function (osname) {
-      return request({
-        url: `https://storage.googleapis.com/flutter_infra_release/releases/releases_${osname}.json`,
-        json: true,
-      }).then(function (resp) {
-        var body = resp.body;
-        all.download = body.base_url + '/{{ download }}';
-        body.releases.forEach(function (asset) {
-          if (!map[asset.channel]) {
-            map[asset.channel] = true;
-          }
-          all.releases.push({
-            version: asset.version,
-            lts: false,
-            channel: asset.channel,
-            date: asset.release_date.replace(/T.*/, ''),
-            os: osname,
-            arch: 'amd64',
-            hash: '-', // not sure about including hash / sha256 yet
-            download: asset.archive,
-          });
-        });
-      });
-    }),
-  ).then(function () {
-    all.releases.sort(function (a, b) {
-      if ('stable' === a.channel && a.channel !== b.channel) {
-        return -1;
-      }
-      if ('stable' === b.channel && a.channel !== b.channel) {
-        return 1;
-      }
-      if ('beta' === a.channel && a.channel !== b.channel) {
-        return -1;
-      }
-      if ('beta' === b.channel && a.channel !== b.channel) {
-        return 1;
-      }
-      return new Date(b.date).valueOf() - new Date(a.date).valueOf();
+
+  for (let osname of FLUTTER_OSES) {
+    let resp = await request({
+      url: `https://storage.googleapis.com/flutter_infra_release/releases/releases_${osname}.json`,
+      json: true,
     });
-    return all;
-  });
+
+    let body = resp.body;
+    all.download = `${body.base_url}/{{ download }}`;
+
+    for (let asset of body.releases) {
+      if (!channelMap[asset.channel]) {
+        channelMap[asset.channel] = true;
+      }
+
+      all.releases.push({
+        version: asset.version,
+        lts: false,
+        channel: asset.channel,
+        date: asset.release_date.replace(/T.*/, ''),
+        os: osname,
+        arch: 'amd64',
+        hash: asset.hash,
+        download: asset.archive,
+      });
+    }
+  }
+
+  all.channels = Object.keys(channelMap);
+
+  // note: versions have a waterfall relationship with channels:
+  // - a release that is in beta today may become stable tomorrow
+  // - semver prereleases are either beta or dev
+
+  return all;
 };
 
 if (module === require.main) {

--- a/git/releases.js
+++ b/git/releases.js
@@ -12,12 +12,15 @@ module.exports = function (request) {
     all.releases = all.releases
       .filter(function (rel) {
         rel.os = 'windows';
+        rel._version = rel.version.replace(/\.windows.1.*/, '');
+        rel._version = rel._version.replace(/\.windows(\.\d)/, '$1');
         return (
           /MinGit/i.test(rel.name || rel.download) &&
           !/busybox/i.test(rel.name || rel.download)
         );
       })
       .slice(0, 20);
+    all._names = ['MinGit', 'git'];
     return all;
   });
 };

--- a/gitea/releases.js
+++ b/gitea/releases.js
@@ -10,6 +10,9 @@ module.exports = function (request) {
     all.releases = all.releases.filter(function (rel) {
       return !/(\.txt)|(\.deb)|(\.asc)|(\.sha256)$/i.test(rel.name);
     });
+
+    // "windows-4.0" as a nod to Windows NT  ¯\_(ツ)_/¯
+    all._names = ['gitea', '-4.0-'];
     return all;
   });
 };

--- a/gitea/releases.js
+++ b/gitea/releases.js
@@ -4,11 +4,20 @@ var github = require('../_common/github.js');
 var owner = 'go-gitea';
 var repo = 'gitea';
 
+var ODDITIES = ['-gogit-', '-docs-'];
+
 module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
     // remove checksums and .deb
     all.releases = all.releases.filter(function (rel) {
-      return !/(\.txt)|(\.deb)|(\.asc)|(\.sha256)$/i.test(rel.name);
+      for (let oddity of ODDITIES) {
+        let isOddity = rel.name.includes(oddity);
+        if (isOddity) {
+          return false;
+        }
+      }
+
+      return true;
     });
 
     // "windows-4.0" as a nod to Windows NT  ¯\_(ツ)_/¯

--- a/go/releases.js
+++ b/go/releases.js
@@ -47,6 +47,11 @@ function getAllReleases(request) {
       var fileversion = release.version.slice(2);
 
       release.files.forEach((asset) => {
+        let isArtifact = asset.filename.includes('bootstrap');
+        if (isArtifact) {
+          return;
+        }
+
         var filename = asset.filename;
         var os = osMap[asset.os] || asset.os || '-';
         var arch = archMap[asset.arch] || asset.arch || '-';

--- a/go/releases.js
+++ b/go/releases.js
@@ -43,6 +43,8 @@ function getAllReleases(request) {
         parts.push('0');
       }
       var version = parts.join('.');
+      // nix 'go' prefix
+      var fileversion = release.version.slice(2);
 
       release.files.forEach((asset) => {
         var filename = asset.filename;
@@ -50,6 +52,7 @@ function getAllReleases(request) {
         var arch = archMap[asset.arch] || asset.arch || '-';
         all.releases.push({
           version: version,
+          _version: fileversion,
           // all go versions >= 1.0.0 are effectively LTS
           lts: (parts[0] > 0 && release.stable) || false,
           channel: (release.stable && 'stable') || 'beta',

--- a/gpg/releases.js
+++ b/gpg/releases.js
@@ -41,7 +41,6 @@ function transformReleases(links) {
 
   let releases = links
     .map(function (link) {
-      // strip 'go' prefix, standardize version
       let isLts = ltsRe.test(link);
       let parts = link.match(matcher);
       if (!parts || !parts[2]) {
@@ -52,10 +51,12 @@ function transformReleases(links) {
       if (segs.length > 3) {
         version += '+' + segs.slice(3);
       }
+      let fileversion = segs.join('.');
 
       return {
         name: parts[1],
         version: version,
+        _version: fileversion,
         // all go versions >= 1.0.0 are effectively LTS
         lts: isLts,
         channel: 'stable',
@@ -70,6 +71,7 @@ function transformReleases(links) {
     .filter(Boolean);
 
   return {
+    _names: ['GnuPG', 'gpgosx'],
     releases: releases,
   };
 }

--- a/hugo-extended/releases.js
+++ b/hugo-extended/releases.js
@@ -13,12 +13,9 @@ module.exports = async function (request) {
       return false;
     }
 
-    // remove checksums and .deb
-    for (let ignorableExt of ['.txt', '.deb']) {
-      let isIgnorable = rel.name.endsWith(ignorableExt);
-      if (isIgnorable) {
-        return false;
-      }
+    let isOldAlias = rel.name.includes('Linux-64bit');
+    if (isOldAlias) {
+      return false;
     }
 
     return true;

--- a/hugo/releases.js
+++ b/hugo/releases.js
@@ -13,12 +13,9 @@ module.exports = async function (request) {
       return false;
     }
 
-    // remove checksums and .deb
-    for (let ignorableExt of ['.txt', '.deb']) {
-      let isIgnorable = rel.name.endsWith(ignorableExt);
-      if (isIgnorable) {
-        return false;
-      }
+    let isOldAlias = rel.name.includes('Linux-64bit');
+    if (isOldAlias) {
+      return false;
     }
 
     return true;

--- a/iterm2/releases.js
+++ b/iterm2/releases.js
@@ -24,17 +24,24 @@ function transformReleases(links) {
   //console.log(links.length);
 
   return {
+    _names: ['iTerm2', 'iterm2'],
     releases: links
       .map(function (link) {
-        // strip 'go' prefix, standardize version
         var channel = /\/stable\//.test(link) ? 'stable' : 'beta';
+
         var parts = link
           .replace(/.*\/iTerm2[-_]v?(\d_.*)\.zip/, '$1')
           .split('_');
         var version = parts.join('.').replace(/([_-])?beta/, '-beta');
 
+        // ex: 3.5.0-beta17 => 3_5_0beta17
+        // ex: 3.0.2-preview => 3_0_2-preview
+        let fileversion = version.replace(/\./g, '_');
+        fileversion = fileversion.replace(/-beta/g, 'beta');
+
         return {
           version: version,
+          _version: fileversion,
           // all go versions >= 1.0.0 are effectively LTS
           lts: 'stable' === channel,
           channel: channel,

--- a/kubectx/releases.js
+++ b/kubectx/releases.js
@@ -6,6 +6,7 @@ var repo = 'kubectx';
 
 module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
+    all._names = ['kubectx', 'kubens'];
     return all;
   });
 };

--- a/kubectx/releases.js
+++ b/kubectx/releases.js
@@ -4,14 +4,6 @@ var github = require('../_common/github.js');
 var owner = 'ahmetb';
 var repo = 'kubectx';
 
-/******************************************************************************/
-/** Note: Delete this Comment!                                               **/
-/**                                                                          **/
-/** Need a an example that filters out miscellaneous release files?          **/
-/**   See `deno`, `gitea`, or `caddy`                                        **/
-/**                                                                          **/
-/******************************************************************************/
-
 module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
     return all;

--- a/macos/releases.js
+++ b/macos/releases.js
@@ -41,7 +41,11 @@ var headers = {
 };
 
 module.exports = function (request) {
-  var all = { download: '', releases: [] };
+  var all = {
+    _names: ['InstallOS'],
+    download: '',
+    releases: [],
+  };
 
   return Promise.all(
     oses.map(function (os) {

--- a/ollama/releases.js
+++ b/ollama/releases.js
@@ -19,6 +19,7 @@ module.exports = async function (request) {
   }
   all.releases = releases;
 
+  all._names = ['Ollama', 'ollama'];
   return all;
 };
 

--- a/pathman/releases.js
+++ b/pathman/releases.js
@@ -8,6 +8,7 @@ var baseurl = 'https://git.rootprojects.org';
 module.exports = function (request) {
   return github(request, owner, repo, baseurl).then(function (all) {
     all.releases = all.releases.filter(function (release) {
+      release._filename = release.name;
       return !/debug/.test(release.name);
     });
     return all;

--- a/pathman/releases.js
+++ b/pathman/releases.js
@@ -9,7 +9,13 @@ module.exports = function (request) {
   return github(request, owner, repo, baseurl).then(function (all) {
     all.releases = all.releases.filter(function (release) {
       release._filename = release.name;
-      return !/debug/.test(release.name);
+
+      let isOldAlias = release.name.includes('armv8');
+      if (isOldAlias) {
+        return false;
+      }
+
+      return true;
     });
     return all;
   });

--- a/postgres/releases.js
+++ b/postgres/releases.js
@@ -75,6 +75,7 @@ module.exports = async function () {
         download: '',
       },
     ].map(function (rel) {
+      rel._version = `${rel.version}-1`;
       rel.download =
         'https://get.enterprisedb.com/postgresql/' +
         rel.name +
@@ -82,6 +83,7 @@ module.exports = async function () {
       return rel;
     }),
     download: '',
+    _names: ['PostgreSQL', 'postgresql', 'Postgres', 'postgres', 'binaries'],
   };
 };
 

--- a/pwsh/releases.js
+++ b/pwsh/releases.js
@@ -15,6 +15,8 @@ module.exports = function (request) {
 
       return !/(alpine)|(fxdependent)|(\.deb)|(\.pkg)|(\.rpm)$/i.test(rel.name);
     });
+
+    all._names = ['PowerShell', 'powershell'];
     return all;
   });
 };

--- a/rg/releases.js
+++ b/rg/releases.js
@@ -6,6 +6,7 @@ var repo = 'ripgrep';
 
 module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
+    all._names = ['ripgrep', 'rg'];
     return all;
   });
 };

--- a/sass/releases.js
+++ b/sass/releases.js
@@ -6,6 +6,7 @@ var repo = 'dart-sass';
 
 module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
+    all._names = ['dart-sass', 'sass'];
     return all;
   });
 };

--- a/sqlpkg/releases.js
+++ b/sqlpkg/releases.js
@@ -6,6 +6,7 @@ var repo = 'sqlpkg-cli';
 
 module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
+    all._names = ['sqlpkg-cli', 'sqlpkg'];
     return all;
   });
 };

--- a/trip/releases.js
+++ b/trip/releases.js
@@ -6,6 +6,7 @@ var repo = 'trippy';
 
 module.exports = function (request) {
   return github(request, owner, repo).then(function (all) {
+    all._names = ['trippy', 'trip'];
     return all;
   });
 };

--- a/vim-zig/releases.js
+++ b/vim-zig/releases.js
@@ -6,6 +6,7 @@ var gitUrl = 'https://github.com/ziglang/zig.vim.git';
 module.exports = async function (request) {
   let all = await git(gitUrl);
 
+  all._names = ['zig.vim', 'vim-zig'];
   return all;
 };
 

--- a/zig/releases.js
+++ b/zig/releases.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var NON_BUILDS = ['bootstrap', 'src'];
+
 module.exports = function (request) {
   return request({
     url: 'https://ziglang.org/download/index.json',
@@ -22,6 +24,11 @@ module.exports = function (request) {
         // at the same level as platform releases
         let isNotPackage = !pkg || 'object' !== typeof pkg || !pkg.tarball;
         if (isNotPackage) {
+          return;
+        }
+
+        let isNonBuild = NON_BUILDS.includes(platform);
+        if (isNonBuild) {
           return;
         }
 


### PR DESCRIPTION
- include more specific filtering (i.e. deno `.d.ts` meta file)
- remove more generic filtering (i.e. `.SHA1SUM`, `.txt`, `.deb`)
- additional classification
  - `_names` for package name variations & meaningless words (e.g. `sqpkg-cli`, `binaries`)
  - `_version` for the version as it appears in the filename
 