### PR TITLE
ref(ssh-pubkey): switch to ed25519 as the primary algorithm

### DIFF
--- a/ssh-pubkey/ssh-pubkey
+++ b/ssh-pubkey/ssh-pubkey
@@ -2,40 +2,27 @@
 set -e
 set -u
 
-fn_warn_rsa() { (
+fn_fix_rsa() { (
     echo 'WARNING'
     echo '    ~/.ssh/id_rsa is less than the required 3072 bits'
     echo '    (some modern services will reject your key)'
-
     echo ''
-    echo 'SOLUTION'
-    echo '    Generate a new key, and update accordingly'
-
-    my_ts="$(date -u "+%F_%H.%M.%S")"
-
-    echo ''
-    echo '    # OPTION 1: Generate a more efficient, ED25519 256-bit key'
-    echo '    #           and update your ~/.ssh/config accordingly'
-    echo "    mv ~/.ssh/id_rsa ~/.ssh/id_rsa.${my_ts}.bak"
-    # shellcheck disable=SC2016
+    echo 'AUTOMATIC FIX'
+    echo '    Generating an efficient, modern ed25519 key'
     echo '    ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -q -N ""'
+    echo ''
+    my_ts="$(date -u "+%F_%H.%M.%S")"
+    echo 'MANUAL FIX (optional)'
+    echo "    mv ~/.ssh/id_rsa ~/.ssh/id_rsa.${my_ts}.bak"
+    echo '    ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa -q -N ""'
+    # shellcheck disable=SC2016
     echo "    echo 'Host *
         IdentityFile ~/.ssh/id_ed25519
-        IdentityFile ~/.ssh/id_rsa.${my_ts}.bak' >> ~/.ssh/config"
-
-    echo ''
-    echo '    # OPTION 2: Generate a larger, 4096-bit RSA key"'
-    echo '    #           and update your ~/.ssh/config accordingly'
-    echo "    mv ~/.ssh/id_rsa ~/.ssh/id_rsa.${my_ts}.bak"
-    # shellcheck disable=SC2016
-    echo '    ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa -q -N ""'
-    echo "    echo 'Host *
         IdentityFile ~/.ssh/id_rsa
         IdentityFile ~/.ssh/id_rsa.${my_ts}.bak' >> ~/.ssh/config"
 ); }
 
 main() {
-
     if ! test -d ~/.ssh; then
         mkdir -p ~/.ssh/
         chmod 0700 ~/.ssh/
@@ -59,43 +46,52 @@ main() {
             echo >&2 ""
             ssh-keygen -y -f ~/.ssh/id_ed25519 > ~/.ssh/id_ed25519.pub
         fi
-    elif test -f ~/.ssh/id_rsa; then
-        my_keytype='rsa'
-        if ! test -f ~/.ssh/id_rsa.pub; then
-            echo >&2 ""
-            ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
-        fi
     elif test -f ~/.ssh/id_ecda; then
         my_keytype='ecdsa'
         if ! test -f ~/.ssh/id_ecdsa.pub; then
             echo >&2 ""
             ssh-keygen -y -f ~/.ssh/id_ecda > ~/.ssh/id_ecda.pub
         fi
-    else
-        my_keytype='rsa'
-        echo >&2 ""
-        echo >&2 "Generating public/private rsa key pair."
-        ssh-keygen -b 4096 -t rsa -f ~/.ssh/id_rsa -q -N ""
-        ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
     fi
 
-    # TODO use the comment (if any) for the name of the file
-    echo >&2 ""
-    #shellcheck disable=SC2088
-    echo >&2 "~/Downloads/id_${my_keytype}.$(id -u -n).pub":
-    echo >&2 ""
-    rm -f "$HOME/Downloads/id_${my_keytype}.$(id -u -n).pub"
-    cp -RPp "$HOME/.ssh/id_${my_keytype}.pub" "$HOME/Downloads/id_${my_keytype}.$(id -u -n).pub"
-    cat "$HOME/Downloads/id_${my_keytype}.$(id -u -n).pub"
-    echo >&2 ""
-
-    if test -f ~/.ssh/id_rsa; then
-        my_rsa_chars="$(cat ~/.ssh/id_rsa)"
-        if test "${#my_rsa_chars}" -lt 2500; then
-            fn_warn_rsa >&2
-            echo >&2 ""
+    if test -z "${my_keytype}"; then
+        if test -f ~/.ssh/id_rsa; then
+            my_rsa_chars="$(cat ~/.ssh/id_rsa)"
+            if test "${#my_rsa_chars}" -lt 2500; then
+                fn_fix_rsa >&2
+                echo >&2 ""
+            else
+                my_keytype='rsa'
+            fi
         fi
     fi
+
+    if test -z "${my_keytype}"; then
+        echo >&2 ""
+
+        my_keytype='ed25519'
+        ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -q -N ""
+        ssh-keygen -y -f ~/.ssh/id_ed25519 > ~/.ssh/id_ed25519.pub
+
+        # my_keytype='rsa'
+        # echo >&2 "Generating public/private rsa key pair."
+        # ssh-keygen -b 4096 -t rsa -f ~/.ssh/id_rsa -q -N ""
+        # ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
+    fi
+
+    my_comment="$(cut -d' ' -f3 < ~/.ssh/"id_${my_keytype}.pub")"
+    if test -z "${my_comment}"; then
+        my_comment="$(id -u -n)"
+    fi
+
+    echo >&2 ""
+    #shellcheck disable=SC2088
+    echo >&2 "~/Downloads/id_${my_keytype}.${my_comment}.pub":
+    echo >&2 ""
+    rm -f "$HOME/Downloads/id_${my_keytype}.${my_comment}.pub"
+    cp -RPp "$HOME/.ssh/id_${my_keytype}.pub" "$HOME/Downloads/id_${my_keytype}.${my_comment}.pub"
+    cat "$HOME/Downloads/id_${my_keytype}.${my_comment}.pub"
+    echo >&2 ""
 }
 
 main

--- a/ssh-pubkey/ssh-pubkey.ps1
+++ b/ssh-pubkey/ssh-pubkey.ps1
@@ -22,21 +22,21 @@ if (!(Test-Path -Path "$Env:USERPROFILE/.ssh/config")) {
 #    #& icacls "$Env:USERPROFILE/.ssh/authorized_keys" /grant:r "$Env:USERNAME":"(F)"
 #}
 
-if (!(Test-Path -Path "$Env:USERPROFILE/.ssh/id_rsa")) {
-    & ssh-keygen -b 2048 -t rsa -f "$Env:USERPROFILE/.ssh/id_rsa" -q -N """"
+if (!(Test-Path -Path "$Env:USERPROFILE/.ssh/id_ed25519")) {
+    & ssh-keygen -t ed25519 -f "$Env:USERPROFILE/.ssh/id_ed25519" -q -N """"
     Write-Output ""
 }
 
-if (!(Test-Path -Path "$Env:USERPROFILE/.ssh/id_rsa.pub")) {
-    & ssh-keygen -y -f "$Env:USERPROFILE/.ssh/id_rsa" > "$Env:USERPROFILE/.ssh/id_rsa.pub"
+if (!(Test-Path -Path "$Env:USERPROFILE/.ssh/id_ed25519.pub")) {
+    & ssh-keygen -y -f "$Env:USERPROFILE/.ssh/id_ed25519" > "$Env:USERPROFILE/.ssh/id_ed25519.pub"
     Write-Output ""
 }
 
 # TODO use the comment (if any) for the name of the file
 Write-Output ""
-Write-Output "~/Downloads/id_rsa.$Env:USERNAME.pub":
+Write-Output "~/Downloads/id_ed25519.$Env:USERNAME.pub":
 Write-Output ""
-#rm -f "$Env:USERPROFILE/Downloads/id_rsa.$Env:USERNAME.pub":
-Copy-Item -Path "$Env:USERPROFILE/.ssh/id_rsa.pub" -Destination "$Env:USERPROFILE/Downloads/id_rsa.$Env:USERNAME.pub"
-& Get-Content "$Env:USERPROFILE/Downloads/id_rsa.$Env:USERNAME.pub"
+#rm -f "$Env:USERPROFILE/Downloads/id_ed25519.$Env:USERNAME.pub":
+Copy-Item -Path "$Env:USERPROFILE/.ssh/id_ed25519.pub" -Destination "$Env:USERPROFILE/Downloads/id_ed25519.$Env:USERNAME.pub"
+& Get-Content "$Env:USERPROFILE/Downloads/id_ed25519.$Env:USERNAME.pub"
 Write-Output ""


### PR DESCRIPTION
Generating sufficiently large RSA keys takes a really long time, and, as far as I can tell, ed25519 has been supported for a very long time. So I think it's time to switch the default.

Support was introduced in January of 2014, over 10 years ago.

On Ubuntu 20.04.1 LTS `ssh -V` shows `OpenSSH_8.2p1`.

Ubuntu 18.04.3 LTS `ssh -V` shows `OpenSSH_7.6p1`.

I don't have any running systems older than that.

Due to issues with various services not accepting RSA keys less than 3072 bits, the keys that previous issued a warning will now cause an ed25519 key to be generated, and show a prompt for how to manually generate a larger RSA key.

Re: https://github.com/webinstall/webi-installers/pull/841