### PR TITLE
fix: revert curl --fail-with-body to --fail

### DIFF
--- a/_webi/curl-pipe-bootstrap.tpl.sh
+++ b/_webi/curl-pipe-bootstrap.tpl.sh
@@ -119,9 +119,9 @@ fn_curl() { (
     a_url="${1}"
     a_path="${2}"
 
-    cmd_curl="curl --fail-with-body -sSL -#"
+    cmd_curl="curl -f -sSL -#"
     if fn_is_interactive; then
-        cmd_curl="curl --fail-with-body sSL"
+        cmd_curl="curl -f sSL"
     fi
 
     b_triple_ua="$(fn_get_target_triple_user_agent)"

--- a/_webi/install-package.tpl.ps1
+++ b/_webi/install-package.tpl.ps1
@@ -69,7 +69,7 @@ function Invoke-DownloadUrl {
         Write-Host "        ?$Params"
         $URL = "${URL}?${Params}"
     }
-    curl.exe '-#' --fail-with-body -sS -A $Env:WEBI_UA -L $URL | Out-File $TmpPath
+    curl.exe '-#' -f -sS -A $Env:WEBI_UA -L $URL | Out-File $TmpPath
 
     Remove-Item -Path $Path -Force -ErrorAction Ignore
     Move-Item $TmpPath $Path

--- a/ssh-authorize/ssh-authorize.ps1
+++ b/ssh-authorize/ssh-authorize.ps1
@@ -166,7 +166,7 @@ function Add-AuthorizedKey($UrlOrPath) {
 
     $TmpKeys = "new_authorized_keys.tmp.txt"
 
-    curl.exe --fail-with-body -sS $UrlOrPath | Out-File -Force "${TmpKeys}.partial"
+    curl.exe -f -sS $UrlOrPath | Out-File -Force "${TmpKeys}.partial"
     $null = Move-Item -Force "${TmpKeys}.partial" $TmpKeys
 
     IF ($IsHttp) {

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -71,7 +71,7 @@ function Invoke-DownloadUrl {
         Write-Host "        ?$Params"
         $URL = "${URL}?${Params}"
     }
-    curl.exe '-#' --fail-with-body -sS -A $Env:WEBI_UA -L $URL | Out-File $TmpPath
+    curl.exe '-#' -f -sS -A $Env:WEBI_UA -L $URL | Out-File $TmpPath
 
     Remove-Item -Path $Path -Force -ErrorAction Ignore
     Move-Item $TmpPath $Path


### PR DESCRIPTION
Deployed to `hotfix`.

Re: #767 #769 

Improved error handling causes errors 🤷‍♂️. Reverted `--fail-with-body` (which is only a few years old) to `-f` (which works on old and enterprise-y systems).