### PR TITLE
fix(sass): manually match arches { arm: armv7, ia32: x86, x64: amd64 }

### DIFF
--- a/sass/releases.js
+++ b/sass/releases.js
@@ -1,21 +1,46 @@
 'use strict';
 
-var github = require('../_common/github.js');
-var owner = 'sass';
-var repo = 'dart-sass';
+let Releases = module.exports;
 
-module.exports = function () {
-  return github(null, owner, repo).then(function (all) {
-    all._names = ['dart-sass', 'sass'];
+let Github = require('../_common/github.js');
+let owner = 'sass';
+let repo = 'dart-sass';
+
+// https://github.com/sass/dart-sass/releases/
+
+/** @type {Object.<String, String>} */
+let archMap = {
+  ia32: 'x86',
+  x64: 'amd64',
+  arm: 'armv7',
+};
+let keys = Object.keys(archMap);
+let keyList = keys.join('|');
+let archRe = new RegExp(`\\b(${keyList})\\b`);
+
+Releases.latest = function () {
+  return Github.getDistributables(null, owner, repo).then(function (all) {
+    Object.assign(all, {
+      _names: ['dart-sass', 'sass'],
+    });
+
+    for (let asset of all.releases) {
+      let m = asset.name.match(archRe);
+      let arch = m?.[1];
+      if (arch) {
+        asset.arch = archMap[arch];
+      }
+    }
+
     return all;
   });
 };
 
 if (module === require.main) {
-  module.exports().then(function (all) {
+  Releases.latest().then(function (all) {
     all = require('../_webi/normalize.js')(all);
     // just select the first 5 for demonstration
-    all.releases = all.releases.slice(0, 5);
+    all.releases = all.releases.slice(0, 10);
     console.info(JSON.stringify(all, null, 2));
   });
 }


### PR DESCRIPTION
The term `arm` does not actually set a match - as it may ambiguously refer to any of `armv5`, `armv7l`, or `arm64`.

If no match is set, then the default for `musl` is to match `x86_64`.

As such, both `arm` (by default) and `x64` were matching `x86_64`.

These ambiguous and confusing cases must be matched manually.