### PR TITLE
fix(rg): Handle missing rg command in install.sh

### DIFF
--- a/rg/install.sh
+++ b/rg/install.sh
@@ -33,6 +33,10 @@ __init_rg() {
 
     # pkg_get_current_version is recommended, but (soon) not required
     pkg_get_current_version() {
+        if ! command -v rg >/dev/null 2>&1; then
+            echo ""
+            return
+        fi
         # 'rg --version' has output in this format:
         #       ripgrep 12.1.1 (rev 7cb211378a)
         #       -SIMD -AVX (compiled)


### PR DESCRIPTION
The `pkg_get_current_version` function in `rg/install.sh` would fail if the `rg` command was not found in the `PATH`. This change adds a check to ensure the command exists before attempting to execute it, preventing the installation script from failing unexpectedly.