### PR TITLE
fix(busybox): wget on busybox

### DIFF
--- a/_webi/package-install.tpl.sh
+++ b/_webi/package-install.tpl.sh
@@ -709,9 +709,14 @@ fn_wget() { (
     a_url="${1}"
     a_path="${2}"
 
-    cmd_wget="wget -q --user-agent"
+    cmd_wget="wget -c -q --user-agent"
     if fn_is_tty; then
-        cmd_wget="wget -q --show-progress --user-agent"
+        cmd_wget="wget -c -q --show-progress --user-agent"
+    fi
+    # busybox wget doesn't support --show-progress
+    # See <https://github.com/webinstall/webi-installers/pull/772>
+    if readlink "$(command -v wget)" | grep -q busybox; then
+        cmd_wget="wget --user-agent"
     fi
 
     b_triple_ua="$(fn_get_target_triple_user_agent)"
@@ -720,9 +725,9 @@ fn_wget() { (
         b_agent="webi/wget+curl ${b_triple_ua}"
     fi
 
-    if ! $cmd_wget "${b_agent}" -c "${a_url}" -O "${a_path}"; then
+    if ! $cmd_wget "${b_agent}" "${a_url}" -O "${a_path}"; then
         echo >&2 "    $(t_err "failed to download (wget)") '$(t_url "${a_url}")'"
-        echo >&2 "    $cmd_wget '${b_agent}' -c '${a_url}' -O '${a_path}'"
+        echo >&2 "    $cmd_wget '${b_agent}' '${a_url}' -O '${a_path}'"
         echo >&2 "    $(wget -V)"
         return 1
     fi
@@ -765,10 +770,10 @@ fn_download_to_path() { (
     a_path="${2}"
 
     mkdir -p "$(dirname "${a_path}")"
-    if command -v wget > /dev/null; then
-        fn_wget "${a_url}" "${a_path}.part"
-    elif command -v curl > /dev/null; then
+    if command -v curl > /dev/null; then
         fn_curl "${a_url}" "${a_path}.part"
+    elif command -v wget > /dev/null; then
+        fn_wget "${a_url}" "${a_path}.part"
     else
         echo >&2 "    $(t_err "failed to detect HTTP client (curl, wget)")"
         return 1

--- a/webi/webi.sh
+++ b/webi/webi.sh
@@ -61,8 +61,6 @@ __webi_main() {
     set +e
     WEBI_CURL="$(command -v curl)"
     export WEBI_URL
-    WEBI_WGET="$(command -v wget)"
-    export WEBI_WGET
     set -e
 
     my_libc=''


### PR DESCRIPTION
## Problem

Failing on Alpine / Busybox wget due to `--show-progress`.

I discovered this since fixing TTY support in #736 while working on and testing #768

```sh
wget https://next.webinstall.dev/webi-essential -O - | sh
```

## Fixes & Changes

- prefer `curl` over `wget` (with `-#`, curl is just better)
- limit `wget` options on busybox
  - no `-c` because it gives confusing errors when the file is downloaded (i.e. `https://example.com`)
  - no `--show-progress` because it's not supported at all
  - drop unused `WEBI_WGET` (to avoid furute confusion over something that does nothing)

## Historical Reasons for `wget`

Originally I preferred `wget` for `-c` to resume downloads (and maybe the nicer default progress bar), but in reality downloads rarely fail, and `curl -#` is better than `--progres=dot` for non-ttys.

Beyond that minimal Ubuntus and Alpine ship with `wget` as the default rather than `curl`.