### PR TITLE
fix+sec: correctly scope GitHub tokens (don't send to Gitea)

### DIFF
--- a/_common/gitea.js
+++ b/_common/gitea.js
@@ -9,13 +9,22 @@ var ghRelease = require('./github.js');
  * @param {String} owner
  * @param {String} repo
  * @param {String} baseurl
+ * @param {String} [username]
+ * @param {String} [token]
  */
-async function getAllReleases(request, owner, repo, baseurl) {
+async function getAllReleases(
+  request,
+  owner,
+  repo,
+  baseurl,
+  username = '',
+  token = '',
+) {
   if (!baseurl) {
     throw new Error('missing baseurl');
   }
   baseurl = `${baseurl}/api/v1`;
-  let all = await ghRelease(request, owner, repo, baseurl);
+  let all = await ghRelease(request, owner, repo, baseurl, username, token);
   return all;
 }
 
@@ -24,9 +33,11 @@ module.exports = getAllReleases;
 if (module === require.main) {
   getAllReleases(
     require('@root/request'),
-    'coolaj86',
-    'go-pathman',
-    'https://git.coolaj86.com',
+    'root',
+    'pathman',
+    'https://git.rootprojects.org',
+    '',
+    '',
   ).then(
     //getAllReleases(require('@root/request'), 'root', 'serviceman', 'https://git.rootprojects.org').then(
     function (all) {

--- a/_common/gitea.js
+++ b/_common/gitea.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var ghRelease = require('./github.js');
+var GitHubish = require('./githubish.js');
 
 /**
  * Lists Gitea Releases (w/ uploaded assets)
@@ -24,7 +24,14 @@ async function getAllReleases(
     throw new Error('missing baseurl');
   }
   baseurl = `${baseurl}/api/v1`;
-  let all = await ghRelease(request, owner, repo, baseurl, username, token);
+  let all = await GitHubish.getAllReleases(
+    request,
+    owner,
+    repo,
+    baseurl,
+    username,
+    token,
+  );
   return all;
 }
 

--- a/_common/gitea.js
+++ b/_common/gitea.js
@@ -3,23 +3,20 @@
 var ghRelease = require('./github.js');
 
 /**
- * Gets the releases for 'ripgrep'. This function could be trimmed down and made
- * for use with any github release.
+ * Lists Gitea Releases (w/ uploaded assets)
  *
- * @param request
- * @param {string} owner
- * @param {string} repo
- * @returns {PromiseLike<any> | Promise<any>}
+ * @param {any} request
+ * @param {String} owner
+ * @param {String} repo
+ * @param {String} baseurl
  */
-function getAllReleases(request, owner, repo, baseurl) {
+async function getAllReleases(request, owner, repo, baseurl) {
   if (!baseurl) {
-    return Promise.reject('missing baseurl');
+    throw new Error('missing baseurl');
   }
-  return ghRelease(request, owner, repo, baseurl + '/api/v1').then(
-    function (all) {
-      return all;
-    },
-  );
+  baseurl = `${baseurl}/api/v1`;
+  let all = await ghRelease(request, owner, repo, baseurl);
+  return all;
 }
 
 module.exports = getAllReleases;

--- a/_common/github.js
+++ b/_common/github.js
@@ -9,12 +9,16 @@ require('dotenv').config();
  * @param {String} owner
  * @param {String} repo
  * @param {String} [baseurl]
+ * @param {String} [username]
+ * @param {String} [token]
  */
 async function getAllReleases(
   request,
   owner,
   repo,
   baseurl = 'https://api.github.com',
+  username = process.env.GITHUB_USERNAME || '',
+  token = process.env.GITHUB_TOKEN || '',
 ) {
   if (!owner) {
     throw new Error('missing owner for repo');
@@ -28,11 +32,10 @@ async function getAllReleases(
     json: true,
   };
 
-  // TODO I really don't like global config, find a way to do better
-  if (process.env.GITHUB_USERNAME) {
+  if (username) {
     req.auth = {
-      user: process.env.GITHUB_USERNAME,
-      pass: process.env.GITHUB_TOKEN,
+      user: username,
+      pass: token,
     };
   }
 

--- a/_common/github.js
+++ b/_common/github.js
@@ -1,14 +1,16 @@
 'use strict';
 
-var GitHubish = require('./githubish.js');
+require('dotenv').config({ path: '.env' });
+
+let GitHubish = require('./githubish.js');
 
 /**
- * Lists Gitea Releases (w/ uploaded assets)
+ * Lists GitHub Releases (w/ uploaded assets)
  *
  * @param {any} request
  * @param {String} owner
  * @param {String} repo
- * @param {String} baseurl
+ * @param {String} [baseurl]
  * @param {String} [username]
  * @param {String} [token]
  */
@@ -16,11 +18,10 @@ async function getAllReleases(
   request,
   owner,
   repo,
-  baseurl,
-  username = '',
-  token = '',
+  baseurl = 'https://api.github.com',
+  username = process.env.GITHUB_USERNAME || '',
+  token = process.env.GITHUB_TOKEN || '',
 ) {
-  baseurl = `${baseurl}/api/v1`;
   let all = await GitHubish.getAllReleases(
     request,
     owner,
@@ -35,15 +36,7 @@ async function getAllReleases(
 module.exports = getAllReleases;
 
 if (module === require.main) {
-  getAllReleases(
-    require('@root/request'),
-    'root',
-    'pathman',
-    'https://git.rootprojects.org',
-    '',
-    '',
-  ).then(
-    //getAllReleases(require('@root/request'), 'root', 'serviceman', 'https://git.rootprojects.org').then(
+  getAllReleases(require('@root/request'), 'BurntSushi', 'ripgrep').then(
     function (all) {
       console.info(JSON.stringify(all, null, 2));
     },

--- a/_common/github.js
+++ b/_common/github.js
@@ -5,10 +5,10 @@ require('dotenv').config();
 /**
  * Lists GitHub Releases (w/ uploaded assets)
  *
- * @param request
- * @param {string} owner
- * @param {string} repo
- * @returns {PromiseLike<any> | Promise<any>}
+ * @param {any} request
+ * @param {String} owner
+ * @param {String} repo
+ * @param {String} [baseurl]
  */
 async function getAllReleases(
   request,

--- a/_common/githubish.js
+++ b/_common/githubish.js
@@ -1,16 +1,14 @@
 'use strict';
 
-require('dotenv').config();
-
 let GitHubish = module.exports;
 
 /**
- * Lists GitHub Releases (w/ uploaded assets)
+ * Lists GitHub-Like Releases (w/ uploaded assets)
  *
  * @param {any} request
  * @param {String} owner
  * @param {String} repo
- * @param {String} [baseurl]
+ * @param {String} baseurl
  * @param {String} [username]
  * @param {String} [token]
  */
@@ -18,15 +16,18 @@ GitHubish.getAllReleases = async function (
   request,
   owner,
   repo,
-  baseurl = 'https://api.github.com',
-  username = process.env.GITHUB_USERNAME || '',
-  token = process.env.GITHUB_TOKEN || '',
+  baseurl,
+  username = '',
+  token = '',
 ) {
   if (!owner) {
     throw new Error('missing owner for repo');
   }
   if (!repo) {
     throw new Error('missing repo name');
+  }
+  if (!baseurl) {
+    throw new Error('missing baseurl');
   }
 
   var req = {
@@ -97,9 +98,12 @@ GitHubish.getAllReleases = async function (
 };
 
 if (module === require.main) {
-  GitHubish.getAllReleases(require('@root/request'), 'BurntSushi', 'ripgrep').then(
-    function (all) {
-      console.info(JSON.stringify(all, null, 2));
-    },
-  );
+  GitHubish.getAllReleases(
+    require('@root/request'),
+    'BurntSushi',
+    'ripgrep',
+    'https://api.github.com',
+  ).then(function (all) {
+    console.info(JSON.stringify(all, null, 2));
+  });
 }

--- a/_common/githubish.js
+++ b/_common/githubish.js
@@ -2,6 +2,8 @@
 
 require('dotenv').config();
 
+let GitHubish = module.exports;
+
 /**
  * Lists GitHub Releases (w/ uploaded assets)
  *
@@ -12,7 +14,7 @@ require('dotenv').config();
  * @param {String} [username]
  * @param {String} [token]
  */
-async function getAllReleases(
+GitHubish.getAllReleases = async function (
   request,
   owner,
   repo,
@@ -92,12 +94,10 @@ async function getAllReleases(
   }
 
   return all;
-}
-
-module.exports = getAllReleases;
+};
 
 if (module === require.main) {
-  getAllReleases(require('@root/request'), 'BurntSushi', 'ripgrep').then(
+  GitHubish.getAllReleases(require('@root/request'), 'BurntSushi', 'ripgrep').then(
     function (all) {
       console.info(JSON.stringify(all, null, 2));
     },


### PR DESCRIPTION
Re: #850 

Gitea was receiving the (unprivileged) GitHub tokens. A recent update to Gitea caused it to error (due to the incorrect authentication).

This separates the GitHub auth from Gitea auth.