### PR TITLE
feat(serviceman): update for v0.9

### DIFF
--- a/brew/brew-update-service-install
+++ b/brew/brew-update-service-install
@@ -7,11 +7,11 @@ main() { (
     chmod a+x ~/.local/bin/brew-update-hourly
 
     echo "Checking for serviceman..."
+    ~/.local/bin/webi serviceman
     if ! command -v serviceman > /dev/null; then
-        "$HOME/.local/bin/webi" serviceman
         export PATH="$HOME/.local/bin:$PATH"
-        serviceman --version
     fi
+    serviceman --version
 
     env PATH="$PATH" serviceman add --agent \
         --workdir ~/.local/opt/brew/ \

--- a/brew/brew-update-service-install
+++ b/brew/brew-update-service-install
@@ -13,7 +13,7 @@ main() { (
         serviceman --version
     fi
 
-    env PATH="$PATH" serviceman add --user \
+    env PATH="$PATH" serviceman add --agent \
         --workdir ~/.local/opt/brew/ \
         --name sh.brew.updater -- \
         ~/.local/bin/brew-update-hourly

--- a/bun/README.md
+++ b/bun/README.md
@@ -132,9 +132,7 @@ file)
    ```
 3. Add your project to the system launcher, running as the current user
    ```sh
-   sudo env PATH="$PATH" \
-       serviceman add --path="$PATH" --system \
-           --username "$(id -u -n)" --name my-project -- \
+   serviceman add --name 'my-project' --daemon -- \
        bun run ./my-project.js
    ```
 4. Restart the logging service
@@ -155,6 +153,6 @@ For **macOS**:
    ```
 3. Add your project to the system launcher, running as the current user
    ```sh
-   serviceman add --path="$PATH" --agent --name my-project -- \
+   serviceman add --agent --name 'my-project' -- \
        bun run ./my-project.js
    ```

--- a/bun/README.md
+++ b/bun/README.md
@@ -155,6 +155,6 @@ For **macOS**:
    ```
 3. Add your project to the system launcher, running as the current user
    ```sh
-   serviceman add --path="$PATH" --user --name my-project -- \
+   serviceman add --path="$PATH" --agent --name my-project -- \
        bun run ./my-project.js
    ```

--- a/caddy/README.md
+++ b/caddy/README.md
@@ -821,7 +821,7 @@ To avoid the nitty-gritty details of `launchd` plist files, you can use
    ```sh
    my_username="$(id -u -n)"
 
-   serviceman add --user --name caddy -- \
+   serviceman add --agent --name caddy -- \
        caddy run --config ./Caddyfile --envfile ~/.config/caddy/env
    ```
 
@@ -915,9 +915,9 @@ See the notes below to run as a **User Service** or use the JSON Config.
 
 To create a **User Service** instead:
 
-- don't use `sudo`, but do use `--user` when running `serviceman`:
+- don't use `sudo`, but do use `--agent` when running `serviceman`:
   ```sh
-  serviceman add --user --name caddy -- \
+  serviceman add --agent --name caddy -- \
      caddy run --config ./Caddyfile --envfile ~/.config/caddy/env
   ```
   (this will create `~/.config/systemd/user/`)

--- a/caddy/README.md
+++ b/caddy/README.md
@@ -821,8 +821,8 @@ To avoid the nitty-gritty details of `launchd` plist files, you can use
    ```sh
    my_username="$(id -u -n)"
 
-   serviceman add --agent --name caddy -- \
-       caddy run --config ./Caddyfile --envfile ~/.config/caddy/env
+   serviceman add --agent --name 'caddy' --workdir ./ -- \
+       caddy run --envfile ~/.config/caddy/env --config ./Caddyfile --adapter caddyfile
    ```
 
    (this will create `~/Library/LaunchAgents/caddy.plist`)
@@ -837,8 +837,8 @@ This process creates a _User-Level_ service in `~/Library/LaunchAgents`. To
 create a _System-Level_ service in `/Library/LaunchDaemons/` instead:
 
 ```sh
-sudo serviceman add --system --name caddy -- \
-   caddy run --config ./Caddyfile --envfile ~/.config/caddy/env
+serviceman add --name 'caddy' --workdir ./ --daemon -- \
+   caddy run --envfile ~/.config/caddy/env --config ./Caddyfile --adapter caddyfile
 ```
 
 ### How to run Caddy as a Windows Service
@@ -856,7 +856,7 @@ sudo serviceman add --system --name caddy -- \
 3. Create a **Startup Registry Entry** with Serviceman.
    ```sh
    serviceman.exe add --name caddy -- \
-       caddy run --config ./Caddyfile --envfile ~/.config/caddy/env
+       caddy run --envfile ~/.config/caddy/env --config ./Caddyfile --adapter caddyfile
    ```
 4. You can manage the service directly with Serviceman. For example:
    ```sh
@@ -901,10 +901,8 @@ See the notes below to run as a **User Service** or use the JSON Config.
    ```
 4. Use Serviceman to create a _systemd_ config file.
    ```sh
-   my_username="$(id -u -n)"
-   sudo env PATH="$PATH" \
-       serviceman add --system --username "${my_username}" --name caddy -- \
-           caddy run --config ./Caddyfile --envfile ~/.config/caddy/env
+   serviceman add --name 'caddy' --daemon -- \
+       caddy run --envfile ~/.config/caddy/env --config ./Caddyfile --adapter caddyfile
    ```
    (this will create `/etc/systemd/system/caddy.service`)
 5. Manage the service with `systemctl` and `journalctl`:
@@ -915,10 +913,10 @@ See the notes below to run as a **User Service** or use the JSON Config.
 
 To create a **User Service** instead:
 
-- don't use `sudo`, but do use `--agent` when running `serviceman`:
+- use `--agent` when running `serviceman`:
   ```sh
   serviceman add --agent --name caddy -- \
-     caddy run --config ./Caddyfile --envfile ~/.config/caddy/env
+      caddy run --envfile ~/.config/caddy/env --config ./Caddyfile --adapter caddyfile
   ```
   (this will create `~/.config/systemd/user/`)
 - user the `--user` flag to manage services and logs:
@@ -1183,7 +1181,8 @@ To prevent search engine and browser confusion
 - _DO NOT_ prevent crawling via `robots.txt` \
   (counter-intuitive, but pages _must_ be crawled for links to _NOT_ be indexed)
 - _all_ domains using public TLS certs _will_ be indexed by default \
-  (they are all linked to and crawled from various Certificate Transparency reports)
+  (they are all linked to and crawled from various Certificate Transparency
+  reports)
 - follow these guidelines even if the dev sites use HTTP Basic Auth
 
 ```Caddyfile
@@ -1363,19 +1362,13 @@ See also: <https://caddyserver.com/docs/running>
 2. Generate the `service` file: \
    - JSON Config
      ```sh
-     my_app_user="$(id -u -n)"
-     sudo env PATH="${PATH}" \
-         serviceman add --system --cap-net-bind \
-             --username "${my_app_user}" --name caddy -- \
-             caddy run --resume --envfile ./caddy.env
+     serviceman add --name 'caddy' --daemon -- \
+         caddy run --resume --envfile ./caddy.env
      ```
    - Caddyfile
      ```sh
-     my_app_user="$(id -u -n)"
-     sudo env PATH="${PATH}" \
-         serviceman add --system --cap-net-bind \
-             --username "${my_app_user}" --name caddy -- \
-             caddy run --config ./Caddyfile --envfile ./caddy.env
+     serviceman add --name 'caddy' --daemon -- \
+         caddy run --config ./Caddyfile --envfile ./caddy.env
      ```
 3. Reload `systemd` config files, the logging service (it may not be started on
    a new VPS), and caddy

--- a/dashcore-utils/README.md
+++ b/dashcore-utils/README.md
@@ -100,8 +100,7 @@ mkdir -p ~/.dashcore/wallets/
 mkdir -p /mnt/slc1_vol_100g/dashcore/_data
 mkdir -p /mnt/slc1_vol_100g/dashcore/_caches
 
-sudo env PATH="$PATH" serviceman add \
-        --system --user "$my_user" --path "$PATH" --name dashd --force -- \
+serviceman add --name 'dashd' --daemon -- \
     dashd \
         -usehd \
         -conf="$HOME/.dashcore/dash.conf" \

--- a/dashcore-utils/dashd-hd-service-install
+++ b/dashcore-utils/dashd-hd-service-install
@@ -84,20 +84,8 @@ fn_srv_install() { (
         my_name="dashd-${my_netname}"
     fi
 
-    my_system_args=""
-    my_kernel="$(
-        uname -s
-    )"
-    if test "Darwin" != "${my_kernel}"; then
-        my_user="$(
-            id -u -n
-        )"
-        my_system_args="--system --username ${my_user}"
-    fi
-
     # shellcheck disable=SC2016,SC1090
-    echo 'sudo env PATH="$PATH"' \
-        "serviceman add ${my_system_args} --path \"\$PATH\" --name \"${my_name}\" --force --" \
+    echo "serviceman add --name \"${my_name}\" --" \
         "dashd " \
         "${my_net_flag}" \
         -usehd \
@@ -107,16 +95,16 @@ fn_srv_install() { (
         "-datadir=\"${my_datadir}\"" \
         "-blocksdir=\"${my_blocksdir}\""
 
+    echo ""
+    echo "Installing latest 'serviceman'..."
+    echo ""
+    "$HOME/.local/bin/webi" serviceman > /dev/null
     if ! command -v serviceman > /dev/null; then
-        echo ""
-        echo "Installing 'serviceman'..."
-        echo ""
-        {
-            "$HOME/.local/bin/webi" serviceman
-        } > /dev/null
-
-        # shellcheck disable=SC1090
-        . ~/.config/envman/PATH.env || true
+        export PATH="$HOME/.local/bin:$PATH"
+    fi
+    serviceman --version
+    if ! command -v dashd > /dev/null; then
+        export PATH="$HOME/.local/opt/dashcore/bin:$PATH"
     fi
 
     mkdir -p "$HOME/.dashcore/wallets/"
@@ -132,7 +120,7 @@ fn_srv_install() { (
     # leave options unquoted so they're interpreted separately
     # shellcheck disable=SC2086
     sudo env PATH="${PATH}" \
-        serviceman add ${my_system_args} --path "${PATH}" --name "${my_name}" --force -- \
+        serviceman add --name "${my_name}" -- \
         dashd \
         ${my_net_flag} \
         -usehd \

--- a/dashd/README.md
+++ b/dashd/README.md
@@ -219,14 +219,7 @@ You can use [`serviceman`](../serviceman/):
 **Linux**
 
 ```sh
-sudo env PATH="$PATH" \
-    serviceman add \
-        --system \
-        --username "$(id -n -u)" \
-        --path "$PATH" \
-        --name dashd \
-        --force \
-        -- \
+serviceman add --name 'dashd' -- \
     dashd \
         -usehd \
         -conf="$HOME/.dashcore/dash.conf" \
@@ -239,11 +232,7 @@ sudo env PATH="$PATH" \
 **Mac**
 
 ```sh
-serviceman add \
-    --path "$PATH" \
-    --name dashd \
-    --force \
-    -- \
+serviceman add --name 'dashd' -- \
     dashd \
         -usehd \
         -conf="$HOME/.dashcore/dash.conf" \

--- a/go/README.md
+++ b/go/README.md
@@ -80,8 +80,7 @@ webi serviceman
 pushd ./hello/
 
 # swap 'hello' and './hello' for the name of your project and binary
-sudo env PATH="$PATH" \
-    serviceman add --system --username "$(id -u -n)" --name hello -- \
+serviceman add --name 'hello' -- \
     ./hello
 
 # Restart the logging service

--- a/golang/README.md
+++ b/golang/README.md
@@ -85,8 +85,7 @@ webi serviceman
 pushd ./hello/
 
 # swap 'hello' and './hello' for the name of your project and binary
-sudo env PATH="$PATH" \
-    serviceman add --system --username "$(id -u -n)" --name hello -- \
+serviceman add --name 'hello' -- \
     ./hello
 
 # Restart the logging service

--- a/node/README.md
+++ b/node/README.md
@@ -66,7 +66,8 @@ To run them manually on your code;
   jhint -c ./.jshintrc *.js */*.js
   ```
 - fixjson \
-  (turns JavaScript Objects with comments, trailing commas, etc into actual json)
+  (turns JavaScript Objects with comments, trailing commas, etc into actual
+  json)
   ```sh
   fixjson -i 2 -w ./package.json
   ```
@@ -229,7 +230,7 @@ Node app as a Non-System (Unprivileged) Service on Mac, Windows, and Linux:
    ```sh
    my_username="$(id -u -n)"
 
-   serviceman add --user --name my-node-project -- \
+   serviceman add --agent --name my-node-project -- \
        caddy run --config ./Caddyfile --envfile ~/.config/caddy/env
    ```
 

--- a/node/README.md
+++ b/node/README.md
@@ -276,11 +276,8 @@ Node app as a Non-System (Unprivileged) Service on Mac, Windows, and Linux:
 ```sh
 pushd ./my-node-project/
 
-my_username="$(id -u -n)"
-sudo env PATH="$PATH" \
-    serviceman add --system --path "$PATH" --cap-net-bind \
-    --name my-node-project --username "${my_username}" -- \
-        npm run start
+serviceman add --name 'my-node-project' -- \
+    npm run start
 ```
 
 #### ... with auto-reload in Dev
@@ -288,10 +285,8 @@ sudo env PATH="$PATH" \
 ```sh
 pushd ./my-node-project/
 
-sudo env PATH="$PATH" \
-    serviceman add --system --path "$PATH" --cap-net-bind \
-    --name my-node-project --username "$(id -u -n)" -- \
-        npx -p nodemon@3 -- nodemon ./server.js
+serviceman add --name 'my-node-project' -- \
+    npx -p nodemon@3 -- nodemon ./server.js
 ```
 
 #### View Logs & Restart

--- a/pg/install.sh
+++ b/pg/install.sh
@@ -58,16 +58,19 @@ __init_pg() {
     }
 
     pkg_done_message() {
-        # TODO show with serviceman
         echo "    Installed $(t_pkg "$pkg_cmd_name v$WEBI_VERSION") (and $(t_pkg "psql")) to $(t_link "$(fn_sub_home "${pkg_dst_bin}")")"
         echo ""
         echo "IMPORTANT!!!"
         echo ""
-        echo "Database initialized at $POSTGRES_DATA_DIR:"
-        echo "    postgres -D $POSTGRES_DATA_DIR -p 5432"
+        echo "Database initialized at:"
+        echo "    $POSTGRES_DATA_DIR"
         echo ""
         echo "Username and password set to 'postgres':"
         echo "    psql 'postgres://postgres:postgres@localhost:5432/postgres'"
+        echo ""
+        echo "To install as a service:"
+        echo "    serviceman add --name 'postgres' --workdir '$POSTGRES_DATA_DIR' -- \\"
+        echo "        postgres -D '$POSTGRES_DATA_DIR' -p 5432"
         echo ""
     }
 }

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -34,8 +34,7 @@ To enable Postgres as a Linux Service with [serviceman](../serviceman/): \
 (see macOS below)
 
 ```sh
-sudo env PATH="$PATH" \
-    serviceman add --system --username "$(id -u -n)" --name 'postgres' -- \
+serviceman add --name 'postgres' --workdir ~/.local/share/postgres/var -- \
     postgres -D ~/.local/share/postgres/var -p 5432
 
 sudo systemctl restart systemd-journald
@@ -119,8 +118,7 @@ curl https://webi.sh/serviceman | sh
 ```
 
 ```sh
-sudo env PATH="$PATH" \
-    serviceman add --system --username "$(id -u -n)" --name 'postgres' -- \
+serviceman add --name 'postgres' --workdir ~/.local/share/postgres/var -- \
     postgres -D ~/.local/share/postgres/var -p 5432
 
 sudo systemctl restart systemd-journald
@@ -185,7 +183,7 @@ sudo tail -f /var/log/postgres
 #### macOS
 
 ```sh
-serviceman add --name 'postgres' -- \
+serviceman add --name 'postgres' --workdir ~/.local/share/postgres/var -- \
     postgres -D ~/.local/share/postgres/var -p 5432
 
 tail -f ~/.local/share/postgres/var/log/postgres.log

--- a/postgres/install.sh
+++ b/postgres/install.sh
@@ -78,16 +78,19 @@ __init_postgres() {
     }
 
     pkg_done_message() {
-        # TODO show with serviceman
         echo "Installed 'postgres' and 'psql' at $pkg_dst"
         echo ""
         echo "IMPORTANT!!!"
         echo ""
-        echo "Database initialized at $POSTGRES_DATA_DIR:"
-        echo "    postgres -D $POSTGRES_DATA_DIR -p 5432"
+        echo "Database initialized at:"
+        echo "    $POSTGRES_DATA_DIR"
         echo ""
         echo "Username and password set to 'postgres':"
         echo "    psql 'postgres://postgres:postgres@localhost:5432/postgres'"
+        echo ""
+        echo "To install as a service:"
+        echo "    serviceman add --name 'postgres' --workdir '$POSTGRES_DATA_DIR' -- \\"
+        echo "        postgres -D '$POSTGRES_DATA_DIR' -p 5432"
         echo ""
     }
 }

--- a/serviceman/install.sh
+++ b/serviceman/install.sh
@@ -12,28 +12,62 @@ __init_serviceman() {
     pkg_cmd_name="serviceman"
 
     pkg_dst_cmd="$HOME/.local/bin/serviceman"
+    # shellcheck disable=SC2034
     pkg_dst="$pkg_dst_cmd"
 
     pkg_src_cmd="$HOME/.local/opt/serviceman-v$WEBI_VERSION/bin/serviceman"
+    pkg_src_bin="$HOME/.local/opt/serviceman-v$WEBI_VERSION/bin"
     pkg_src_dir="$HOME/.local/opt/serviceman-v$WEBI_VERSION"
+    # shellcheck disable=SC2034
     pkg_src="$pkg_src_cmd"
 
     pkg_install() {
-        # $HOME/.local/opt/serviceman-v0.8.0/bin
-        mkdir -p "$pkg_src_bin"
+        if test -e ./*"$pkg_cmd_name"*/share; then
+            rm -rf "${pkg_src_dir}"
+            # mv ./bnnanet-serviceman-* "$HOME/.local/opt/serviceman-v0.9.1"
+            mv ./*"$pkg_cmd_name"*/ "${pkg_src_dir}"
+        else
+            echo "NO share"
+            # $HOME/.local/opt/serviceman-v0.8.0/bin
+            mkdir -p "$pkg_src_bin"
 
-        # mv ./serviceman* "$HOME/.local/opt/serviceman-v0.8.0/bin/serviceman"
-        mv ./"$pkg_cmd_name"* "$pkg_src_cmd"
+            # mv ./serviceman* "$HOME/.local/opt/serviceman-v0.8.0/bin/serviceman"
+            mv ./"$pkg_cmd_name"* "$pkg_src_cmd"
 
-        # chmod a+x "$HOME/.local/opt/serviceman-v0.8.0/bin/serviceman"
-        chmod a+x "$pkg_src_cmd"
+            # chmod a+x "$HOME/.local/opt/serviceman-v0.8.0/bin/serviceman"
+            chmod a+x "$pkg_src_cmd"
+        fi
+    }
+
+    pkg_link() {
+        (
+            cd ~/.local/opt/ || return 1
+            rm -rf ./serviceman
+            ln -s "serviceman-v$WEBI_VERSION" 'serviceman'
+        )
+
+        (
+            mkdir -p ~/.local/share/
+            cd ~/.local/share/ || return 1
+            rm -rf ./serviceman
+            ln -s "../opt/serviceman-v$WEBI_VERSION/share/serviceman" 'serviceman'
+        )
+
+        (
+            mkdir -p ~/.local/bin/
+            cd ~/.local/bin/ || return 1
+            rm -rf ./serviceman
+            ln -s "../opt/serviceman-v$WEBI_VERSION/bin/serviceman" 'serviceman'
+        )
     }
 
     pkg_get_current_version() {
         # 'serviceman version' has output in this format:
-        #       serviceman v0.8.0 (f3ab547) 2020-12-02T16:19:10-07:00
+        #       serviceman v0.9.1 (2024-12-11 14:29 -0500)
+        #       Copyright 2024 AJ ONeal
+        #       Licensed under the MPL-2.0
         # This trims it down to just the version number:
-        #       0.8.0
+        #       0.9.1
         serviceman --version 2> /dev/null | head -n 1 | cut -d' ' -f2 | sed 's:^v::'
     }
 

--- a/serviceman/releases.js
+++ b/serviceman/releases.js
@@ -1,18 +1,35 @@
 'use strict';
 
-var github = require('../_common/github.js');
-var owner = 'therootcompany';
-var repo = 'serviceman';
+let Releases = module.exports;
 
-module.exports = function () {
-  return github(null, owner, repo).then(function (all) {
-    return all;
-  });
+let GitHub = require('../_common/github.js');
+let oldOwner = 'therootcompany';
+let oldRepo = 'serviceman';
+
+let GitHubSource = require('../_common/github-source.js');
+let owner = 'bnnanet';
+let repo = 'serviceman';
+
+Releases.latest = async function () {
+  let all = await GitHubSource.getDistributables({ owner, repo });
+  for (let pkg of all.releases) {
+    //@ts-expect-error
+    pkg.os = 'posix_2017';
+  }
+
+  let all2 = await GitHub.getDistributables(null, oldOwner, oldRepo);
+  for (let pkg of all2.releases) {
+    //@ts-expect-error
+    all.releases.push(pkg);
+  }
+
+  return all;
 };
 
 if (module === require.main) {
-  module.exports().then(function (all) {
+  //@ts-expect-error
+  Releases.latest().then(function (all) {
     all = require('../_webi/normalize.js')(all);
-    console.info(JSON.stringify(all));
+    console.info(JSON.stringify(all, null, 2));
   });
 }

--- a/syncthing/README.md
+++ b/syncthing/README.md
@@ -46,7 +46,7 @@ webi serviceman
 
 ```sh
 mkdir -p ~/.config/syncthing/
-env PATH="$PATH" serviceman add --user --name syncthing -- \
+env PATH="$PATH" serviceman add --agent --name syncthing -- \
   syncthing --home ~/.config/syncthing/
 ```
 


### PR DESCRIPTION
- update docs (`sudo` and `--path "$PATH"` are now automatic)
- update new homepage
- handle both install types

note: v0.9.1 wouldn't show up, but v0.9.0 would. There must be something funny about v0.x.1 versions.