### PR TITLE
feat: add nextdeploy and nextdeployd

### DIFF
--- a/nextdeploy/README.md
+++ b/nextdeploy/README.md
@@ -1,0 +1,95 @@
+---
+title: NextDeploy
+homepage: https://github.com/aynaash/nextdeploy
+tagline: |
+  Self-hosted Next.js deployment platform
+description: |
+  NextDeploy is an open-source CLI + daemon for deploying and managing Next.js applications on your own infrastructure. No lock-in. No magic. Just Docker, SSH, and full control.
+---
+
+## Cheat Sheet
+
+> NextDeploy gives you Vercel-like deployment experience on your own VPS. Build, ship, and manage Next.js apps with full transparency and zero vendor lock-in.
+
+### Quick Start
+
+```sh
+# Initialize a Next.js project for deployment
+nextdeploy init
+
+# Build production Docker image
+nextdeploy build
+
+# Test locally with production config
+nextdeploy runimage
+
+# Deploy to your VPS
+nextdeploy ship
+
+# Serve with automatic HTTPS
+nextdeploy ship --serve
+```
+
+### Key Features
+
+- **🧱 Builds** Docker images optimized for Next.js
+- **🚀 Ships** to any VPS via SSH (Hetzner, DigitalOcean, AWS)
+- **🔐 Injects secrets** securely with Doppler integration
+- **📊 Streams logs & metrics** from running containers
+- **🧪 Runimage** - test production builds locally with real secrets
+- **🛠️ Daemon support** - health checks, logs, and automation
+
+### Configuration
+
+Create a `nextdeploy.yml` in your project root:
+
+```yaml
+version: "1.0"
+
+app:
+  name: my-app
+  environment: production
+  domain: app.example.com
+  port: 3000
+
+docker:
+  image: username/my-app
+  registry: ghcr.io
+  push: true
+
+deployment:
+  server:
+    host: 192.0.2.123
+    user: deploy
+    ssh_key: ~/.ssh/id_rsa
+```
+
+### Secret Management
+
+NextDeploy is **Doppler-first** for zero `.env` file management:
+
+```sh
+# Secrets are injected at deploy/runtime
+# Fully encrypted + scoped (dev/staging/prod)
+# Update → restart → done
+```
+
+### Files
+
+These are the files / directories that are created and/or modified with this install:
+
+```text
+~/.config/envman/PATH.env
+~/.local/bin/nextdeploy
+~/.local/opt/nextdeploy/
+```
+
+### Philosophy
+
+Other platforms abstract until you lose control. **NextDeploy flips that.**
+
+- You own the pipeline
+- You see every step
+- No black boxes
+- No middleware
+- Just you and your server

--- a/nextdeploy/install.ps1
+++ b/nextdeploy/install.ps1
@@ -1,0 +1,52 @@
+#!/usr/bin/env pwsh
+
+##################
+# Install nextdeploy #
+##################
+
+# Every package should define these variables
+$pkg_cmd_name = "nextdeploy"
+
+$pkg_dst_cmd = "$Env:USERPROFILE\.local\bin\nextdeploy.exe"
+$pkg_dst = "$pkg_dst_cmd"
+
+$pkg_src_cmd = "$Env:USERPROFILE\.local\opt\nextdeploy-v$Env:WEBI_VERSION\bin\nextdeploy.exe"
+$pkg_src_bin = "$Env:USERPROFILE\.local\opt\nextdeploy-v$Env:WEBI_VERSION\bin"
+$pkg_src_dir = "$Env:USERPROFILE\.local\opt\nextdeploy-v$Env:WEBI_VERSION"
+$pkg_src = "$pkg_src_cmd"
+
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+
+# Fetch archive
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi"))
+{
+    New-Item -Path "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | Out-Null
+}
+Write-Host "Downloading nextdeploy v$Env:WEBI_VERSION from $Env:WEBI_PKG_URL to $pkg_download"
+& curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download"
+
+IF (!(Test-Path -Path "$pkg_src_dir"))
+{
+    New-Item -Path "$pkg_src_dir\bin" -ItemType Directory -Force | Out-Null
+}
+
+Write-Host "Installing nextdeploy"
+
+# Move the binary to the versioned directory
+Move-Item -Path "$pkg_download" -Destination "$pkg_src_cmd" -Force
+
+# Create the symlink
+Write-Host "Copying into '$pkg_dst_cmd' from '$pkg_src_cmd'"
+Remove-Item -Path "$pkg_dst_cmd" -Recurse -ErrorAction Ignore | Out-Null
+Copy-Item -Path "$pkg_src_cmd" -Destination "$pkg_dst_cmd" -Recurse
+
+# Add to PATH
+& "$Env:USERPROFILE\.local\bin\pathman.exe" add "$Env:USERPROFILE\.local\bin"
+
+Write-Host ""
+Write-Host "Installed 'nextdeploy' v$Env:WEBI_VERSION as $pkg_dst_cmd"
+Write-Host ""
+Write-Host "Get started:"
+Write-Host "    nextdeploy init       # Initialize your Next.js project"
+Write-Host "    nextdeploy build      # Build Docker image"
+Write-Host "    nextdeploy ship       # Deploy to VPS"

