### PR TITLE
Refactor: Replace ```whoami``` with ```id -u -n``` in scripts for POSIX compliance (#854)

### DIFF
--- a/bun/README.md
+++ b/bun/README.md
@@ -134,7 +134,7 @@ file)
    ```sh
    sudo env PATH="$PATH" \
        serviceman add --path="$PATH" --system \
-           --username "$(whoami)" --name my-project -- \
+           --username "$(id -u -n)" --name my-project -- \
        bun run ./my-project.js
    ```
 4. Restart the logging service

--- a/caddy/README.md
+++ b/caddy/README.md
@@ -819,7 +819,7 @@ To avoid the nitty-gritty details of `launchd` plist files, you can use
 2. Use Serviceman to create a _launchd_ plist file
 
    ```sh
-   my_username="$( id -u -n )"
+   my_username="$(id -u -n)"
 
    serviceman add --user --name caddy -- \
        caddy run --config ./Caddyfile --envfile ~/.config/caddy/env
@@ -901,7 +901,7 @@ See the notes below to run as a **User Service** or use the JSON Config.
    ```
 4. Use Serviceman to create a _systemd_ config file.
    ```sh
-   my_username="$( id -u -n )"
+   my_username="$(id -u -n)"
    sudo env PATH="$PATH" \
        serviceman add --system --username "${my_username}" --name caddy -- \
            caddy run --config ./Caddyfile --envfile ~/.config/caddy/env
@@ -1363,7 +1363,7 @@ See also: <https://caddyserver.com/docs/running>
 2. Generate the `service` file: \
    - JSON Config
      ```sh
-     my_app_user="$( id -u -n )"
+     my_app_user="$(id -u -n)"
      sudo env PATH="${PATH}" \
          serviceman add --system --cap-net-bind \
              --username "${my_app_user}" --name caddy -- \
@@ -1371,7 +1371,7 @@ See also: <https://caddyserver.com/docs/running>
      ```
    - Caddyfile
      ```sh
-     my_app_user="$( id -u -n )"
+     my_app_user="$(id -u -n)"
      sudo env PATH="${PATH}" \
          serviceman add --system --cap-net-bind \
              --username "${my_app_user}" --name caddy -- \

--- a/fish/README.md
+++ b/fish/README.md
@@ -43,7 +43,7 @@ the file:
 ```sh
 #!/bin/bash
 
-echo "Who am I? I'm $(whoami)."
+echo "Who am I? I'm $(id -u -n)."
 ```
 
 You can also run bash explicitly:
@@ -99,7 +99,7 @@ You should use `chsh` to change your shell:
 ```sh
 #!/bin/sh
 
-sudo chsh -s "$(command -v fish)" "$(whoami)"
+sudo chsh -s "$(command -v fish)" "$(id -u -n)"
 ```
 
 If vim uses `fish` instead of `bash`, annoying errors will happen.

--- a/go/README.md
+++ b/go/README.md
@@ -81,7 +81,7 @@ pushd ./hello/
 
 # swap 'hello' and './hello' for the name of your project and binary
 sudo env PATH="$PATH" \
-    serviceman add --system --username "$(whoami)" --name hello -- \
+    serviceman add --system --username "$(id -u -n)" --name hello -- \
     ./hello
 
 # Restart the logging service

--- a/golang/README.md
+++ b/golang/README.md
@@ -86,7 +86,7 @@ pushd ./hello/
 
 # swap 'hello' and './hello' for the name of your project and binary
 sudo env PATH="$PATH" \
-    serviceman add --system --username "$(whoami)" --name hello -- \
+    serviceman add --system --username "$(id -u -n)" --name hello -- \
     ./hello
 
 # Restart the logging service

