### PR TITLE
docs(README.md): Update readme to reflect repo name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Just create an empty directory and run the tests until you get a good result.
 git clone git@github.com:webinstall/webi-installers.git
 pushd ./webi-installers/
 git submodule update --init
-npm install
+npm clean-install
 ```
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ You just fill in the blanks.
 Just create an empty directory and run the tests until you get a good result.
 
 ```sh
-git clone git@github.com:webinstall/packages.git
-pushd packages
+git clone git@github.com:webinstall/webi-installers.git
+pushd ./webi-installers/
 npm install
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Just create an empty directory and run the tests until you get a good result.
 ```sh
 git clone git@github.com:webinstall/webi-installers.git
 pushd ./webi-installers/
+git submodule update --init
 npm install
 ```
 


### PR DESCRIPTION
Updated README.md from `packages` to `webi-installers` to be in line with current project structure.

If you want to skip the PR process for this, I completely understand. This came up in issue #813. 