### PR TITLE
fix(ollama): classify 'rocm' as its own cpu

### DIFF
--- a/ollama/install.ps1
+++ b/ollama/install.ps1
@@ -1,5 +1,64 @@
 #!/usr/bin/env pwsh
 
-Write-Host "Error: ollama doesn't have Windows support yet:"
-Write-Host "See https://github.com/jmorganca/ollama/issues/403"
-exit 1
+##################
+# Install ollama #
+##################
+
+# Every package should define these variables
+$pkg_cmd_name = "ollama"
+
+$pkg_dst_cmd = "$Env:USERPROFILE\.local\opt\ollama\ollama.exe"
+$pkg_dst_bin = "$Env:USERPROFILE\.local\opt\ollama"
+$pkg_dst_dir = "$Env:USERPROFILE\.local\opt\ollama"
+$pkg_dst = "$pkg_dst_dir"
+
+$pkg_src_cmd = "$Env:USERPROFILE\.local\opt\ollama-v$Env:WEBI_VERSION\ollama.exe"
+$pkg_src_bin = "$Env:USERPROFILE\.local\opt\ollama-v$Env:WEBI_VERSION"
+$pkg_src_dir = "$Env:USERPROFILE\.local\opt\ollama-v$Env:WEBI_VERSION"
+$pkg_src = "$pkg_src_dir"
+
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | Out-Null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\ollama\$Env:WEBI_VERSION\$Env:WEBI_PKG_FILE"
+
+# Fetch archive
+IF (!(Test-Path -Path "$pkg_download")) {
+    Write-Output "    Downloading ollama v$Env:WEBI_VERSION from $Env:WEBI_PKG_URL to $pkg_download"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
+    & Move-Item "$pkg_download.part" "$pkg_download"
+}
+
+IF (!(Test-Path -Path "$pkg_src_dir")) {
+    Write-Output "    Installing ollama v$Env:WEBI_VERSION"
+
+    Push-Location .local\tmp
+
+    # Remove any leftover tmp cruft
+    Remove-Item -Path ".\ollama*" -Recurse -ErrorAction Ignore
+
+    # Unpack archive file into this temporary directory
+    New-Item "ollama-v$Env:WEBI_VERSION" -ItemType Directory -Force | Out-Null
+    Push-Location "ollama-v$Env:WEBI_VERSION"
+
+    # Windows BSD-tar handles zip. Imagine that.
+    Write-Output "Unpacking $pkg_download"
+    & tar xf "$pkg_download"
+
+    Pop-Location
+
+    # Settle unpacked archive into place
+    Write-Output "Install Location: $pkg_src_cmd"
+    Move-Item -Path ".\ollama*" -Destination "$pkg_src_dir"
+
+    # Exit tmp
+    Pop-Location
+}
+
+Write-Output "    Copying into '$pkg_dst_dir' from '$pkg_src_dir'"
+Remove-Item -Path "$pkg_dst_dir" -Recurse -ErrorAction Ignore | Out-Null
+Copy-Item -Path "$pkg_src" -Destination "$pkg_dst" -Recurse
+webi_path_add "$pkg_dst_bin"
+$version_output = & "$pkg_dst_cmd" --version
+$version_line = $version_output |
+    ForEach-Object { $_.Split(':')[1].Trim() } |
+    Where-Object { $_ -match "version" }
+Write-Output "    Installed Ollama: $version_line"

--- a/ollama/install.sh
+++ b/ollama/install.sh
@@ -1,21 +1,62 @@
 #!/bin/sh
-set -e
-set -u
+# shellcheck disable=SC2034
 
 __init_ollama() {
+    set -e
+    set -u
 
-    ##############
+    ##################
     # Install ollama #
-    ##############
+    ##################
 
-    WEBI_SINGLE=true
+    # Every package should define these 6 variables
+    pkg_cmd_name="ollama"
+
+    pkg_dst_cmd="${HOME}/.local/opt/ollama/bin/ollama"
+    pkg_dst_dir="${HOME}/.local/opt/ollama"
+    pkg_dst="${pkg_dst_dir}"
+
+    pkg_src_cmd="${HOME}/.local/opt/ollama-v${WEBI_VERSION}/bin/ollama"
+    pkg_src_dir="${HOME}/.local/opt/ollama-v${WEBI_VERSION}"
+    pkg_src="${pkg_src_dir}"
+
+    # pkg_install must be defined by every package
+    pkg_install() {
+        # ~/.local/opt/
+        mkdir -p "$(dirname "${pkg_src_dir}")"
+
+        if test -d ./ollama-*/; then
+            # the de facto way (in case it's supported in the future)
+            # mv ./ollama-*/ ~/.local/opt/ollama-v3.27.0/
+            mv ./ollama-*/ "${pkg_src}"
+        elif test -d ./bin; then
+            # how linux is presently done
+            mkdir -p "${pkg_src_dir}"
+            mv ./bin "${pkg_src_dir}"
+            if test -f ./lib; then
+                mv ./lib "${pkg_src_dir}"
+            fi
+        else
+            # how macOS is presently done
+            mkdir -p "$(dirname "${pkg_src_cmd}")"
+            mv ./ollama-* "${pkg_src_cmd}"
+        fi
+
+        # remove previous location
+        if test -f ~/.local/bin/ollama; then
+            rm ~/.local/bin/ollama
+        fi
+    }
 
     pkg_get_current_version() {
         # 'ollama --version' has output in this format:
-        #       ollama version 0.1.3
+        #       ollama version is 0.3.10
         # This trims it down to just the version number:
-        #       0.1.3
-        ollama --version 2> /dev/null | head -n 1 | sed 's:^ollama version ::'
+        #       0.3.10
+        ollama --version 2> /dev/null |
+            head -n 1 |
+            cut -d' ' -f4 |
+            sed 's:^v::'
     }
 }
 

--- a/ollama/releases.js
+++ b/ollama/releases.js
@@ -22,6 +22,12 @@ module.exports = async function (request) {
 
       rel.arch = 'aarch64';
     }
+
+    let isROCm = rel.name.includes('-rocm');
+    if (isROCm) {
+      Object.assign(rel, { arch: 'x86_64_rocm' });
+    }
+
     releases.push(rel);
   }
   all.releases = releases;

--- a/ollama/releases.js
+++ b/ollama/releases.js
@@ -28,6 +28,21 @@ module.exports = async function (request) {
       Object.assign(rel, { arch: 'x86_64_rocm' });
     }
 
+    let oddballs = {
+      tgz: 'tar.gz',
+      tbz2: 'tar.bz2',
+      txz: 'tar.xz',
+    };
+    let oddExts = Object.keys(oddballs);
+    for (let oddExt of oddExts) {
+      let isOddball = rel.name.endsWith(`.${oddExt}`);
+      if (isOddball) {
+        let ext = oddballs[oddExt];
+        rel.name = rel.name.replace(`.${oddExt}`, `.${ext}`);
+        rel.ext = ext;
+      }
+    }
+
     releases.push(rel);
   }
   all.releases = releases;


### PR DESCRIPTION
As per @jojobyte report of the Ollama CPU mismatch.

See also:
- https://github.com/webinstall/webi-build-classifier/pull/15
- https://github.com/webinstall/webi-installers/issues/879
- https://github.com/golang/go/issues/45453