### PR TITLE
fix(koji): update binary path, docs

### DIFF
--- a/koji/README.md
+++ b/koji/README.md
@@ -26,7 +26,7 @@ You can use koji in one of two ways:
 Here's the shortlist of options we've found most useful:
 
 ```text
--e, --emoji - use emoji for commit type (ex: `✨ feat:`)
+-e, --emoji - use emoji for commit summary (ex: `feat: ✨ ...`)
 -a, --autocomplete - guess 'scope' based on commit history (slow on large projects)
 --hook - expect to be run from 'git commit', rather than wrap it
 ```
@@ -72,8 +72,8 @@ git commit
 
 ### How to use Emoji
 
-You can use `-e` (or `--emoji`) to prepend your commit message with the relevant
-emoji for the commit type:
+You can use `-e` (or `--emoji`) to prepend your commit message summary with the
+relevant emoji for the commit type:
 
 ```sh
 koji -e
@@ -91,18 +91,20 @@ koji --emoji --hook
 You can also use _shortcodes_ (`:pinched_fingers:`) in the scope, summary, or
 body.
 
-### How to configure Koji (custom emoji)
+### How to configure koji
 
-You can add custom commit types via a `koji.toml` in the project directory.
+You can configure koji via a custom config passed with `--config`, a
+`.koji.toml` file in the project root, or a user config at
+`~/.config/koji/config.toml`.
 
-For example:
+Here's an example of a custom commit type:
 
 ```toml
 [[commit_types]]
-name = "feat"
+name = "cust"
 emoji = "✨"
-description = "A new feature"
+description = "A custom commit type"
 ```
 
-The default emoji can be seen in
+The default configuration can be seen in
 [default.toml](https://github.com/cococonscious/koji/blob/main/meta/config/default.toml).

--- a/koji/install.sh
+++ b/koji/install.sh
@@ -19,13 +19,13 @@ __init_koji() {
         # ~/.local/opt/koji-v1.5.0/bin
         mkdir -p "$(dirname "$pkg_src_cmd")"
 
-        # mv ./koji-*/koji ~/.local/opt/koji-v1.5.0/bin/koji
-        mv ./koji-*/koji "$pkg_src_cmd"
+        # mv koji ~/.local/opt/koji-v1.5.0/bin/koji
+        mv koji "$pkg_src_cmd"
     }
 
     # pkg_get_current_version is recommended, but (soon) not required
     pkg_get_current_version() {
-        # 'koji version' has output in this format:
+        # 'koji --version' has output in this format:
         #       koji 1.5.0
         # This trims it down to just the version number:
         #       1.5.0

--- a/koji/install.sh
+++ b/koji/install.sh
@@ -19,8 +19,19 @@ __init_koji() {
         # ~/.local/opt/koji-v1.5.0/bin
         mkdir -p "$(dirname "$pkg_src_cmd")"
 
-        # mv koji ~/.local/opt/koji-v1.5.0/bin/koji
-        mv koji "$pkg_src_cmd"
+        if test -f ./koji; then
+            # mv koji ~/.local/opt/koji-v1.5.0/bin/koji
+            mv ./koji "$pkg_src_cmd"
+        elif test -e ./koji-*/koji; then
+            # mv koji-1.4.0/koji ~/.local/opt/koji-v1.4.0/bin/koji
+            mv ./koji-*/koji "$pkg_src_cmd"
+        elif test -e ./koji-*; then
+            # mv koji-linux-amd64 ~/.local/opt/koji-v1.2.0/bin/koji
+            mv ./koji-* "$pkg_src_cmd"
+        else
+            echo >&2 "failed to find 'koji' exectutable"
+            return 1
+        fi
     }
 
     # pkg_get_current_version is recommended, but (soon) not required
@@ -29,7 +40,7 @@ __init_koji() {
         #       koji 1.5.0
         # This trims it down to just the version number:
         #       1.5.0
-        koji --version 2> /dev/null | cut -c6-
+        koji --version 2> /dev/null | head -n 1 | cut -d' ' -f2
     }
 }
 


### PR DESCRIPTION
The release process of koji has been updated a while ago, resulting in the binary not being nested in the archive anymore.

Fixes https://github.com/cococonscious/koji/issues/137