### PR TITLE
fix OS detection when `uname -o` is not supported + typo fix in output

### DIFF
--- a/_webi/curl-pipe-bootstrap.tpl.sh
+++ b/_webi/curl-pipe-bootstrap.tpl.sh
@@ -27,9 +27,33 @@ fn_show_welcome() { (
     echo ""
     echo "    $(t_attn 'Success')? Star it!   $(t_url 'https://github.com/webinstall/webi-installers')"
     echo "    $(t_attn 'Problem')? Report it: $(t_url 'https://github.com/webinstall/webi-installers/issues')"
-    echo "                        $(t_dim "(your system is") $(t_host "$(uname -s)")/$(t_host "$(uname -m)") $(t_dim "with") $(t_host "$(fn_get_libc)") $(t_dim "&") $(t_host "$(fn_get_http_client_name)")$(t_dim ")")"
+    echo "                        $(t_dim "(your system is") $(t_host "$(fn_get_os)")/$(t_host "$(uname -m)") $(t_dim "with") $(t_host "$(fn_get_libc)") $(t_dim "&") $(t_host "$(fn_get_http_client_name)")$(t_dim ")")"
 
     sleep 0.2
+); }
+
+fn_get_os() { (
+    # Ex:
+    #     GNU/Linux
+    #     Android
+    #     Linux (often Alpine, musl)
+    #     Darwin
+    b_os="$(uname -o 2> /dev/null || echo '')"
+    b_sys="$(uname -s)"
+    if test -z "${b_os}" || test "${b_os}" = "${b_sys}"; then
+        # ex: 'Darwin' (and plain, non-GNU 'Linux')
+        echo "${b_sys}"
+        return 0
+    fi
+
+    if echo "${b_os}" | grep -q "${b_sys}"; then
+        # ex: 'GNU/Linux'
+        echo "${b_os}"
+        return 0
+    fi
+
+    # ex: 'Android/Linux'
+    echo "${b_os}/${b_sys}"
 ); }
 
 fn_get_libc() { (
@@ -38,7 +62,7 @@ fn_get_libc() { (
     #     libc
     if ldd /bin/ls 2> /dev/null | grep -q 'musl' 2> /dev/null; then
         echo 'musl'
-    elif uname -o | grep -q 'GNU' || uname -s | grep -q 'Linux'; then
+    elif fn_get_os | grep -q 'GNU|Linux'; then
         echo 'gnu'
     else
         echo 'libc'
@@ -177,9 +201,9 @@ fn_curl() { (
 
 fn_get_target_triple_user_agent() { (
     # Ex:
-    #     x86_64/unknown Linux/5.15.107-2-pve gnu
+    #     x86_64/unknown GNU/Linux/5.15.107-2-pve gnu
     #     arm64/unknown Darwin/22.6.0 libc
-    echo "$(uname -m)/unknown $(uname -s)/$(uname -r) $(fn_get_libc)"
+    echo "$(uname -m)/unknown $(fn_get_os)/$(uname -r) $(fn_get_libc)"
 ); }
 
 fn_download_to_path() { (

--- a/_webi/package-install.tpl.sh
+++ b/_webi/package-install.tpl.sh
@@ -26,6 +26,7 @@ __bootstrap_webi() {
     #PKG_ARCHES=
     #PKG_LIBCS=
     #PKG_FORMATS=
+    #PKG_LATEST=
     WEBI_PKG_DOWNLOAD=""
     WEBI_DOWNLOAD_DIR="${HOME}/Downloads"
     if command -v xdg-user-dir > /dev/null; then
@@ -125,8 +126,12 @@ __bootstrap_webi() {
         {
             echo ""
             echo "    $(t_err "Error: no '${PKG_NAME:-"Unknown Package"}@${WEBI_TAG:-"Unknown Tag"}' release for '${WEBI_OS:-"Unknown OS"}' (${WEBI_LIBC:-"Unknown Libc"}) on '${WEBI_ARCH:-"Unknown CPU"}' as one of '${WEBI_FORMATS:-"Unknown File Type"}'")"
-            echo "      '$PKG_NAME' is available for '$PKG_OSES' ($PKG_LIBCS) on '$PKG_ARCHES' as one of '$PKG_FORMATS'"
-            echo "      (check that the package name and version are correct)"
+            echo ""
+            echo "        CPUs: $PKG_ARCHES"
+            echo "        OSes: $PKG_OSES"
+            echo "        libcs: $PKG_LIBCS"
+            echo "        Package Formats: $PKG_FORMATS"
+            echo "        (check that the package name and version are correct)"
 
             echo ""
             my_release_url="$(echo "$WEBI_RELEASES" | sed 's:?.*::')"

--- a/_webi/package-install.tpl.sh
+++ b/_webi/package-install.tpl.sh
@@ -533,9 +533,33 @@ fn_show_welcome_back() { (
     echo ""
     echo "    $(t_attn 'Success')? Star it!   $(t_url 'https://github.com/webinstall/webi-installers')"
     echo "    $(t_attn 'Problem')? Report it: $(t_url 'https://github.com/webinstall/webi-installers/issues')"
-    echo "                        $(t_dim "(your system is") $(t_host "$(uname -s)")/$(t_host "$(uname -m)") $(t_dim "with") $(t_host "$(fn_get_libc)") $(t_dim "&") $(t_host "$(fn_get_http_client_name)")$(t_dim ")")"
+    echo "                        $(t_dim "(your system is") $(t_host "$(fn_get_os)")/$(t_host "$(uname -m)") $(t_dim "with") $(t_host "$(fn_get_libc)") $(t_dim "&") $(t_host "$(fn_get_http_client_name)")$(t_dim ")")"
 
     sleep 0.2
+); }
+
+fn_get_os() { (
+    # Ex:
+    #     GNU/Linux
+    #     Android
+    #     Linux (often Alpine, musl)
+    #     Darwin
+    b_os="$(uname -o 2> /dev/null || echo '')"
+    b_sys="$(uname -s)"
+    if test -z "${b_os}" || test "${b_os}" = "${b_sys}"; then
+        # ex: 'Darwin' (and plain, non-GNU 'Linux')
+        echo "${b_sys}"
+        return 0
+    fi
+
+    if echo "${b_os}" | grep -q "${b_sys}"; then
+        # ex: 'GNU/Linux'
+        echo "${b_os}"
+        return 0
+    fi
+
+    # ex: 'Android/Linux'
+    echo "${b_os}/${b_sys}"
 ); }
 
 fn_get_libc() { (
@@ -544,7 +568,7 @@ fn_get_libc() { (
     #     libc
     if ldd /bin/ls 2> /dev/null | grep -q 'musl' 2> /dev/null; then
         echo 'musl'
-    elif uname -o | grep -q 'GNU' || uname -s | grep -q 'Linux'; then
+    elif fn_get_os | grep -q 'GNU|Linux'; then
         echo 'gnu'
     else
         echo 'libc'
@@ -683,9 +707,9 @@ fn_curl() { (
 
 fn_get_target_triple_user_agent() { (
     # Ex:
-    #     x86_64/unknown Linux/5.15.107-2-pve gnu
+    #     x86_64/unknown GNU/Linux/5.15.107-2-pve gnu
     #     arm64/unknown Darwin/22.6.0 libc
-    echo "$(uname -m)/unknown $(uname -s)/$(uname -r) $(fn_get_libc)"
+    echo "$(uname -m)/unknown $(fn_get_os)/$(uname -r) $(fn_get_libc)"
 ); }
 
 fn_download_to_path() { (

--- a/_webi/releases.js
+++ b/_webi/releases.js
@@ -99,7 +99,7 @@ Releases.renderBash = async function (
     ['WEBI_ARCH', arch],
     ['WEBI_LIBC', libc],
     ['WEBI_TAG', tag],
-    ['WEBI_RELEASES', `${baseurl}/${releaseUrl}`],
+    ['WEBI_RELEASES', `${baseurl}${releaseUrl}`],
     ['WEBI_CSV', releaseCsv],
     ['WEBI_VERSION', rel.version],
     ['WEBI_MAJOR', v.major],


### PR DESCRIPTION
Alpine (musl) and some BSDs don't always support `uname -o` (Operating System), which is required on Linux to distinguish between GNU and Bionic (Android).

This adds some feature detection for that.