--- a/node/README.md
+++ b/node/README.md
@@ -227,7 +227,7 @@ Node app as a Non-System (Unprivileged) Service on Mac, Windows, and Linux:
    or _User Unit_ (Linux):
 
    ```sh
-   my_username="$( id -u -n )"
+   my_username="$(id -u -n)"
 
    serviceman add --user --name my-node-project -- \
        caddy run --config ./Caddyfile --envfile ~/.config/caddy/env
@@ -275,7 +275,7 @@ Node app as a Non-System (Unprivileged) Service on Mac, Windows, and Linux:
 ```sh
 pushd ./my-node-project/
 
-my_username="$( id -u -n )"
+my_username="$(id -u -n)"
 sudo env PATH="$PATH" \
     serviceman add --system --path "$PATH" --cap-net-bind \
     --name my-node-project --username "${my_username}" -- \

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -35,7 +35,7 @@ To enable Postgres as a Linux Service with [serviceman](../serviceman/): \
 
 ```sh
 sudo env PATH="$PATH" \
-    serviceman add --system --username "$(whoami)" --name 'postgres' -- \
+    serviceman add --system --username "$(id -u -n)" --name 'postgres' -- \
     postgres -D ~/.local/share/postgres/var -p 5432
 
 sudo systemctl restart systemd-journald
@@ -120,7 +120,7 @@ curl https://webi.sh/serviceman | sh
 
 ```sh
 sudo env PATH="$PATH" \
-    serviceman add --system --username "$(whoami)" --name 'postgres' -- \
+    serviceman add --system --username "$(id -u -n)" --name 'postgres' -- \
     postgres -D ~/.local/share/postgres/var -p 5432
 
 sudo systemctl restart systemd-journald

--- a/ssh-adduser/ssh-adduser
+++ b/ssh-adduser/ssh-adduser
@@ -14,7 +14,7 @@ main() {
     my_key_url="${2:-}"
     my_keys=""
 
-    if [ "root" != "$(whoami)" ]; then
+    if [ "root" != "$(id -u -n)" ]; then
         echo "webi adduser: running user is already a non-root user"
         exit 0
     fi

--- a/ssh-pubkey/README.md
+++ b/ssh-pubkey/README.md
@@ -61,7 +61,7 @@ folder:
 
 ```sh
 rsync -av "$HOME/.ssh/id_rsa.pub" \
-    "$HOME/Downloads/id_rsa.$(whoami).pub"
+    "$HOME/Downloads/id_rsa.$(id -u -n).pub"
 ```
 
 How to print your public key to the Terminal:

--- a/ssh-pubkey/ssh-pubkey
+++ b/ssh-pubkey/ssh-pubkey
@@ -82,11 +82,11 @@ main() {
     # TODO use the comment (if any) for the name of the file
     echo >&2 ""
     #shellcheck disable=SC2088
-    echo >&2 "~/Downloads/id_${my_keytype}.$(whoami).pub":
+    echo >&2 "~/Downloads/id_${my_keytype}.$(id -u -n).pub":
     echo >&2 ""
-    rm -f "$HOME/Downloads/id_${my_keytype}.$(whoami).pub"
-    cp -RPp "$HOME/.ssh/id_${my_keytype}.pub" "$HOME/Downloads/id_${my_keytype}.$(whoami).pub"
-    cat "$HOME/Downloads/id_${my_keytype}.$(whoami).pub"
+    rm -f "$HOME/Downloads/id_${my_keytype}.$(id -u -n).pub"
+    cp -RPp "$HOME/.ssh/id_${my_keytype}.pub" "$HOME/Downloads/id_${my_keytype}.$(id -u -n).pub"
+    cat "$HOME/Downloads/id_${my_keytype}.$(id -u -n).pub"
     echo >&2 ""
 
     if test -f ~/.ssh/id_rsa; then


### PR DESCRIPTION
This PR addresses issue #854 by replacing all instances of the whoami command with id -u -n, aligning with the POSIX standard for guaranteed behavior across Unix-like systems.

**Changes Made:**

- Conducted a find-and-replace for whoami across relevant scripts and documentation files.
- Verified using grep that no remaining whoami instances exist within the repository.

This simple refactor improves cross-platform compatibility, following best practices as outlined in the issue description.