### PR TITLE
feat: Add tlrc package - fast tldr client written in Rust

### DIFF
--- a/tlrc/README.md
+++ b/tlrc/README.md
@@ -1,0 +1,71 @@
+---
+title: tlrc
+homepage: https://github.com/tldr-pages/tlrc
+tagline: |
+  tlrc: A fast tldr client written in Rust.
+---
+
+To update or switch versions, run `webi tlrc@stable` (or `@v1.11`, `@beta`, etc).
+
+### Files
+
+These are the files / directories that are created and/or modified with this
+install:
+
+```text
+~/.config/envman/PATH.env
+~/.local/bin/tlrc
+~/.local/opt/tlrc/
+```
+
+## Cheat Sheet
+
+> `tlrc` is a fast tldr client written in Rust. It provides community-maintained
+> help pages for command-line tools with practical examples instead of lengthy
+> man pages.
+
+To get help for a command:
+
+```sh
+tlrc tar
+```
+
+### List all available pages
+
+To see all available commands:
+
+```sh
+tlrc --list
+```
+
+### Update the cache
+
+To update the local cache of tldr pages:
+
+```sh
+tlrc --update
+```
+
+### Search for commands
+
+To search for commands containing a keyword:
+
+```sh
+tlrc --search "compress"
+```
+
+### Show examples for specific platform
+
+To show examples for a specific platform:
+
+```sh
+tlrc --platform linux tar
+```
+
+### Random page
+
+To display a random page:
+
+```sh
+tlrc --random
+```

--- a/tlrc/README.md
+++ b/tlrc/README.md
@@ -5,7 +5,8 @@ tagline: |
   tlrc: A fast tldr client written in Rust.
 ---
 
-To update or switch versions, run `webi tlrc@stable` (or `@v1.11`, `@beta`, etc).
+To update or switch versions, run `webi tlrc@stable` (or `@v1.11`, `@beta`,
+etc).
 
 ### Files
 

--- a/tlrc/README.md
+++ b/tlrc/README.md
@@ -15,8 +15,8 @@ install:
 
 ```text
 ~/.config/envman/PATH.env
-~/.local/bin/tlrc
-~/.local/opt/tlrc/
+~/.local/bin/tldr
+~/.local/opt/tldr/
 ```
 
 ## Cheat Sheet
@@ -28,7 +28,7 @@ install:
 To get help for a command:
 
 ```sh
-tlrc tar
+tldr tar
 ```
 
 ### List all available pages
@@ -36,7 +36,7 @@ tlrc tar
 To see all available commands:
 
 ```sh
-tlrc --list
+tldr --list
 ```
 
 ### Update the cache
@@ -44,7 +44,7 @@ tlrc --list
 To update the local cache of tldr pages:
 
 ```sh
-tlrc --update
+tldr --update
 ```
 
 ### Search for commands
@@ -52,7 +52,7 @@ tlrc --update
 To search for commands containing a keyword:
 
 ```sh
-tlrc --search "compress"
+tldr --search "compress"
 ```
 
 ### Show examples for specific platform
@@ -60,7 +60,7 @@ tlrc --search "compress"
 To show examples for a specific platform:
 
 ```sh
-tlrc --platform linux tar
+tldr --platform linux tar
 ```
 
 ### Random page
@@ -68,5 +68,5 @@ tlrc --platform linux tar
 To display a random page:
 
 ```sh
-tlrc --random
+tldr --random
 ```

--- a/tlrc/install.sh
+++ b/tlrc/install.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -e
+set -u
+
+__init_tlrc() {
+
+    ###############
+    # Install tlrc #
+    ###############
+
+    # Every package should define these 6 variables
+    pkg_cmd_name="tlrc"
+
+    pkg_dst_cmd="$HOME/.local/bin/tlrc"
+    pkg_dst="$pkg_dst_cmd"
+
+    pkg_src_cmd="$HOME/.local/opt/tlrc-v$WEBI_VERSION/tlrc"
+    pkg_src_dir="$HOME/.local/opt/tlrc-v$WEBI_VERSION"
+    pkg_src="$pkg_src_cmd"
+
+    # pkg_install must be defined by every package
+    pkg_install() {
+        # ~/.local/opt/tlrc-v1.11.1/
+        mkdir -p "$(dirname "${pkg_src_cmd}")"
+
+        # mv ./tlrc ~/.local/opt/tlrc-v1.11.1/tlrc
+        mv ./tlrc "${pkg_src_cmd}"
+    }
+
+    # pkg_get_current_version is recommended, but not required
+    pkg_get_current_version() {
+        # 'tlrc --version' has output in this format:
+        #       tlrc 1.11.1
+        # This trims it down to just the version number:
+        #       1.11.1
+        tlrc --version 2> /dev/null |
+            head -n 1 |
+            cut -d ' ' -f 2
+    }
+
+}
+
+__init_tlrc

--- a/tlrc/install.sh
+++ b/tlrc/install.sh
@@ -9,12 +9,12 @@ __init_tlrc() {
     ###############
 
     # Every package should define these 6 variables
-    pkg_cmd_name="tlrc"
+    pkg_cmd_name="tldr"
 
     pkg_dst_cmd="$HOME/.local/bin/tlrc"
     pkg_dst="$pkg_dst_cmd"
 
-    pkg_src_cmd="$HOME/.local/opt/tlrc-v$WEBI_VERSION/tlrc"
+    pkg_src_cmd="$HOME/.local/opt/tlrc-v$WEBI_VERSION/tldr"
     pkg_src_dir="$HOME/.local/opt/tlrc-v$WEBI_VERSION"
     pkg_src="$pkg_src_cmd"
 
@@ -29,11 +29,11 @@ __init_tlrc() {
 
     # pkg_get_current_version is recommended, but not required
     pkg_get_current_version() {
-        # 'tlrc --version' has output in this format:
+        # 'tldr --version' has output in this format:
         #       tlrc 1.11.1
         # This trims it down to just the version number:
         #       1.11.1
-        tlrc --version 2> /dev/null |
+        tldr --version 2> /dev/null |
             head -n 1 |
             cut -d ' ' -f 2
     }

--- a/tlrc/releases.js
+++ b/tlrc/releases.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var github = require('../_common/github.js');
+var owner = 'tldr-pages';
+var repo = 'tlrc';
+
+module.exports = function () {
+  return github(null, owner, repo).then(function (all) {
+    // tlrc has a clean release structure, no filtering needed
+    return all;
+  });
+};
+
+if (module === require.main) {
+  module.exports().then(function (all) {
+    all = require('../_webi/normalize.js')(all);
+    console.info(JSON.stringify(all, null, 2));
+  });
+}

--- a/tlrc/releases.js
+++ b/tlrc/releases.js
@@ -6,7 +6,15 @@ var repo = 'tlrc';
 
 module.exports = function () {
   return github(null, owner, repo).then(function (all) {
-    // tlrc has a clean release structure, no filtering needed
+    all.releases = all.releases.map(function (rel) {
+      if (/-gnu/.test(rel.name)) {
+        rel.libc = 'gnu';
+      }
+      if (/-musl/.test(rel.name)) {
+        rel.libc = 'musl';
+      }
+      return rel;
+    });
     return all;
   });
 };


### PR DESCRIPTION
Originally authored by @copyleftdev as PR #1016. 


Tagged ```gnu``` and ```musl``` builds of releases in releases.js
The tlrc package still uses ```tldr``` as the command name. Updated the same in install.sh

~~TODO: Update README.md~~

Updated README.md with correct command name. (Ref: https://tldr.sh/tlrc/)