### PR TITLE
fix(windows+ollama): create download directory before downloading

### DIFF
--- a/ollama/install.ps1
+++ b/ollama/install.ps1
@@ -17,39 +17,38 @@ $pkg_src_bin = "$Env:USERPROFILE\.local\opt\ollama-v$Env:WEBI_VERSION"
 $pkg_src_dir = "$Env:USERPROFILE\.local\opt\ollama-v$Env:WEBI_VERSION"
 $pkg_src = "$pkg_src_dir"
 
-New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | Out-Null
-$pkg_download = "$Env:USERPROFILE\Downloads\webi\ollama\$Env:WEBI_VERSION\$Env:WEBI_PKG_FILE"
+$pkg_download_dir = "$Env:USERPROFILE\Downloads\webi\$pkg_cmd_name\$Env:WEBI_VERSION"
+$pkg_download_file = "$pkg_download_dir\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$pkg_download")) {
-    Write-Output "    Downloading ollama v$Env:WEBI_VERSION from $Env:WEBI_PKG_URL to $pkg_download"
-    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
-    & Move-Item "$pkg_download.part" "$pkg_download"
+IF (!(Test-Path -Path "$pkg_download_file")) {
+    New-Item "$pkg_download_dir" -ItemType Directory -Force | Out-Null
+    Write-Output "    Downloading $pkg_cmd_name v$Env:WEBI_VERSION from $Env:WEBI_PKG_URL to $pkg_download_file"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download_file.part"
+    & Move-Item "$pkg_download_file.part" "$pkg_download_file"
 }
 
-IF (!(Test-Path -Path "$pkg_src_dir")) {
+IF (!(Test-Path -Path "$pkg_src_cmd")) {
     Write-Output "    Installing ollama v$Env:WEBI_VERSION"
 
-    Push-Location .local\tmp
-
-    # Remove any leftover tmp cruft
-    Remove-Item -Path ".\ollama*" -Recurse -ErrorAction Ignore
+    # Remove any leftover tmp cruft, recreate location, push into it
+    Remove-Item -Path ".local\tmp\ollama-v$Env:WEBI_VERSION" -Recurse -ErrorAction Ignore
+    New-Item ".local\tmp\ollama-v$Env:WEBI_VERSION" -ItemType Directory -Force | Out-Null
+    Push-Location ".\.local\tmp\"
 
     # Unpack archive file into this temporary directory
-    New-Item "ollama-v$Env:WEBI_VERSION" -ItemType Directory -Force | Out-Null
-    Push-Location "ollama-v$Env:WEBI_VERSION"
-
+    Push-Location ".\ollama-v$Env:WEBI_VERSION\"
     # Windows BSD-tar handles zip. Imagine that.
-    Write-Output "Unpacking $pkg_download"
-    & tar xf "$pkg_download"
-
+    Write-Output "    Unpacking $pkg_download_file"
+    & tar xf "$pkg_download_file"
     Pop-Location
 
     # Settle unpacked archive into place
-    Write-Output "Install Location: $pkg_src_cmd"
-    Move-Item -Path ".\ollama*" -Destination "$pkg_src_dir"
+    Write-Output "    Install Location: $pkg_src_cmd"
+    Move-Item -Path ".\ollama-v$Env:WEBI_VERSION" -Destination "$pkg_src_dir"
 
-    # Exit tmp
+    # Remove any leftover tmp cruft & exit tmp
+    Remove-Item -Path ".local\tmp\ollama-v$Env:WEBI_VERSION" -Recurse -ErrorAction Ignore
     Pop-Location
 }
 


### PR DESCRIPTION
In testing I created the download directory in order to save time on the 1.6gb download.

That turned out to be the wrong approach because the code wasn't creating the full download directory.