### PR TITLE
fix(github-like): correct Authorization header

### DIFF
--- a/_common/githubish.js
+++ b/_common/githubish.js
@@ -40,7 +40,7 @@ GitHubish.getAllReleases = async function ({
     let userpass = `${username}:${token}`;
     let basicAuth = btoa(userpass);
     Object.assign(opts.headers, {
-      Authentication: `Basic ${basicAuth}`,
+      Authorization: `Basic ${basicAuth}`,
     });
   }
 


### PR DESCRIPTION
Re #855, caused by #852.

Additionally
- `Authorization: Basic <base64(user:token)>` ALWAYS SUCCEEDS, even when the TOKEN IS INCORRECT \
  (unless a rate-limit is hit)
- `Authorization: Bearer <token>` FAILS ON ERROR, as expected.

So that needs to be updated too.