--- a/nextdeploy/install.sh
+++ b/nextdeploy/install.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -e
+set -u
+
+__init_nextdeploy() {
+    # Package-specific variables
+    pkg_cmd_name="nextdeploy"
+    
+    pkg_dst="$HOME/.local/opt/nextdeploy"
+    pkg_dst_cmd="$HOME/.local/bin/nextdeploy"
+    
+    pkg_src="$HOME/.local/opt/nextdeploy-v$WEBI_VERSION"
+    pkg_src_cmd="$HOME/.local/opt/nextdeploy-v$WEBI_VERSION/bin/nextdeploy"
+    
+    # Ex: ~/.local/opt/nextdeploy-v0.1.0/bin
+    pkg_src_bin="$(dirname "$pkg_src_cmd")"
+    # Ex: ~/.local/opt/nextdeploy/bin
+    pkg_dst_bin="$(dirname "$pkg_dst_cmd")"
+}
+
+pkg_get_current_version() {
+    # 'nextdeploy version' has output in this format:
+    #       nextdeploy version 0.1.0
+    # This trims it down to just the version number:
+    #       0.1.0
+    nextdeploy version 2> /dev/null |
+        head -n 1 |
+        cut -d' ' -f3 ||
+        echo "0.0.0"
+}
+
+pkg_install() {
+    # Move the extracted binary to the versioned directory
+    mkdir -p "$(dirname "$pkg_src_cmd")"
+    
+    # The downloaded file will be named like: nextdeploy-linux-amd64
+    # We need to rename it to just 'nextdeploy'
+    mv "$WEBI_TMP"/nextdeploy* "$pkg_src_cmd"
+    chmod a+x "$pkg_src_cmd"
+}
+
+pkg_post_install() {
+    # Create symlink from versioned to current
+    webi_link
+    
+    # Add to PATH
+    webi_path_add "$pkg_dst_bin"
+}
+
+pkg_done_message() {
+    echo "Installed 'nextdeploy' v$WEBI_VERSION as $pkg_dst_cmd"
+    echo ""
+    echo "Get started:"
+    echo "    nextdeploy init       # Initialize your Next.js project"
+    echo "    nextdeploy build      # Build Docker image"
+    echo "    nextdeploy ship       # Deploy to VPS"
+    echo ""
+    echo "For daemon installation (Linux only):"
+    echo "    curl https://webi.sh/nextdeployd | sh"
+}
+
+__init_nextdeploy

