### PR TITLE
fix(api): 'alias' projects (symlinks) should be resolved before checking for 'selfhosted'

### DIFF
--- a/_webi/serve-installer.js
+++ b/_webi/serve-installer.js
@@ -70,17 +70,19 @@ InstallerServer.helper = async function ({
 
   console.log(`dbg: Get Project Installer Type for '${projectName}':`);
   let proj = await Builds.getProjectType(projectName);
-  console.log(proj);
+  if (proj.type === 'alias') {
+    console.log(`dbg: alias`, proj);
+    projectName = proj.detail;
+    proj = await Builds.getProjectType(projectName); // an alias should never resolve to an alias
+  }
+  console.log(`dbg: proj`, proj);
 
-  let validTypes = ['alias', 'selfhosted', 'valid'];
+  let validTypes = ['selfhosted', 'valid'];
   if (!validTypes.includes(proj.type)) {
     let msg = `'${projectName}' doesn't have an installer: '${proj.type}': '${proj.detail}'`;
     let err = new Error(msg);
     err.code = 'ENOENT';
     throw err;
-  }
-  if (proj.type === 'alias') {
-    projectName = proj.detail;
   }
 
   let tmplParams = {


### PR DESCRIPTION
fixes #933 

Projects are marked as an `alias` if they're a symlink, or if `alias: ` is matched in the first 1k of of the `README.md`.

Excluding possible errors, the resolved projects are either `valid` (having a `releases.js`) or `selfhosted` (having an `install.sh` and local files committed to Webi, no remote releases).

Up to this point `alias` projects have simply been cached twice. However, `vim-mouse` is a symlink alias of `vim-gui`, which has no `releases.js` and was therefore failing module resolution (as it didn't match `selfhosted`).

This change resolves `alias` projects before checking if they're `valid` or `selfhosted`.