### PR TITLE
feat: add cilium

### DIFF
--- a/_example/README.md
+++ b/_example/README.md
@@ -23,7 +23,7 @@ install:
 ```text
 ~/.config/envman/PATH.env
 ~/.local/bin/foo
-~/.local/opt/foo
+~/.local/opt/foo/
 ```
 
 ## Cheat Sheet

--- a/_example/releases.js
+++ b/_example/releases.js
@@ -12,17 +12,19 @@ var repo = 'ripgrep';
 /**                                                                          **/
 /******************************************************************************/
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
-    return all;
-  });
+module.exports = async function (request) {
+  let all = await github(request, owner, repo);
+  return all;
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
-    all = require('../_webi/normalize.js')(all);
+  (async function () {
+    let request = require('@root/request');
+    let normalize = require('../_webi/normalize.js');
+    let all = await module.exports(request);
+    all = normalize(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);
     console.info(JSON.stringify(all, null, 2));
-  });
+  })();
 }

--- a/cilium/README.md
+++ b/cilium/README.md
@@ -1,0 +1,47 @@
+---
+title: cilium
+homepage: https://github.com/cilium/cilium-cli
+tagline: |
+  cilium: manage & troubleshoot Kubernetes clusters running Cilium
+---
+
+To update or switch versions, run `webi cilium@stable` (or `@v2`, `@beta`,etc).
+
+### Files
+
+These are the files / directories that are created and/or modified with this
+install:
+
+```text
+~/.config/envman/PATH.env
+~/.local/bin/cilium
+~/.local/opt/cilium/
+```
+
+## Cheat Sheet
+
+> Cilium is an open source, cloud native solution for providing, securing, and
+> observing network connectivity between workloads, fueled by the revolutionary
+> Kernel technology eBPF.
+
+Quick Start User Guide:
+
+<https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#k8s-install-quick>
+
+To install the default version of the Cilium image:
+
+```sh
+cilium install
+```
+
+To upgrade to a specific version of the Cilium image:
+
+```sh
+cilium upgrade --version v1.15.3
+```
+
+To check the status of the current Cilium deployment:
+
+```sh
+cilium status
+```

--- a/cilium/install.ps1
+++ b/cilium/install.ps1
@@ -1,0 +1,45 @@
+#!/usr/bin/env pwsh
+
+##################
+# Install cilium #
+##################
+
+$pkg_cmd_name = "cilium"
+
+$pkg_dst_cmd = "$Env:USERPROFILE\.local\bin\cilium.exe"
+$pkg_dst = "$pkg_dst_cmd"
+
+$pkg_src_cmd = "$Env:USERPROFILE\.local\opt\cilium-v$Env:WEBI_VERSION\bin\cilium.exe"
+$pkg_src_bin = "$Env:USERPROFILE\.local\opt\cilium-v$Env:WEBI_VERSION\bin"
+$pkg_src_dir = "$Env:USERPROFILE\.local\opt\cilium-v$Env:WEBI_VERSION"
+$pkg_src = "$pkg_src_cmd"
+
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | Out-Null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
+    Write-Output "Downloading cilium from $Env:WEBI_PKG_URL to $pkg_download"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
+    & Move-Item "$pkg_download.part" "$pkg_download"
+}
+
+IF (!(Test-Path -Path "$pkg_src_cmd")) {
+    Write-Output "Installing cilium"
+    Push-Location .local\tmp
+
+    Remove-Item -Path ".\cilium-v*" -Recurse -ErrorAction Ignore
+    Remove-Item -Path ".\cilium.exe" -Recurse -ErrorAction Ignore
+
+    Write-Output "Unpacking $pkg_download"
+    & tar xf "$pkg_download"
+
+    Write-Output "Install Location: $pkg_src_cmd"
+    New-Item "$pkg_src_bin" -ItemType Directory -Force
+    Move-Item -Path ".\cilium-*\cilium.exe" -Destination "$pkg_src_bin"
+
+    Pop-Location
+}
+
+Write-Output "Copying into '$pkg_dst_cmd' from '$pkg_src_cmd'"
+Remove-Item -Path "$pkg_dst_cmd" -Recurse -ErrorAction Ignore
+Copy-Item -Path "$pkg_src" -Destination "$pkg_dst" -Recurse

--- a/cilium/install.sh
+++ b/cilium/install.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+__init_cilium() {
+    set -e
+    set -u
+
+    ##################
+    # Install cilium #
+    ##################
+
+    pkg_cmd_name="cilium"
+
+    pkg_dst_cmd="$HOME/.local/bin/cilium"
+    pkg_dst="$pkg_dst_cmd"
+
+    pkg_src_cmd="$HOME/.local/opt/cilium-v$WEBI_VERSION/bin/cilium"
+    pkg_src_dir="$HOME/.local/opt/cilium-v$WEBI_VERSION"
+    pkg_src="$pkg_src_cmd"
+
+    WEBI_SINGLE=true
+
+    # pkg_install must be defined by every package
+    pkg_install() {
+        # ~/.local/opt/cilium-v0.16.16/bin
+        mkdir -p "$(dirname "${pkg_src_cmd}")"
+
+        # mv ./hugo ~/.local/opt/cilium-v0.16.16/bin/
+        mv ./cilium "${pkg_src_cmd}"
+    }
+
+    pkg_get_current_version() {
+        cilium version 2> /dev/null |
+            head -n 1 |
+            cut -d ' ' -f 2
+    }
+
+}
+
+__init_cilium

--- a/cilium/releases.js
+++ b/cilium/releases.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var github = require('../_common/github.js');
+var owner = 'cilium';
+var repo = 'cilium-cli';
+
+module.exports = async function (request) {
+  let all = await github(request, owner, repo);
+  return all;
+};
+
+if (module === require.main) {
+  (async function () {
+    let request = require('@root/request');
+    let normalize = require('../_webi/normalize.js');
+    let all = await module.exports(request);
+    all = normalize(all);
+    // just select the first 5 for demonstration
+    all.releases = all.releases.slice(0, 5);
+    console.info(JSON.stringify(all, null, 2));
+  })();
+}


### PR DESCRIPTION
Adding the command line tool to install and manage https://cilium.io

Based entirely on what the `kind` installer does.