### PR TITLE
fix - wmic deprecated

### DIFF
--- a/_webi/package-install.tpl.ps1
+++ b/_webi/package-install.tpl.ps1
@@ -88,7 +88,7 @@ function Get-UserAgent {
     IF ($my_arch -eq "AMD64") {
         # Because PowerShell is sometimes AMD64 on Windows 10 ARM
         # See https://oofhours.com/2020/02/04/powershell-on-windows-10-arm64/
-        $my_os_arch = wmic os get osarchitecture
+        $my_os_arch = (Get-WmiObject -Class Win32_OperatingSystem).OSArchitecture
 
         # Using -clike because of the trailing newline
         IF ($my_os_arch -clike "ARM 64*") {

--- a/_webi/package-install.tpl.ps1
+++ b/_webi/package-install.tpl.ps1
@@ -88,7 +88,7 @@ function Get-UserAgent {
     IF ($my_arch -eq "AMD64") {
         # Because PowerShell is sometimes AMD64 on Windows 10 ARM
         # See https://oofhours.com/2020/02/04/powershell-on-windows-10-arm64/
-        $my_os_arch = (Get-WmiObject -Class Win32_OperatingSystem).OSArchitecture
+        $my_os_arch = (Get-CimInstance -ClassName Win32_OperatingSystem).OSArchitecture
 
         # Using -clike because of the trailing newline
         IF ($my_os_arch -clike "ARM 64*") {

--- a/vcruntime/install.ps1
+++ b/vcruntime/install.ps1
@@ -7,7 +7,7 @@ IF ($my_arch -eq $null -or $my_arch -eq "") {
 IF ($my_arch -eq "AMD64") {
     # Because PowerShell isn't ARM yet.
     # See https://oofhours.com/2020/02/04/powershell-on-windows-10-arm64/
-    $my_os_arch = wmic os get osarchitecture
+    $my_os_arch = (Get-WmiObject -Class Win32_OperatingSystem).OSArchitecture
 
     # Using -clike because of the trailing newline
     IF ($my_os_arch -clike "ARM 64*") {

--- a/vcruntime/install.ps1
+++ b/vcruntime/install.ps1
@@ -7,7 +7,7 @@ IF ($my_arch -eq $null -or $my_arch -eq "") {
 IF ($my_arch -eq "AMD64") {
     # Because PowerShell isn't ARM yet.
     # See https://oofhours.com/2020/02/04/powershell-on-windows-10-arm64/
-    $my_os_arch = (Get-WmiObject -Class Win32_OperatingSystem).OSArchitecture
+    $my_os_arch = (Get-CimInstance -ClassName Win32_OperatingSystem).OSArchitecture
 
     # Using -clike because of the trailing newline
     IF ($my_os_arch -clike "ARM 64*") {

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -90,7 +90,7 @@ function Get-UserAgent {
     IF ($my_arch -eq "AMD64") {
         # Because PowerShell is sometimes AMD64 on Windows 10 ARM
         # See https://oofhours.com/2020/02/04/powershell-on-windows-10-arm64/
-        $my_os_arch = (Get-WmiObject -Class Win32_OperatingSystem).OSArchitecture
+        $my_os_arch = (Get-CimInstance -ClassName Win32_OperatingSystem).OSArchitecture
 
         # Using -clike because of the trailing newline
         IF ($my_os_arch -clike "ARM 64*") {

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -90,7 +90,7 @@ function Get-UserAgent {
     IF ($my_arch -eq "AMD64") {
         # Because PowerShell is sometimes AMD64 on Windows 10 ARM
         # See https://oofhours.com/2020/02/04/powershell-on-windows-10-arm64/
-        $my_os_arch = wmic os get osarchitecture
+        $my_os_arch = (Get-WmiObject -Class Win32_OperatingSystem).OSArchitecture
 
         # Using -clike because of the trailing newline
         IF ($my_os_arch -clike "ARM 64*") {


### PR DESCRIPTION
fixes #911

WMIC deprecated on Windows 11 and later versions of Windows 10 as per https://learn.microsoft.com/en-us/windows/win32/wmisdk/wmic

This alternative works on both older and newer versions of Powershell, and outputs in a similar enough format that related code works with no additional changes.