### PR TITLE
fix(windows): use -File to pass $HOME as a single argument when it contains spaces

### DIFF
--- a/psscriptanalyzer/install.ps1
+++ b/psscriptanalyzer/install.ps1
@@ -13,7 +13,7 @@ function Repair-MissingCommand {
         Return
     }
 
-    & $HOME\.local\bin\webi-pwsh.ps1 $Package
+    & "$HOME\.local\bin\webi-pwsh.ps1" $Package
     $null = Sync-EnvPath
 }
 

--- a/pwsh-essentials/install.ps1
+++ b/pwsh-essentials/install.ps1
@@ -15,7 +15,7 @@ function Repair-MissingCommand {
         Return
     }
 
-    & $HOME\.local\bin\webi-pwsh.ps1 $Package
+    & "$HOME\.local\bin\webi-pwsh.ps1" $Package
     $null = Sync-EnvPath
 }
 
@@ -47,7 +47,7 @@ function Install-PwshEssential {
     Repair-MissingCommand -Name "PowerShell Core" -Package "pwsh" -Command "pwsh"
 
     # Fetch PSScriptAnalyzer (fmt, lint, fix)
-    & $HOME\.local\bin\webi-pwsh.ps1 psscriptanalyzer
+    & "$HOME\.local\bin\webi-pwsh.ps1" psscriptanalyzer
 
     # Fetch shorthand commands to fmt, lint, & fix
     $ScriptNames = , "pwsh-fmt", "pwsh-fix", "pwsh-lint"

--- a/sd/install.ps1
+++ b/sd/install.ps1
@@ -45,7 +45,7 @@ IF (!(Test-Path -Path "$pkg_src_cmd")) {
     # Settle unpacked archive into place
     Write-Output "Install Location: $pkg_src_cmd"
     New-Item "$pkg_src_bin" -ItemType Directory -Force | Out-Null
-    Move-Item -Path "b\*\release\sd.exe" -Destination "$pkg_src_bin"
+    Move-Item -Path "sd-*\sd.exe" -Destination "$pkg_src_bin"
     # Exit tmp
     Pop-Location
 }

--- a/webi-essentials/install.sh
+++ b/webi-essentials/install.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
 set -u
-#set -x
 
 fn_install_webi_essentials_macos() { (
     # streamline the output to be pretty
@@ -235,7 +234,7 @@ _install_webi_essentials_webi() { (
     cmd_sudo="${1}"
     b_pkgs="${2}"
 
-    if test "${b_pkgs}" == 'xz'; then
+    if test "${b_pkgs}" = 'xz'; then
         ~/.local/bin/webi xz
         return 0
     fi

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -199,7 +199,7 @@ $UrlParams = "formats=zip,exe,tar,git&libc=msvc"
 $PkgInstallPwsh = "$HOME\.local\tmp\$exename.install.ps1"
 Invoke-DownloadUrl -Force -URL $PKG_URL -Params $UrlParams -Path $PkgInstallPwsh
 
-powershell $HOME\.local\tmp\${exename}.install.ps1
+powershell -File "$HOME\.local\tmp\${exename}.install.ps1"
 
 IF ($IsWebiParent) {
     Write-Host ""

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -133,7 +133,7 @@ Push-Location $Env:USERPROFILE
 New-Item -Path "$HOME\.local\bin\" -ItemType Directory -Force | Out-Null
 
 # See note on Set-ExecutionPolicy above
-Set-Content -Path "$HOME\.local\bin\webi.bat" -Value "@echo off`r`npowershell -ExecutionPolicy Bypass %USERPROFILE%\.local\bin\webi-pwsh.ps1 %*"
+Set-Content -Path "$HOME\.local\bin\webi.bat" -Value "@echo off`r`npowershell -ExecutionPolicy Bypass -File `"%USERPROFILE%\.local\bin\webi-pwsh.ps1`" %*"
 # Backwards-compat bugfix: remove old webi-pwsh.ps1 location
 Remove-Item -Path "$HOME\.local\bin\webi.ps1" -Recurse -ErrorAction Ignore
 if (!(Test-Path -Path "$HOME\.local\opt")) {


### PR DESCRIPTION
Re #799 

In general variables don't need to be quoted in PowerShell - because variables are passed as objects.

However, when invoked with `&`, there's no consensus on how to properly quote them.

https://stackoverflow.com/questions/18537098/spaces-cause-split-in-path-with-powershell

However, in this particular case it looks like explicitly using `-File` works.