### PR TITLE
feat(fish): add Linux x86_64 and aarch64 binary support

### DIFF
--- a/_webi/test.js
+++ b/_webi/test.js
@@ -71,6 +71,14 @@ Builds.getPackage({ name: projName }).then(async function (/*projInfo*/) {
   var nodeOs = os.platform();
   var nodeOsRelease = os.release();
   var nodeArch = os.arch();
+  
+   // To make arch names compatible across all helpers
+  if (nodeArch === 'x64') {
+    nodeArch = 'amd64';
+  } else if (nodeArch === 'arm64') {
+    nodeArch = 'arm64';
+  }
+
   var nodeLibc = 'libc';
   if (process.platform === 'linux') {
     nodeLibc = 'gnu';

--- a/fish/install.sh
+++ b/fish/install.sh
@@ -35,8 +35,38 @@ pkg_src_dir="$HOME/.local/opt/fish-v$WEBI_VERSION"
 pkg_src="$pkg_src_cmd"
 
 # pkg_install must be defined by every package
+_linux_post_install() {
+    if [ "Linux" != "$(uname -s)" ]; then #terminate if MacOS
+        return 0
+    fi
+
+    if ! [ -e "$HOME/.local/bin/fish" ]; then
+        return 0
+    fi
+
+    echo ""
+    echo "To set fish as your default shell, run:"
+    echo ""
+
+    # Check if fish is in /etc/shells
+    if grep -q "$HOME/.local/bin/fish" /etc/shells 2> /dev/null; then
+        echo "    chsh -s $HOME/.local/bin/fish"
+    else
+        echo "    # First, add fish to allowed shells"
+        echo "    echo '$HOME/.local/bin/fish' | sudo tee -a /etc/shells"
+        echo ""
+        echo "    # Then change your default shell:"
+        echo "    chsh -s $HOME/.local/bin/fish"
+    fi
+    echo ""
+}
 
 _macos_post_install() {
+
+    if [ "Darwin" != "$(uname -s)" ]; then #terminate if linux machine
+        return 0
+    fi
+
     if ! [ -e "$HOME/.local/bin/fish" ]; then
         return 0
     fi
@@ -85,7 +115,7 @@ pkg_post_install() {
 
     # try again to update default shells, now that all files should exist
     _macos_post_install
-
+    _linux_post_install
     if [ ! -e ~/.config/fish/config.fish ]; then
         mkdir -p ~/.config/fish
         touch ~/.config/fish/config.fish

--- a/fish/install.sh
+++ b/fish/install.sh
@@ -10,11 +10,6 @@ if command -v fish > /dev/null; then
     fi
 fi
 
-if [ "Darwin" != "$(uname -s)" ]; then
-    echo "No fish installer for Linux yet. Try this instead:"
-    echo "    sudo apt install -y fish"
-    exit 1
-fi
 
 ################
 # Install fish #
@@ -105,8 +100,12 @@ _macos_post_install() {
 _macos_post_install
 
 pkg_install() {
-    mv fish.app/Contents/Resources/base/usr/local "$HOME/.local/opt/fish-v${WEBI_VERSION}"
-
+    if [ "Darwin" = "$(uname -s)" ]; then
+        mv fish.app/Contents/Resources/base/usr/local "$pkg_src_dir"
+    else
+        mkdir -p "$pkg_src_dir/bin"
+        mv fish "$pkg_src_dir/bin/"
+    fi
 }
 
 pkg_post_install() {
@@ -126,8 +125,8 @@ pkg_post_install() {
 # pkg_get_current_version is recommended, but (soon) not required
 pkg_get_current_version() {
     # 'fish --version' has output in this format:
-    #       fish, version 3.1.2
+    #       fish, version 4.3.3
     # This trims it down to just the version number:
-    #       3.1.2
+    #       4.3.3
     fish --version 2> /dev/null | head -n 1 | cut -d ' ' -f 3
 }

--- a/fish/install.sh
+++ b/fish/install.sh
@@ -3,22 +3,18 @@ set -e
 set -u
 
 if command -v fish > /dev/null; then
-    if [ ! -e ~/.config/fish/config.fish ]; then
-        mkdir -p ~/.config/fish
-        touch ~/.config/fish/config.fish
-        chmod 0600 ~/.config/fish/config.fish
-    fi
-fi
-
-if [ "Darwin" != "$(uname -s)" ]; then
-    echo "No fish installer for Linux yet. Try this instead:"
-    echo "    sudo apt install -y fish"
-    exit 1
+	if ! test -e ~/.config/fish/config.fish; then
+		mkdir -p ~/.config/fish
+		touch ~/.config/fish/config.fish
+		chmod 0600 ~/.config/fish/config.fish
+	fi
 fi
 
 ################
 # Install fish #
 ################
+
+my_os=$(uname -s)
 
 # Every package should define these 6 variables
 # shellcheck disable=2034
@@ -34,70 +30,109 @@ pkg_src_dir="$HOME/.local/opt/fish-v$WEBI_VERSION"
 # shellcheck disable=2034
 pkg_src="$pkg_src_cmd"
 
-# pkg_install must be defined by every package
+if test "Darwin" = "${my_os}"; then
+	pkg_src_cmd="/Applications/fish.app/Contents/Resources/base/usr/local/bin/fish"
+	# shellcheck disable=2034
+	pkg_src="${pkg_src_cmd}"
+fi
+
+_linux_post_install() {
+	if ! test -e "$HOME/.local/bin/fish"; then
+		return 0
+	fi
+
+	echo ""
+	echo "To set fish as your default shell, run:"
+	echo "    chsh -s $HOME/.local/bin/fish"
+	echo ""
+}
 
 _macos_post_install() {
-    if ! [ -e "$HOME/.local/bin/fish" ]; then
-        return 0
-    fi
+	if ! test -e "$HOME/.local/bin/fish"; then
+		return 0
+	fi
 
-    echo ""
-    echo "Trying to set fish as the default shell..."
-    echo ""
-    # stop the caching of preferences
-    killall cfprefsd
+	echo ""
+	echo "Trying to set fish as the default shell..."
+	echo ""
+	# stop the caching of preferences
+	killall cfprefsd
 
-    # Set default Terminal.app shell to fish
-    defaults write com.apple.Terminal "Shell" -string "$HOME/.local/bin/fish"
-    echo "To set 'fish' as the default Terminal.app shell:"
-    echo "    Terminal > Preferences > General > Shells open with:"
-    echo "    $HOME/.local/bin/fish"
-    echo ""
+	# Set default Terminal.app shell to fish
+	defaults write com.apple.Terminal "Shell" -string "$HOME/.local/bin/fish"
+	echo "To set 'fish' as the default Terminal.app shell:"
+	echo "    Terminal > Preferences > General > Shells open with:"
+	echo "    $HOME/.local/bin/fish"
+	echo ""
 
-    # Set default iTerm2 shell to fish
-    if [ -e "$HOME/Library/Preferences/com.googlecode.iterm2.plist" ]; then
-        /usr/libexec/PlistBuddy \
-            -c "SET ':New Bookmarks:0:Custom Command' 'Custom Shell'" \
-            "$HOME/Library/Preferences/com.googlecode.iterm2.plist"
-        /usr/libexec/PlistBuddy \
-            -c "SET ':New Bookmarks:0:Command' $HOME/.local/bin/fish" \
-            "$HOME/Library/Preferences/com.googlecode.iterm2.plist"
-        echo "To set 'fish' as the default iTerm2 shell:"
-        echo "    iTerm2 > Preferences > Profiles > General > Command >"
-        echo "    Custom Shell: $HOME/.local/bin/fish"
-        echo ""
-    fi
+	# Set default iTerm2 shell to fish
+	if test -e "$HOME/Library/Preferences/com.googlecode.iterm2.plist"; then
+		/usr/libexec/PlistBuddy \
+			-c "SET ':New Bookmarks:0:Custom Command' 'Custom Shell'" \
+			"$HOME/Library/Preferences/com.googlecode.iterm2.plist"
+		/usr/libexec/PlistBuddy \
+			-c "SET ':New Bookmarks:0:Command' $HOME/.local/bin/fish" \
+			"$HOME/Library/Preferences/com.googlecode.iterm2.plist"
+		echo "To set 'fish' as the default iTerm2 shell:"
+		echo "    iTerm2 > Preferences > Profiles > General > Command >"
+		echo "    Custom Shell: $HOME/.local/bin/fish"
+		echo ""
+	fi
 
-    killall cfprefsd
+	killall cfprefsd
 }
 
 # always try to reset the default shells
-_macos_post_install
+if test "Darwin" = "${my_os}"; then
+	_macos_post_install
+fi
 
 pkg_install() {
-    mv fish.app/Contents/Resources/base/usr/local "$HOME/.local/opt/fish-v${WEBI_VERSION}"
+	if test "Darwin" = "${my_os}"; then
+		rm -rf "/Applications/fish-v${WEBI_VERSION}.app"
+		mv -f fish*.app "/Applications/fish-v${WEBI_VERSION}.app"
+		rm -rf /Applications/fish.app
+		mv "/Applications/fish-v${WEBI_VERSION}.app" "/Applications/fish.app"
+		return 0
+	fi
 
+	mkdir -p "$pkg_src_dir/bin"
+	mv fish "$pkg_src_dir/bin/"
+}
+
+pkg_link() {
+	if test "Darwin" = "${my_os}"; then
+		mkdir -p "$HOME/.local/bin"
+		ln -sf /Applications/fish.app/Contents/Resources/base/usr/local/bin/fish "$HOME/.local/bin/fish"
+		return 0
+	fi
+
+	rm -rf "$pkg_dst_cmd"
+	ln -s "$pkg_src_cmd" "$pkg_dst_cmd"
 }
 
 pkg_post_install() {
-    # don't skip what webi would do automatically
-    webi_post_install
+	# don't skip what webi would do automatically
+	webi_post_install
 
-    # try again to update default shells, now that all files should exist
-    _macos_post_install
-
-    if [ ! -e ~/.config/fish/config.fish ]; then
-        mkdir -p ~/.config/fish
-        touch ~/.config/fish/config.fish
-        chmod 0600 ~/.config/fish/config.fish
-    fi
+	# try again to update default shells, now that all files should exist
+	if test "Darwin" = "${my_os}"; then
+		_macos_post_install
+	else
+		_linux_post_install
+	fi
+	if ! test -e ~/.config/fish/config.fish; then
+		mkdir -p ~/.config/fish
+		touch ~/.config/fish/config.fish
+		chmod 0600 ~/.config/fish/config.fish
+	fi
 }
 
 # pkg_get_current_version is recommended, but (soon) not required
 pkg_get_current_version() {
-    # 'fish --version' has output in this format:
-    #       fish, version 3.1.2
-    # This trims it down to just the version number:
-    #       3.1.2
-    fish --version 2> /dev/null | head -n 1 | cut -d ' ' -f 3
+	# 'fish --version' has output in this format:
+	#       fish, version 4.3.3
+	# This trims it down to just the version number:
+	#       4.3.3
+	fish --version 2> /dev/null | head -n 1 | cut -d ' ' -f 3
 }

--- a/fish/releases.js
+++ b/fish/releases.js
@@ -23,6 +23,23 @@ module.exports = function () {
           rel.arch = 'amd64';
           return rel;
         }
+        
+        // Linux x86_64 binary
+        // e.g. fish-4.3.2-linux-x86_64.tar.xz
+        if (/-linux-x86_64\.tar\.xz$/.test(rel.name)) {
+          rel.os = 'linux';
+          rel.arch = 'amd64';
+          return rel;
+        }
+
+        // Linux aarch64 binary
+        // e.g. fish-4.3.2-linux-aarch64.tar.xz
+        if (/-linux-aarch64\.tar\.xz$/.test(rel.name)) {
+          rel.os = 'linux';
+          rel.arch = 'arm64';
+          return rel;
+        }
+
       })
       .filter(Boolean);
     return all;


### PR DESCRIPTION
## Summary

Adds Linux x86_64 and aarch64 binary support for fish 4.x.

- Removes the Linux guard that previously exited with an \`apt\` suggestion
- **Linux** \`pkg_install\`: extracts bare \`fish\` binary from \`fish-VERSION-linux-ARCH.tar.xz\` into \`~/.local/opt/fish-vVERSION/bin/\`
- **macOS** \`pkg_install\`: moves \`fish*.app\` to \`/Applications/fish.app\` (glob covers v3 \`fish.app\` and v4 \`fish-VERSION.app\`)
- **macOS** \`pkg_link\`: symlinks \`~/.local/bin/fish\` → \`/Applications/fish.app/Contents/Resources/base/usr/local/bin/fish\` (the real shell, not the GUI launcher at \`Contents/MacOS/fish\`)
- OS detected once via \`uname -s\` at top level; no per-function OS guards
- \`pkg_link\` implements linking directly — does not call \`webi_link\` (which calls back into \`pkg_link\`, causing infinite recursion)
- Adds \`_linux_post_install()\` with \`chsh\` instructions
- Drops \`releases.js\` (superseded by \`releases.conf\` + build classifier)
- Replaces \`[\` with \`test\` throughout per POSIX shell conventions

## Test plan

- [x] \`webi fish@stable\` — Linux x86_64 (beta.webi.sh): fish v4.7.1 installs to \`~/.local/bin/fish\`
- [x] \`webi fish@stable\` — macOS arm64: fish v4.7.1 installs to \`~/.local/bin/fish\`, \`fish --version\` works