### PR TITLE
chore: bump version to 1.2.7

### DIFF
--- a/webi/webi.sh
+++ b/webi/webi.sh
@@ -152,7 +152,7 @@ __webi_main() {
         my_checksum="$(
             fn_checksum
         )"
-        my_version=v1.2.0
+        my_version=v1.2.7
         printf "\e[35mwebi\e[32m %s\e[0m Copyright 2020+ AJ ONeal\n" "${my_version} (${my_checksum})"
         printf "    \e[36mhttps://webinstall.dev/webi\e[0m\n"
     }


### PR DESCRIPTION
There have been significant changes since b1d7df19:

https://github.com/webinstall/webi-installers/compare/b1d7df19...main?expand=1#diff-394881dbd4ce87350748996136104628b890fb4b02139e5d6d89b5d1208c3c11

I'm not quite ready to call this v1.3.0 - that will be once we bring in the same changes as in `_webi/curl-pipe-bootstrap.tpl.sh` and `_webi/package-install.tpl.ps1`.