--- a/nextdeploy/releases.js
+++ b/nextdeploy/releases.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var github = require('../_common/github.js');
+var owner = 'aynaash';
+var repo = 'nextdeploy';
+
+module.exports = function (request) {
+    return github(request, owner, repo).then(function (all) {
+        // Filter to only include CLI releases (cross-platform)
+        // The releases should have binaries named like:
+        // nextdeploy-linux-amd64, nextdeploy-darwin-arm64, nextdeploy-windows-amd64.exe
+
+        all.releases = all.releases.filter(function (rel) {
+            // Only keep releases that have nextdeploy CLI binaries (not daemon)
+            return rel.download && (
+                rel.download.includes('nextdeploy-') &&
+                !rel.download.includes('nextdeployd-')
+            );
+        });
+
+        return all;
+    });
+};
+
+if (module === require.main) {
+    module.exports(null).then(function (all) {
+        all = require('../_webi/normalize.js')(all);
+        console.info(JSON.stringify(all, null, 2));
+    });
+}

--- a/nextdeployd/README.md
+++ b/nextdeployd/README.md
@@ -1,0 +1,90 @@
+---
+title: NextDeploy Daemon
+homepage: https://github.com/aynaash/nextdeploy
+tagline: |
+  Server-side orchestration daemon for NextDeploy
+description: |
+  The NextDeploy daemon runs on your VPS to handle container orchestration, health monitoring, and deployment automation. Works with the NextDeploy CLI for seamless Next.js deployments.
+---
+
+## Cheat Sheet
+
+> The NextDeploy daemon provides PM2-like process management for your Next.js containers with automatic health checks, restarts, and monitoring.
+
+### Installation (Linux Only)
+
+```sh
+curl https://webi.sh/nextdeployd | sh
+```
+
+### Start the Daemon
+
+```sh
+# Using systemd (recommended)
+sudo systemctl enable nextdeployd
+sudo systemctl start nextdeployd
+
+# Check status
+sudo systemctl status nextdeployd
+```
+
+### Daemon Commands
+
+The daemon responds to CLI commands sent via the NextDeploy CLI:
+
+```sh
+# Pull and deploy a container
+nextdeployd pull --image=myapp:latest
+
+# Switch containers (blue-green deployment)
+nextdeployd switch --current=myapp:v1 --new=myapp:v2
+
+# Setup Caddy reverse proxy
+nextdeployd caddy --setup
+
+# View logs
+journalctl -u nextdeployd -f
+```
+
+### Configuration
+
+The daemon reads from `/etc/nextdeploy/daemon.yml`:
+
+```yaml
+socket_path: /var/run/nextdeploy.sock
+log_dir: /var/log/nextdeploy
+docker_socket: /var/run/docker.sock
+```
+
+### Features
+
+- **🔄 Auto-restart** - PM2-like container monitoring
+- **💚 Health checks** - Automatic failure detection
+- **📊 Metrics** - CPU, memory, disk monitoring
+- **🔐 Secure** - Unix socket + JWT authentication
+- **🚀 Blue-green** - Zero-downtime deployments
+
+### Files
+
+These are the files / directories that are created and/or modified with this install:
+
+```text
+~/.local/bin/nextdeployd
+~/.local/opt/nextdeployd/
+/etc/systemd/system/nextdeployd.service (if using systemd)
+/var/log/nextdeploy/ (logs)
+```
+
+### Requirements
+
+- **Linux only** (systemd recommended)
+- Docker installed and running
+- Port 80/443 available (for Caddy)
+
+### Security
+
+The daemon uses:
+- Unix sockets for local communication
+- JWT tokens for authentication
+- ECDH key exchange for secrets
+- Ed25519 signatures for audit logs

