### PR TITLE
fix(windows): use -File and quotations in webi.bat file to pass %USERPROFILE% as a single argument when it contains spaces

### DIFF
--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -133,7 +133,7 @@ Push-Location $Env:USERPROFILE
 New-Item -Path "$HOME\.local\bin\" -ItemType Directory -Force | Out-Null
 
 # See note on Set-ExecutionPolicy above
-Set-Content -Path "$HOME\.local\bin\webi.bat" -Value "@echo off`r`npowershell -ExecutionPolicy Bypass %USERPROFILE%\.local\bin\webi-pwsh.ps1 %*"
+Set-Content -Path "$HOME\.local\bin\webi.bat" -Value "@echo off`r`npowershell -ExecutionPolicy Bypass -File `"%USERPROFILE%\.local\bin\webi-pwsh.ps1`" %*"
 # Backwards-compat bugfix: remove old webi-pwsh.ps1 location
 Remove-Item -Path "$HOME\.local\bin\webi.ps1" -Recurse -ErrorAction Ignore
 if (!(Test-Path -Path "$HOME\.local\opt")) {


### PR DESCRIPTION
The fix from #799 allowed me to install webi successfully. However, after installation, running `webi` gives me the same error message related to the space in my username.

I found that modifying the `C:\Users\username with space\.local\bin\webi.bat` file to add `-File` and quotations around the path containing %USERPROFILE% allows me to run `webi` successfully one time. Running it once subsequently clobbers my changes to the webi.bat file and brings back the error.

I modified `webi-pwsh.ps1` to include these changes when it generates the webi.bat file.