### PR TITLE
ref: semi-automated removal of unused request

### DIFF
--- a/_common/gitea.js
+++ b/_common/gitea.js
@@ -5,7 +5,7 @@ var GitHubish = require('./githubish.js');
 /**
  * Lists Gitea Releases (w/ uploaded assets)
  *
- * @param {any} _request - deprecated
+ * @param {null} _ - deprecated
  * @param {String} owner
  * @param {String} repo
  * @param {String} baseurl
@@ -13,7 +13,7 @@ var GitHubish = require('./githubish.js');
  * @param {String} [token]
  */
 async function getDistributables(
-  _request,
+  _,
   owner,
   repo,
   baseurl,
@@ -42,7 +42,6 @@ if (module === require.main) {
     '',
     '',
   ).then(
-    //getDistributables(require('@root/request'), 'root', 'serviceman', 'https://git.rootprojects.org').then(
     function (all) {
       console.info(JSON.stringify(all, null, 2));
     },

--- a/_common/github.js
+++ b/_common/github.js
@@ -7,7 +7,7 @@ let GitHubish = require('./githubish.js');
 /**
  * Lists GitHub Releases (w/ uploaded assets)
  *
- * @param {null} _request - deprecated
+ * @param {null} _ - deprecated
  * @param {String} owner
  * @param {String} repo
  * @param {String} [baseurl]
@@ -15,7 +15,7 @@ let GitHubish = require('./githubish.js');
  * @param {String} [token]
  */
 module.exports = async function (
-  _request,
+  _,
   owner,
   repo,
   baseurl = 'https://api.github.com',

--- a/_example/releases.js
+++ b/_example/releases.js
@@ -20,9 +20,8 @@ Releases.latest = async function () {
 };
 
 Releases.sample = async function () {
-  let request = require('@root/request');
   let normalize = require('../_webi/normalize.js');
-  let all = await module.exports(request);
+  let all = await module.exports();
   all = normalize(all);
   // just select the first 5 for demonstration
   all.releases = all.releases.slice(0, 5);

--- a/_example/releases.js
+++ b/_example/releases.js
@@ -21,7 +21,7 @@ Releases.latest = async function () {
 
 Releases.sample = async function () {
   let normalize = require('../_webi/normalize.js');
-  let all = await module.exports();
+  let all = await Releases.latest();
   all = normalize(all);
   // just select the first 5 for demonstration
   all.releases = all.releases.slice(0, 5);

--- a/_example/releases.js
+++ b/_example/releases.js
@@ -14,8 +14,8 @@ var repo = 'ripgrep';
 
 let Releases = module.exports;
 
-Releases.latest = async function (request) {
-  let all = await github(request, owner, repo);
+Releases.latest = async function () {
+  let all = await github(null, owner, repo);
   return all;
 };
 

--- a/_npm/scripts/install-webi.js
+++ b/_npm/scripts/install-webi.js
@@ -4,7 +4,6 @@
 
 //var pkg = require('../package.json');
 var os = require('os');
-//var request = require('@root/request');
 //var promisify = require('util').promisify;
 //var exec = promisify(require('child_process').exec);
 var exec = require('child_process').exec;

--- a/arc/releases.js
+++ b/arc/releases.js
@@ -4,15 +4,15 @@ var github = require('../_common/github.js');
 var owner = 'mholt';
 var repo = 'archiver';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all._names = ['archiver', 'arc'];
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/atomicparsley/releases.js
+++ b/atomicparsley/releases.js
@@ -32,8 +32,8 @@ let targets = {
   },
 };
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     for (let rel of all.releases) {
       let windows32 = rel.name.includes('WindowsX86.');
       if (windows32) {
@@ -71,7 +71,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
     //console.info(JSON.stringify(all, null, 2));

--- a/awless/releases.js
+++ b/awless/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'wallix';
 var repo = 'awless';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     // remove checksums and .deb
     all.releases = all.releases.filter(function (rel) {
       return !/(\.txt)|(\.deb)$/i.test(rel.name);
@@ -15,7 +15,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
   });

--- a/bat/releases.js
+++ b/bat/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'sharkdp';
 var repo = 'bat';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     all.releases = all.releases.slice(0, 10);
     //console.info(JSON.stringify(all));

--- a/bun/releases.js
+++ b/bun/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'oven-sh';
 var repo = 'bun';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all.releases = all.releases
       .filter(function (r) {
         let isDebug = r.name.includes('-profile');
@@ -30,7 +30,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/caddy/releases.js
+++ b/caddy/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'caddyserver';
 var repo = 'caddy';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     // remove checksums and .deb
     all.releases = all.releases.filter(function (rel) {
       let isOneOffAsset = rel.download.includes('buildable-artifact');
@@ -20,7 +20,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
   });

--- a/cilium/releases.js
+++ b/cilium/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'cilium';
 var repo = 'cilium-cli';
 
-module.exports = async function (request) {
-  let all = await github(request, owner, repo);
+module.exports = async function () {
+  let all = await github(null, owner, repo);
   return all;
 };
 

--- a/cilium/releases.js
+++ b/cilium/releases.js
@@ -11,9 +11,8 @@ module.exports = async function () {
 
 if (module === require.main) {
   (async function () {
-    let request = require('@root/request');
     let normalize = require('../_webi/normalize.js');
-    let all = await module.exports(request);
+    let all = await module.exports();
     all = normalize(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/cmake/releases.js
+++ b/cmake/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'Kitware';
 var repo = 'CMake';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     for (let rel of all.releases) {
       if (rel.version.startsWith('v')) {
         rel._version = rel.version.slice(1);
@@ -44,7 +44,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/comrak/releases.js
+++ b/comrak/releases.js
@@ -6,8 +6,8 @@ var repo = 'comrak';
 
 var ODDITIES = ['-musleabihf.1-'];
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     let builds = [];
 
     loopBuilds: for (let build of all.releases) {
@@ -31,7 +31,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     all.releases = all.releases.slice(0, 10);
     //console.info(JSON.stringify(all));

--- a/crabz/releases.js
+++ b/crabz/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'sstadick';
 var repo = 'crabz';
 
-module.exports = async function (request) {
-  let all = await github(request, owner, repo);
+module.exports = async function () {
+  let all = await github(null, owner, repo);
 
   let releases = [];
   for (let rel of all.releases) {
@@ -22,7 +22,7 @@ module.exports = async function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/curlie/releases.js
+++ b/curlie/releases.js
@@ -4,15 +4,15 @@ var github = require('../_common/github.js');
 var owner = 'rs';
 var repo = 'curlie';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all._names = ['curlie', 'curl-httpie'];
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     all.releases = all.releases.slice(0, 10);
     //console.info(JSON.stringify(all));

--- a/dashcore/releases.js
+++ b/dashcore/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'dashpay';
 var repo = 'dash';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all.releases.forEach(function (rel) {
       if (rel.name.includes('osx64')) {
         rel.os = 'macos';
@@ -22,7 +22,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/dashmsg/releases.js
+++ b/dashmsg/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'dashhive';
 var repo = 'dashmsg';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all, null, 2));
   });

--- a/delta/releases.js
+++ b/delta/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'dandavison';
 var repo = 'delta';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 15 for demonstration
     all.releases = all.releases.slice(0, 15);

--- a/deno/releases.js
+++ b/deno/releases.js
@@ -6,8 +6,8 @@ var github = require('../_common/github.js');
 var owner = 'denoland';
 var repo = 'deno';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     // remove checksums and .deb
     all.releases = all.releases
       .filter(function (rel) {
@@ -35,7 +35,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all, null, 2));
   });

--- a/dotenv-linter/releases.js
+++ b/dotenv-linter/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'dotenv-linter';
 var repo = 'dotenv-linter';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/dotenv/releases.js
+++ b/dotenv/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'therootcompany';
 var repo = 'dotenv';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
   });

--- a/fd/releases.js
+++ b/fd/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'sharkdp';
 var repo = 'fd';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     let builds = [];
 
     for (let build of all.releases) {
@@ -22,7 +22,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     all.releases = all.releases.slice(0, 10);
     //console.info(JSON.stringify(all));

--- a/ffmpeg/releases.js
+++ b/ffmpeg/releases.js
@@ -6,8 +6,8 @@ var github = require('../_common/github.js');
 var owner = 'eugeneware';
 var repo = 'ffmpeg-static';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all.releases = all.releases
       .filter(function (rel) {
         let isFfmpeg = rel.name.includes('ffmpeg');
@@ -38,7 +38,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
   });

--- a/ffuf/releases.js
+++ b/ffuf/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'ffuf';
 var repo = 'ffuf';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/fish/releases.js
+++ b/fish/releases.js
@@ -6,8 +6,8 @@ var repo = 'fish-shell';
 
 var ODDITIES = ['bundledpcre'];
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all.releases = all.releases
       .map(function (rel) {
         for (let oddity of ODDITIES) {
@@ -30,7 +30,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/fzf/releases.js
+++ b/fzf/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'junegunn';
 var repo = 'fzf';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     all.releases = all.releases.slice(0, 10);
     //console.info(JSON.stringify(all));

--- a/gh/releases.js
+++ b/gh/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'cli';
 var repo = 'cli';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/git/releases.js
+++ b/git/releases.js
@@ -4,9 +4,9 @@ var github = require('../_common/github.js');
 var owner = 'git-for-windows';
 var repo = 'git';
 
-module.exports = function (request) {
+module.exports = function () {
   // TODO support mac and linux tarballs
-  return github(request, owner, repo).then(function (all) {
+  return github(null, owner, repo).then(function (all) {
     // See https://github.com/git-for-windows/git/wiki/MinGit
     // also consider https://github.com/git-for-windows/git/wiki/Silent-or-Unattended-Installation
     all.releases = all.releases
@@ -26,7 +26,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all, null, 2));
   });

--- a/gitdeploy/releases.js
+++ b/gitdeploy/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'therootcompany';
 var repo = 'gitdeploy';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
   });

--- a/gitea/releases.js
+++ b/gitea/releases.js
@@ -6,8 +6,8 @@ var repo = 'gitea';
 
 var ODDITIES = ['-gogit-', '-docs-'];
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     // remove checksums and .deb
     all.releases = all.releases.filter(function (rel) {
       for (let oddity of ODDITIES) {
@@ -27,7 +27,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
   });

--- a/goreleaser/releases.js
+++ b/goreleaser/releases.js
@@ -4,15 +4,15 @@ var github = require('../_common/github.js');
 var owner = 'goreleaser';
 var repo = 'goreleaser';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all._names = ['goreleaser', '1'];
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/gprox/releases.js
+++ b/gprox/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'creedasaurus';
 var repo = 'gprox';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/grype/releases.js
+++ b/grype/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'anchore';
 var repo = 'grype';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/hexyl/releases.js
+++ b/hexyl/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'sharkdp';
 var repo = 'hexyl';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     all.releases = all.releases.slice(0, 10);
     //console.info(JSON.stringify(all));

--- a/hugo-extended/releases.js
+++ b/hugo-extended/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'gohugoio';
 var repo = 'hugo';
 
-module.exports = async function (request) {
-  let all = await github(request, owner, repo);
+module.exports = async function () {
+  let all = await github(null, owner, repo);
 
   all.releases = all.releases.filter(function (rel) {
     let isExtended = rel.name.includes('_extended_');
@@ -25,7 +25,7 @@ module.exports = async function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
   });

--- a/hugo/releases.js
+++ b/hugo/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'gohugoio';
 var repo = 'hugo';
 
-module.exports = async function (request) {
-  let all = await github(request, owner, repo);
+module.exports = async function () {
+  let all = await github(null, owner, repo);
 
   all.releases = all.releases.filter(function (rel) {
     let isExtended = rel.name.includes('_extended_');
@@ -25,7 +25,7 @@ module.exports = async function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
   });

--- a/jq/releases.js
+++ b/jq/releases.js
@@ -15,8 +15,8 @@ function isOdd(build) {
   }
 }
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     let builds = [];
 
     for (let build of all.releases) {
@@ -35,7 +35,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
     //console.info(JSON.stringify(all, null, 2));

--- a/k9s/releases.js
+++ b/k9s/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'derailed';
 var repo = 'k9s';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/keypairs/releases.js
+++ b/keypairs/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'therootcompany';
 var repo = 'keypairs';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all, null, 2));
   });

--- a/kind/releases.js
+++ b/kind/releases.js
@@ -12,14 +12,14 @@ var repo = 'kind';
 /**                                                                          **/
 /******************************************************************************/
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/koji/releases.js
+++ b/koji/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'cococonscious';
 var repo = 'koji';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
   });

--- a/kubectx/releases.js
+++ b/kubectx/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'ahmetb';
 var repo = 'kubectx';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     let builds = [];
 
     for (let build of all.releases) {
@@ -28,7 +28,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/kubens/releases.js
+++ b/kubens/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'ahmetb';
 var repo = 'kubectx';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     let builds = [];
 
     for (let build of all.releases) {
@@ -28,7 +28,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/lf/releases.js
+++ b/lf/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'gokcehan';
 var repo = 'lf';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all.releases = all.releases.map(function (r) {
       // r21 -> 0.21.0
       if (/^r/.test(r.version)) {
@@ -18,7 +18,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')._debug(all);
     console.info(JSON.stringify(all, null, 2));
   });

--- a/lsd/releases.js
+++ b/lsd/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'lsd-rs';
 var repo = 'lsd';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all.releases = all.releases.filter(function (rel) {
       return !/(-msvc\.)|(\.deb$)/.test(rel.name);
     });
@@ -14,7 +14,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/mutagen/releases.js
+++ b/mutagen/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'mutagen-io';
 var repo = 'mutagen';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')._debug(all);
     console.info(JSON.stringify(all, null, 2));
   });

--- a/ollama/releases.js
+++ b/ollama/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'jmorganca';
 var repo = 'ollama';
 
-module.exports = async function (request) {
-  let all = await github(request, owner, repo);
+module.exports = async function () {
+  let all = await github(null, owner, repo);
 
   let releases = [];
   for (let rel of all.releases) {
@@ -51,7 +51,7 @@ module.exports = async function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
     //console.info(JSON.stringify(all, null, 2));

--- a/ots/releases.js
+++ b/ots/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'emdneto';
 var repo = 'otsgo';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/pandoc/releases.js
+++ b/pandoc/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'jgm';
 var repo = 'pandoc';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/pathman/releases.js
+++ b/pathman/releases.js
@@ -5,8 +5,8 @@ var owner = 'root';
 var repo = 'pathman';
 var baseurl = 'https://git.rootprojects.org';
 
-module.exports = function (request) {
-  return github(request, owner, repo, baseurl).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo, baseurl).then(function (all) {
     all.releases = all.releases.filter(function (release) {
       release._filename = release.name;
 
@@ -22,7 +22,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     console.info(JSON.stringify(all, null, 2));
   });
 }

--- a/pwsh/releases.js
+++ b/pwsh/releases.js
@@ -15,8 +15,8 @@ function isOdd(build) {
   }
 }
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     // remove checksums and .deb
     all.releases = all.releases.filter(function (rel) {
       let odd = isOdd(rel);
@@ -44,7 +44,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
   });

--- a/rclone/releases.js
+++ b/rclone/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'rclone';
 var repo = 'rclone';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     all.releases = all.releases.slice(0, 10);
     console.info(JSON.stringify(all, null, 2));

--- a/rg/releases.js
+++ b/rg/releases.js
@@ -4,15 +4,15 @@ var github = require('../_common/github.js');
 var owner = 'BurntSushi';
 var repo = 'ripgrep';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all._names = ['ripgrep', 'rg'];
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/ripgrep/releases.js
+++ b/ripgrep/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'BurntSushi';
 var repo = 'ripgrep';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
     //console.info(JSON.stringify(all, null, 2));

--- a/sass/releases.js
+++ b/sass/releases.js
@@ -4,15 +4,15 @@ var github = require('../_common/github.js');
 var owner = 'sass';
 var repo = 'dart-sass';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all._names = ['dart-sass', 'sass'];
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/sclient/releases.js
+++ b/sclient/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'therootcompany';
 var repo = 'sclient';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
   });

--- a/sd/releases.js
+++ b/sd/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'chmln';
 var repo = 'sd';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/serviceman/releases.js
+++ b/serviceman/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'therootcompany';
 var repo = 'serviceman';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
   });

--- a/shellcheck/releases.js
+++ b/shellcheck/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'koalaman';
 var repo = 'shellcheck';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/shfmt/releases.js
+++ b/shfmt/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'mvdan';
 var repo = 'sh';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     all.releases = all.releases.slice(0, 5);
     console.info(JSON.stringify(all, null, 2));

--- a/sqlpkg/releases.js
+++ b/sqlpkg/releases.js
@@ -4,15 +4,15 @@ var github = require('../_common/github.js');
 var owner = 'nalgeon';
 var repo = 'sqlpkg-cli';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all._names = ['sqlpkg-cli', 'sqlpkg'];
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all, null, 2));
   });

--- a/sttr/releases.js
+++ b/sttr/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'abhimanyu003';
 var repo = 'sttr';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/syncthing/releases.js
+++ b/syncthing/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'syncthing';
 var repo = 'syncthing';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/tinygo/releases.js
+++ b/tinygo/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'tinygo-org';
 var repo = 'tinygo';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     // all.releases = all.releases.filter(function (rel) {
     //   return !rel.name.endsWith('.deb');
     // });
@@ -14,7 +14,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/trip/releases.js
+++ b/trip/releases.js
@@ -4,15 +4,15 @@ var github = require('../_common/github.js');
 var owner = 'fujiapple852';
 var repo = 'trippy';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all._names = ['trippy', 'trip'];
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/vim-commentary/releases.js
+++ b/vim-commentary/releases.js
@@ -3,14 +3,14 @@
 var git = require('../_common/git-tag.js');
 var gitUrl = 'https://github.com/tpope/vim-commentary.git';
 
-module.exports = async function (request) {
+module.exports = async function () {
   let all = await git(gitUrl);
 
   return all;
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
 
     let samples = JSON.stringify(all, null, 2);

--- a/vim-zig/releases.js
+++ b/vim-zig/releases.js
@@ -3,7 +3,7 @@
 var git = require('../_common/git-tag.js');
 var gitUrl = 'https://github.com/ziglang/zig.vim.git';
 
-module.exports = async function (request) {
+module.exports = async function () {
   let all = await git(gitUrl);
 
   all._names = ['zig.vim', 'vim-zig'];
@@ -11,7 +11,7 @@ module.exports = async function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
 
     let samples = JSON.stringify(all, null, 2);

--- a/watchexec/releases.js
+++ b/watchexec/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'watchexec';
 var repo = 'watchexec';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     let builds = [];
     for (let build of all.releases) {
       build.version = build.version.replace(/^cli-/, '');
@@ -18,7 +18,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/xcaddy/releases.js
+++ b/xcaddy/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'caddyserver';
 var repo = 'xcaddy';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     // remove checksums and .deb
     all.releases = all.releases.filter(function (rel) {
       return !/(\.txt)|(\.deb)$/i.test(rel.name);
@@ -15,7 +15,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     console.info(JSON.stringify(all));
   });

--- a/xsv/releases.js
+++ b/xsv/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'BurntSushi';
 var repo = 'xsv';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/xz/releases.js
+++ b/xz/releases.js
@@ -4,8 +4,8 @@ var github = require('../_common/github.js');
 var owner = 'therootcompany';
 var repo = 'xz-static';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     all.releases.forEach(function (rel) {
       if (/windows/.test(rel.download)) {
         if (!/(86|64)/.test(rel.arch)) {
@@ -18,7 +18,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 5);

--- a/yq/releases.js
+++ b/yq/releases.js
@@ -15,8 +15,8 @@ function isOdd(build) {
   }
 }
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     let builds = [];
 
     for (let build of all.releases) {
@@ -34,7 +34,7 @@ module.exports = function (request) {
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     all.releases = all.releases.slice(0, 5);
     console.info(JSON.stringify(all, null, 2));

--- a/zig.vim/releases.js
+++ b/zig.vim/releases.js
@@ -3,14 +3,14 @@
 var git = require('../_common/git-tag.js');
 var gitUrl = 'https://github.com/ziglang/zig.vim.git';
 
-module.exports = async function (request) {
+module.exports = async function () {
   let all = await git(gitUrl);
 
   return all;
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
 
     let samples = JSON.stringify(all, null, 2);

--- a/zoxide/releases.js
+++ b/zoxide/releases.js
@@ -4,14 +4,14 @@ var github = require('../_common/github.js');
 var owner = 'ajeetdsouza';
 var repo = 'zoxide';
 
-module.exports = function (request) {
-  return github(request, owner, repo).then(function (all) {
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports(require('@root/request')).then(function (all) {
+  module.exports().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
     all.releases = all.releases.slice(0, 10);


### PR DESCRIPTION
A mostly automated removal of unused `request` vars:


1. Get a list of files referencing request that use github or githubish (which already use fetch)
   ```sh
   rg -F 'github(request' | grep '' | cut -d':' -f1 | sort -u > ref-request.sh
   ```
2. Add replaces to the beginning of each file
   ```sh
   sd -s 'github(request' 'github(null' _example/releases.js

   sd -s ' function (request) ' ' function () ' _example/releases.js

   sd -s "module.exports(require('@root/request'))" 'module.exports()' _example/releases.js
   ```