### PR TITLE
doc(prettier): Add 'useTabs' to Cheat Sheet

### DIFF
--- a/prettier/README.md
+++ b/prettier/README.md
@@ -47,6 +47,7 @@ necessary!
 {
   "trailingComma": "none",
   "tabWidth": 2,
+  "useTabs": false,
   "singleQuote": true,
   "proseWrap": "always"
 }


### PR DESCRIPTION
Added " 'useTabs': false " to the Cheat Sheet.

This forces prettier to use Spaces, overriding any other configuration defined in the environment.

With reference to #226.