### PR TITLE
Fix vim-devicons homepage link

### DIFF
--- a/vim-devicons/README.md
+++ b/vim-devicons/README.md
@@ -1,6 +1,6 @@
 ---
 title: vim-devicons
-homepage: https://github.com/ryanoasis/devicons
+homepage: https://github.com/ryanoasis/vim-devicons
 tagline: |
   VimDevIcons: Adds Icons to Your Plugins.
 ---


### PR DESCRIPTION
added the missing 'vim-' from the repository name