### PR TITLE
Only call load.sh once, even when .bashrc sources .profile

### DIFF
--- a/_webi/package-install.tpl.sh
+++ b/_webi/package-install.tpl.sh
@@ -285,24 +285,24 @@ __bootstrap_webi() {
         fi
 
         if ! test -e ~/.config/envman/load.sh; then
-            # shellcheck disable=SC2016
-            {
-                echo 'if [ -z "$ENVMAN_LOADED" ]; then'
-                echo '    ENVMAN_LOADED=1'
+            cat << LOADENVMAN > ~/.config/envman/load.sh
+if [ -z "\$ENVMAN_LOADED" ]; then
+    ENVMAN_LOADED=1
 
-                echo '# Generated for envman. Do not edit.'
-                echo 'for x in ~/.config/envman/*.env; do'
-                echo '    my_basename="$(basename "${x}")"'
-                echo '    if [ "*.env" = "${my_basename}" ]; then'
-                echo '        continue'
-                echo '    fi'
-                echo ''
-                echo '    # shellcheck source=/dev/null'
-                echo '    . "${x}"'
-                echo 'done'
+    # Generated for envman. Do not edit.
+    for x in ~/.config/envman/*.env; do
+        my_basename="\$(basename "\${x}")"
+        if [ "*.env" = "\${my_basename}" ]; then
+            continue
+        fi
 
-                echo 'fi'
-            } > ~/.config/envman/load.sh
+        # shellcheck source=/dev/null
+        . "\${x}"
+    done
+
+fi
+LOADENVMAN
+
         fi
 
         if command -v sh > /dev/null; then

--- a/_webi/package-install.tpl.sh
+++ b/_webi/package-install.tpl.sh
@@ -258,6 +258,8 @@ __bootstrap_webi() {
         )"
 
         my_export="export PATH=\"$my_path_export:\$PATH\""
+
+        touch -a ~/.config/envman/PATH.env
         if grep -q -F "${my_export}" ~/.config/envman/PATH.env; then
             return 0
         fi

--- a/_webi/package-install.tpl.sh
+++ b/_webi/package-install.tpl.sh
@@ -571,7 +571,7 @@ __bootstrap_webi() {
     if [ -z "${_WEBI_CHILD-}" ] && [ -f "$_webi_tmp/.PATH.env" ]; then
         if test -s "$_webi_tmp/.PATH.env"; then
             # shellcheck disable=SC2088 # ~ should not expand here
-            echo "    Updated $(t_path '~/.config/envman/PATH.env') updated with:"
+            echo "    Edit $(t_path '~/.config/envman/PATH.env') to add:"
             sort -u "$_webi_tmp/.PATH.env" | while read -r my_new_path; do
                 echo "        $(t_path "${my_new_path}")"
             done

--- a/_webi/package-install.tpl.sh
+++ b/_webi/package-install.tpl.sh
@@ -287,6 +287,9 @@ __bootstrap_webi() {
         if ! test -e ~/.config/envman/load.sh; then
             # shellcheck disable=SC2016
             {
+                echo 'if [ -z "$ENVMAN_LOADED" ]; then'
+                echo '    ENVMAN_LOADED=1'
+
                 echo '# Generated for envman. Do not edit.'
                 echo 'for x in ~/.config/envman/*.env; do'
                 echo '    my_basename="$(basename "${x}")"'
@@ -297,6 +300,8 @@ __bootstrap_webi() {
                 echo '    # shellcheck source=/dev/null'
                 echo '    . "${x}"'
                 echo 'done'
+
+                echo 'fi'
             } > ~/.config/envman/load.sh
         fi
 

--- a/webi-essentials/install.sh
+++ b/webi-essentials/install.sh
@@ -24,8 +24,8 @@ fn_install_webi_essentials_macos() { (
     if ! xcode-select -p > /dev/null 2> /dev/null; then
         cmd_xcode_cli_tools_install="xcode-select --install"
         echo "    Running $(t_cmd "${cmd_xcode_cli_tools_install}")"
-        echo ""
         $cmd_xcode_cli_tools_install 2> /dev/null
+        echo ""
         echo ">>> $(t_attn 'ACTION REQUIRED') <<<"
         echo ""
         echo "        $(t_attn "Click") '$(t_bold 'Install')' $(t_attn "in the pop-up")"
@@ -45,8 +45,10 @@ fn_install_webi_essentials_macos() { (
     if test "$(uname -m)" = 'arm64'; then
         # Also pkgutil --pkg-info com.apple.pkg.RosettaUpdateAuto
         # See <https://apple.stackexchange.com/q/427970/27465>
+        cmd_install_rosetta="softwareupdate --install-rosetta --agree-to-license"
         if ! arch -arch x86_64 uname -m > /dev/null 2>&1; then
-            softwareupdate --install-rosetta --agree-to-license
+            echo "    Running $(t_cmd "${cmd_install_rosetta}")"
+            $cmd_install_rosetta
         fi
     fi
     #tar - built-in


### PR DESCRIPTION
Changed load.sh so that it will load only once.

On fresh debian and ubuntu systems, I have .profile calling .bashrc.

I like it that webi installs the load.sh source-calling in both, but I'd like it to load only once.

Added a 'singleton flag' of sorts to prevent load.sh from loading more than once in a session.