--- a/nextdeployd/install.sh
+++ b/nextdeployd/install.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+set -e
+set -u
+
+__init_nextdeployd() {
+    # Package-specific variables
+    pkg_cmd_name="nextdeployd"
+    
+    pkg_dst="$HOME/.local/opt/nextdeployd"
+    pkg_dst_cmd="$HOME/.local/bin/nextdeployd"
+    
+    pkg_src="$HOME/.local/opt/nextdeployd-v$WEBI_VERSION"
+    pkg_src_cmd="$HOME/.local/opt/nextdeployd-v$WEBI_VERSION/bin/nextdeployd"
+    
+    # Ex: ~/.local/opt/nextdeployd-v0.1.0/bin
+    pkg_src_bin="$(dirname "$pkg_src_cmd")"
+    # Ex: ~/.local/opt/nextdeployd/bin
+    pkg_dst_bin="$(dirname "$pkg_dst_cmd")"
+}
+
+pkg_get_current_version() {
+    # 'nextdeployd version' has output in this format:
+    #       nextdeployd version 0.1.0
+    # This trims it down to just the version number:
+    #       0.1.0
+    nextdeployd version 2> /dev/null |
+        head -n 1 |
+        cut -d' ' -f3 ||
+        echo "0.0.0"
+}
+
+pkg_install() {
+    # Move the extracted binary to the versioned directory
+    mkdir -p "$(dirname "$pkg_src_cmd")"
+    
+    # The downloaded file will be named like: nextdeployd-linux-amd64
+    # We need to rename it to just 'nextdeployd'
+    mv "$WEBI_TMP"/nextdeployd* "$pkg_src_cmd"
+    chmod a+x "$pkg_src_cmd"
+}
+
+pkg_post_install() {
+    # Create symlink from versioned to current
+    webi_link
+    
+    # Add to PATH
+    webi_path_add "$pkg_dst_bin"
+    
+    # Install systemd service if systemd is available
+    if command -v systemctl > /dev/null 2>&1; then
+        install_systemd_service
+    fi
+}
+
+install_systemd_service() {
+    echo ""
+    echo "Setting up systemd service..."
+    
+    # Create systemd service file
+    sudo tee /etc/systemd/system/nextdeployd.service > /dev/null <<EOF
+[Unit]
+Description=NextDeploy Daemon
+Documentation=https://github.com/aynaash/nextdeploy
+After=network.target docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+User=root
+ExecStart=$pkg_dst_cmd
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    
+    # Reload systemd
+    sudo systemctl daemon-reload
+    
+    echo "Systemd service installed. To enable and start:"
+    echo "    sudo systemctl enable nextdeployd"
+    echo "    sudo systemctl start nextdeployd"
+}
+
+pkg_done_message() {
+    echo "Installed 'nextdeployd' v$WEBI_VERSION as $pkg_dst_cmd"
+    echo ""
+    echo "The NextDeploy daemon is now installed."
+    echo ""
+    if command -v systemctl > /dev/null 2>&1; then
+        echo "To start the daemon:"
+        echo "    sudo systemctl enable nextdeployd"
+        echo "    sudo systemctl start nextdeployd"
+        echo ""
+        echo "To check status:"
+        echo "    sudo systemctl status nextdeployd"
+        echo ""
+        echo "To view logs:"
+        echo "    journalctl -u nextdeployd -f"
+    else
+        echo "To start the daemon manually:"
+        echo "    sudo $pkg_dst_cmd"
+    fi
+    echo ""
+    echo "For CLI installation:"
+    echo "    curl https://webi.sh/nextdeploy | sh"
+}
+
+__init_nextdeployd

--- a/nextdeployd/releases.js
+++ b/nextdeployd/releases.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var github = require('../_common/github.js');
+var owner = 'aynaash';
+var repo = 'nextdeploy';
+
+module.exports = function (request) {
+    return github(request, owner, repo).then(function (all) {
+        // Filter to only include daemon releases (Linux only)
+        // The releases should have binaries named like:
+        // nextdeployd-linux-amd64, nextdeployd-linux-arm64
+
+        all.releases = all.releases.filter(function (rel) {
+            // Only keep releases that have Linux daemon binaries
+            return rel.download && (
+                rel.download.includes('nextdeployd-linux') ||
+                rel.download.includes('nextdeployd_linux')
+            );
+        });
+
+        return all;
+    });
+};
+
+if (module === require.main) {
+    module.exports(null).then(function (all) {
+        all = require('../_webi/normalize.js')(all);
+        console.info(JSON.stringify(all, null, 2));
+    });
+}


### PR DESCRIPTION
Adds installers for NextDeploy - a self-hosted Next.js deployment platform.

nextdeploy: CLI for building and deploying (cross-platform)
nextdeployd: Server daemon for orchestration (Linux only)

Repository: https://github.com/aynaash/nextdeploy