### PR TITLE
Comply with XDG Base Dir Specs

### DIFF
--- a/vim-viminfo/README.md
+++ b/vim-viminfo/README.md
@@ -13,13 +13,14 @@ These are the files / directories that are created and/or modified with this
 install:
 
 ```text
-~/.vim/plugins/viminfo.vim
+~/.local/share/vim/viminfo
+~/.config/vim/plugins/viminfo.vim
 ~/.vimrc
 ```
 
 ## Cheat Sheet
 
-> ~/.viminfo stores cursor position, copy and paste buffers, command history,
+> ~/.local/share/vim/viminfo stores cursor position, copy and paste buffers, command history,
 > and a few other goodies. The defaults aren't always good, and should be
 > tweaked.
 
@@ -32,8 +33,8 @@ This one-line plugin does just that.
 
 ### How to install manually
 
-Create the file `~/.vim/plugins/viminfo.vim`. Add the same contents as
-<https://github.com/webinstall/webi-installers/blob/master/vim-viminfo/viminfo.vim>.
+Create the file `~/.config/vim/plugins/viminfo.vim`. Add the same contents as
+<https://github.com/webinstall/webi-installers/blob/main/vim-viminfo/viminfo.vim>.
 
 That will look something like this:
 
@@ -44,12 +45,16 @@ That will look something like this:
 "  :200  :  up to 200 lines of command-line history will be remembered
 "  %     :  saves and restores the buffer list
 "  n...  :  where to save the viminfo files
-set viminfo='100,\"20000,:200,%,n~/.viminfo
+set viminfo='100,\"20000,:200,%,n~/.local/share/vim/viminfo
 ```
+
+Then create the directory `~/.local/share/vim/` to keep viminfo file.
+
+Optionally, copy or move your existing viminfo file to `~/.local/share/vim/`.
 
 Then `~/.vimrc` should be updated to include it:
 
 ```vim
 " viminfo: reasonable defaults from webinstall.dev/vim-viminfo
-source ~/.vim/plugins/viminfo.vim
+source ~/.config/vim/plugins/viminfo.vim
 ```

--- a/vim-viminfo/install.sh
+++ b/vim-viminfo/install.sh
@@ -4,8 +4,13 @@ __init_vim_viminfo() {
     set -e
     set -u
 
-    mkdir -p "$HOME/.vim/plugins"
-    rm -rf "$HOME/.vim/plugins/viminfo.vim"
+    mkdir -p "$HOME/.config/vim/plugins"
+    rm -rf "$HOME/.config/vim/plugins/viminfo.vim"
+
+    # create XDG_DATA_HOME dir to keep vim related files such as viminfo
+    if [ ! -d "$HOME/.local/share/vim" ]; then
+        mkdir -p "$HOME/.local/share/vim"
+    fi
 
     echo ""
 
@@ -13,21 +18,21 @@ __init_vim_viminfo() {
         touch "$HOME/.vimrc"
     fi
 
-    if ! [ -f "$HOME/.vim/plugins/viminfo.vim" ]; then
-        mkdir -p ~/.vim/plugins
+    if ! [ -f "$HOME/.config/vim/plugins/viminfo.vim" ]; then
+        mkdir -p ~/.config/vim/plugins
         WEBI_HOST=${WEBI_HOST:-"https://webinstall.dev"}
-        curl -fsS -o ~/.vim/plugins/viminfo.vim "$WEBI_HOST/packages/vim-viminfo/viminfo.vim"
+        curl -fsS -o ~/.config/vim/plugins/viminfo.vim "$WEBI_HOST/packages/vim-viminfo/viminfo.vim"
     fi
 
     if ! grep 'source.*plugins.viminfo.vim' -r ~/.vimrc > /dev/null 2> /dev/null; then
         set +e
-        mkdir -p ~/.vim/plugins
+        mkdir -p ~/.config/vim/plugins
         printf '\n" Vim Info: reasonable defaults (buffers, history, etc) from webinstall.dev/vim-viminfo\n' >> ~/.vimrc
-        printf 'source ~/.vim/plugins/viminfo.vim\n' >> ~/.vimrc
+        printf 'source ~/.config/vim/plugins/viminfo.vim\n' >> ~/.vimrc
         set -e
 
-        echo "added ~/.vim/plugins/viminfo.vim"
-        echo "updated ~/.vimrc with 'source ~/.vim/plugins/viminfo.vim'"
+        echo "added ~/.config/vim/plugins/viminfo.vim"
+        echo "updated ~/.vimrc with 'source ~/.config/vim/plugins/viminfo.vim'"
         echo ""
     fi
 

--- a/vim-viminfo/viminfo.vim
+++ b/vim-viminfo/viminfo.vim
@@ -4,4 +4,4 @@
 "  :200  :  up to 200 lines of command-line history will be remembered
 "  %     :  saves and restores the buffer list
 "  n...  :  where to save the viminfo files
-set viminfo='100,\"20000,:200,%,n~/.viminfo
+set viminfo='100,\"20000,:200,%,n~/.local/share/vim/viminfo


### PR DESCRIPTION
To comply with [XDG Base Dir Specs](https://specifications.freedesktop.org/basedir-spec/latest/index.html). As of Vim [Patch 9.1.327](https://github.com/vim/vim/commit/c9df1fb35a1866901c32df37dd39c8b39dbdb64a), Vim started supporting XDG Base Dir specs. We don't need to use Vim version 9.1.327 (or higher) to use `viminfo` and changes made by this pull request.