### PR TITLE
fix(runzip): use .getDistributables()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,16 @@ install-*.bat
 install-*.ps1
 
 # local config
+.env.*
+*.env
 .env
+!example.env
 
 # caches
+_cache/
 node_modules/
 
 # temporary & backup files
 .*.sw*
 *.bak
+*.bak.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
-.env
-node_modules
+# generated artifacts
 install-*.sh
 install-*.bat
 install-*.ps1
+
+# local config
+.env
+
+# caches
+node_modules/
+
+# temporary & backup files
 .*.sw*
 *.bak

--- a/runzip/releases.js
+++ b/runzip/releases.js
@@ -7,7 +7,7 @@ let owner = 'therootcompany';
 let repo = 'runzip';
 
 Releases.latest = async function () {
-  let all = await GitHub.getAllPackages(null, owner, repo);
+  let all = await GitHub.getDistributables(null, owner, repo);
   return all;
 };
 


### PR DESCRIPTION
runzip was added before the ` .getDistributables()`.

This updates `runzip` to use the correct function.

This also cleans up `.gitignore` to reduce clutter on `beta`.