### PR TITLE
fix: bug double-text in README.md

### DIFF
--- a/hugo-extended/README.md
+++ b/hugo-extended/README.md
@@ -61,4 +61,4 @@ The Standard Edition is written and compiled with Go, which means it's binaries:
 
 ### [Hugo](../hugo/) Quick Start & Tips
 
-See the [Hugo Cheat Sheet](../hugo/). See the [Hugo Cheat Sheet](../hugo/).
+See the [Hugo Cheat Sheet](../hugo/).


### PR DESCRIPTION
closes #967

# Docs(hugo-extended): Bug Double-Text in README.md

Removed double-text found in [webi-installers/hugo-extended/README.md](https://github.com/webinstall/webi-installers/blob/480169beaca5fb0237c28abac2148457a07b0ea5/hugo-extended/README.md?plain=1#L64) on line 64

My suggestion:
```diff
- See the [Hugo Cheat Sheet](../hugo/). See the [Hugo Cheat Sheet](../hugo/).
+ See the [Hugo Cheat Sheet](../hugo/).
```