### PR TITLE
fix(builds-cacher): fallback to setting build.name from build.download

### DIFF
--- a/_webi/builds-cacher.js
+++ b/_webi/builds-cacher.js
@@ -415,6 +415,10 @@ BuildsCacher.create = function ({ ALL_TERMS, installers, caches }) {
         continue;
       }
 
+      if (!build.name) {
+        build.name = build.download.replace(/.*\//, '');
+      }
+
       build.target = buildTarget;
       meta.packages.push(build);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@webinstall/webi-installers",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@webinstall/webi-installers",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@root/request": "^1.9.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webinstall/webi-installers",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "webinstall script repository",
   "main": "_webi/",
   "scripts": {


### PR DESCRIPTION
Amazingly, this didn't actually hard-break most (any?) downloads, but it sure looks like it would have.

For example:

```text
Extracting ~/Downloads/go/1.20/undefined
```

It worked, but...