### PR TITLE
feat(opencode): add installer for AI coding assistant

### DIFF
--- a/opencode/README.md
+++ b/opencode/README.md
@@ -2,10 +2,11 @@
 title: opencode
 homepage: https://github.com/anomalyco/opencode
 tagline: |
-  opencode: The open source coding agent.
+  opencode: A terminal-based AI coding agent with multi-provider LLM support.
 ---
 
-To update or switch versions, run `webi opencode@stable` (or `@v1.2`, `@beta`, etc).
+To update or switch versions, run `webi opencode@stable` (or `@v1.2`, `@beta`,
+etc).
 
 ### Files
 
@@ -21,43 +22,34 @@ install:
 
 ## Cheat Sheet
 
-> `opencode` is a terminal-based AI coding assistant. It connects to LLM
-> providers (Anthropic, OpenAI, Google, local models via Ollama) and gives you
-> an interactive TUI for writing, reviewing, and refactoring code — with full
-> tool use, file editing, and shell access.
+> `opencode` is an AI coding agent that runs in the terminal. It connects to LLM
+> providers (Anthropic, OpenAI, Google, or local models via Ollama) and gives
+> you an interactive TUI with full tool use — file editing, shell commands, and
+> codebase navigation.
 
 ### How to Get Started
 
-1. Set an API key for your preferred provider:
+Set an API key and launch in your project directory:
 
-   ```sh
-   export ANTHROPIC_API_KEY="sk-ant-..."
-   # or
-   export OPENAI_API_KEY="sk-..."
-   ```
+```sh
+export ANTHROPIC_API_KEY="sk-ant-..."
+cd ~/your-project
+opencode
+```
 
-2. Launch opencode in your project directory:
-
-   ```sh
-   cd ~/your-project
-   opencode
-   ```
-
-   opencode starts a TUI where you can chat, edit files, run commands, and
-   navigate your codebase — all from the terminal.
+opencode starts a TUI where you can chat, edit files, run commands, and navigate
+your codebase.
 
 ### How to Configure Providers
 
-opencode supports multiple LLM providers simultaneously. Add them to
-`~/.config/opencode/opencode.json`:
+Add providers to `~/.config/opencode/opencode.json`:
 
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
   "provider": {
     "anthropic": {},
-    "openai": {},
-    "google": {}
+    "openai": {}
   },
   "model": {
     "big": "anthropic/claude-sonnet-4-5-20250514",
@@ -66,91 +58,56 @@ opencode supports multiple LLM providers simultaneously. Add them to
 }
 ```
 
-Anthropic and OpenAI providers read from `ANTHROPIC_API_KEY` and
-`OPENAI_API_KEY` environment variables respectively.
+Anthropic reads `ANTHROPIC_API_KEY`, OpenAI reads `OPENAI_API_KEY`.
 
-### How to Use with Local Models (Optional)
+### How to Use Plugins
 
-If you prefer fully local AI coding with no API calls, you can use
-[ollama](../ollama/) (also available via webi):
+opencode supports plugins for extended workflows.
+[oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) adds
+multi-agent orchestration, model routing, and specialized skills — the entire
+plugin system fits in a single config line:
 
-```sh
-# Install ollama separately (optional)
-curl https://webi.sh/ollama | sh
-source ~/.config/envman/PATH.env
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["oh-my-opencode@latest"],
+  "provider": {
+    "anthropic": {}
+  }
+}
 ```
 
-1. Start the `ollama` server and pull a model:
+That's it. One plugin, your providers, done. The plugin handles agent
+definitions, skill loading, and model routing automatically.
 
-   ```sh
-   ollama serve &
-   ollama pull qwen2.5-coder:14b
-   ```
+### How to Use with Local Models
 
-2. Configure opencode to use the local model:
+Install [ollama](../ollama/) (also available via webi), then configure opencode:
 
-   ```json
-   {
-     "$schema": "https://opencode.ai/config.json",
-     "provider": {
-       "ollama": {
-         "models": {
-           "qwen-coder": {
-             "id": "qwen2.5-coder:14b",
-             "name": "Qwen 2.5 Coder 14B"
-           }
-         }
-       }
-     },
-     "model": {
-       "big": "ollama/qwen-coder",
-       "small": "ollama/qwen-coder"
-     }
-   }
-   ```
+```sh
+webi ollama
+ollama serve &
+ollama pull qwen2.5-coder:14b
+```
 
-3. Launch opencode — it will connect to your local Ollama instance:
-
-   ```sh
-   opencode
-   ```
-
-### How to Use Plugins (oh-my-opencode)
-
-opencode supports plugins for multi-agent orchestration, custom tools, and
-extended workflows.
-[oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) is a plugin
-that adds specialized agents, model routing, and skill-based delegation:
-
-1. Install the plugin:
-
-   ```sh
-   cd ~/.config/opencode
-   npm install oh-my-opencode
-   ```
-
-2. Add it to your config:
-
-   ```json
-   {
-     "$schema": "https://opencode.ai/config.json",
-     "plugin": ["oh-my-opencode"]
-   }
-   ```
-
-3. Configure agents in `~/.config/opencode/oh-my-opencode.json`:
-
-   ```json
-   {
-     "agents": {
-       "oracle": {
-         "description": "Read-only high-IQ consultant for architecture",
-         "model": "anthropic/claude-sonnet-4-5-20250514",
-         "tools": ["Read", "Grep", "Glob", "WebFetch"]
-       }
-     }
-   }
-   ```
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "ollama": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "http://127.0.0.1:11434/v1"
+      },
+      "models": {
+        "qwen2.5-coder:14b": {
+          "name": "Qwen 2.5 Coder 14B (local)"
+        }
+      }
+    }
+  }
+}
+```
 
 ### Useful Key Bindings
 

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -1,0 +1,163 @@
+---
+title: opencode
+homepage: https://github.com/anomalyco/opencode
+tagline: |
+  opencode: The open source coding agent.
+---
+
+To update or switch versions, run `webi opencode@stable` (or `@v1.2`, `@beta`, etc).
+
+### Files
+
+These are the files / directories that are created and/or modified with this
+install:
+
+```text
+~/.config/envman/PATH.env
+~/.local/bin/opencode
+~/.local/opt/opencode-VERSION/bin/opencode
+~/.config/opencode/opencode.json
+```
+
+## Cheat Sheet
+
+> `opencode` is a terminal-based AI coding assistant. It connects to LLM
+> providers (Anthropic, OpenAI, Google, local models via Ollama) and gives you
+> an interactive TUI for writing, reviewing, and refactoring code — with full
+> tool use, file editing, and shell access.
+
+### How to Get Started
+
+1. Set an API key for your preferred provider:
+
+   ```sh
+   export ANTHROPIC_API_KEY="sk-ant-..."
+   # or
+   export OPENAI_API_KEY="sk-..."
+   ```
+
+2. Launch opencode in your project directory:
+
+   ```sh
+   cd ~/your-project
+   opencode
+   ```
+
+   opencode starts a TUI where you can chat, edit files, run commands, and
+   navigate your codebase — all from the terminal.
+
+### How to Configure Providers
+
+opencode supports multiple LLM providers simultaneously. Add them to
+`~/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "anthropic": {},
+    "openai": {},
+    "google": {}
+  },
+  "model": {
+    "big": "anthropic/claude-sonnet-4-5-20250514",
+    "small": "anthropic/claude-haiku-4-5-20250514"
+  }
+}
+```
+
+Anthropic and OpenAI providers read from `ANTHROPIC_API_KEY` and
+`OPENAI_API_KEY` environment variables respectively.
+
+### How to Use with Local Models (Optional)
+
+If you prefer fully local AI coding with no API calls, you can use
+[ollama](../ollama/) (also available via webi):
+
+```sh
+# Install ollama separately (optional)
+curl https://webi.sh/ollama | sh
+source ~/.config/envman/PATH.env
+```
+
+1. Start the `ollama` server and pull a model:
+
+   ```sh
+   ollama serve &
+   ollama pull qwen2.5-coder:14b
+   ```
+
+2. Configure opencode to use the local model:
+
+   ```json
+   {
+     "$schema": "https://opencode.ai/config.json",
+     "provider": {
+       "ollama": {
+         "models": {
+           "qwen-coder": {
+             "id": "qwen2.5-coder:14b",
+             "name": "Qwen 2.5 Coder 14B"
+           }
+         }
+       }
+     },
+     "model": {
+       "big": "ollama/qwen-coder",
+       "small": "ollama/qwen-coder"
+     }
+   }
+   ```
+
+3. Launch opencode — it will connect to your local Ollama instance:
+
+   ```sh
+   opencode
+   ```
+
+### How to Use Plugins (oh-my-opencode)
+
+opencode supports plugins for multi-agent orchestration, custom tools, and
+extended workflows.
+[oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) is a plugin
+that adds specialized agents, model routing, and skill-based delegation:
+
+1. Install the plugin:
+
+   ```sh
+   cd ~/.config/opencode
+   npm install oh-my-opencode
+   ```
+
+2. Add it to your config:
+
+   ```json
+   {
+     "$schema": "https://opencode.ai/config.json",
+     "plugin": ["oh-my-opencode"]
+   }
+   ```
+
+3. Configure agents in `~/.config/opencode/oh-my-opencode.json`:
+
+   ```json
+   {
+     "agents": {
+       "oracle": {
+         "description": "Read-only high-IQ consultant for architecture",
+         "model": "anthropic/claude-sonnet-4-5-20250514",
+         "tools": ["Read", "Grep", "Glob", "WebFetch"]
+       }
+     }
+   }
+   ```
+
+### Useful Key Bindings
+
+| Key      | Action                           |
+| -------- | -------------------------------- |
+| `Enter`  | Send message                     |
+| `Ctrl+E` | Open editor for multi-line input |
+| `Ctrl+C` | Cancel current operation         |
+| `Ctrl+L` | Clear screen                     |
+| `/`      | Slash commands                   |

--- a/opencode/SKILL.md
+++ b/opencode/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: opencode
-description: Terminal-based AI coding assistant with multi-provider LLM support, file editing, shell access, and plugin system. Use when the user wants AI pair programming in the terminal.
+description:
+  Terminal-based AI coding agent with multi-provider LLM support, file editing,
+  shell access, and plugin system. Use when the user wants AI pair programming
+  in the terminal.
 homepage: https://github.com/anomalyco/opencode
 ---
 
 # OpenCode
 
-Terminal-based AI coding assistant that connects to multiple LLM providers (Anthropic, OpenAI, Google, local Ollama) with an interactive TUI for writing, reviewing, and refactoring code.
+Terminal-based AI coding agent that connects to multiple LLM providers
+(Anthropic, OpenAI, Google, local Ollama) with an interactive TUI for writing,
+reviewing, and refactoring code.
 
 ## When to Use
 
 - User wants AI pair programming directly in the terminal
-- User needs to switch between multiple LLM providers mid-session
-- User wants full tool use (file editing, shell commands, grep, read)
-- User prefers terminal UIs over web-based interfaces
+- User needs full tool use (file editing, shell commands, grep, read)
 - User wants plugin-based multi-agent orchestration (oh-my-opencode)
 - User wants local-first AI coding with Ollama (no API costs)
 
@@ -26,24 +29,20 @@ source ~/.config/envman/PATH.env
 
 ## Quick Start
 
-1. **Set API key** (Anthropic, OpenAI, or Google):
+1. **Set API key**:
+
    ```sh
    export ANTHROPIC_API_KEY="sk-ant-..."
-   # or
-   export OPENAI_API_KEY="sk-..."
    ```
 
 2. **Launch in project directory**:
+
    ```sh
    cd ~/your-project
    opencode
    ```
 
-3. **Start coding** — opencode gives you a TUI where you can chat, edit files, run commands, and navigate your codebase.
-
 ## Configuration
-
-### Multi-Provider Setup
 
 Edit `~/.config/opencode/opencode.json`:
 
@@ -52,8 +51,7 @@ Edit `~/.config/opencode/opencode.json`:
   "$schema": "https://opencode.ai/config.json",
   "provider": {
     "anthropic": {},
-    "openai": {},
-    "google": {}
+    "openai": {}
   },
   "model": {
     "big": "anthropic/claude-sonnet-4-5-20250514",
@@ -62,207 +60,65 @@ Edit `~/.config/opencode/opencode.json`:
 }
 ```
 
-### Local Models with Ollama (Optional)
+### With oh-my-opencode Plugin
 
-For offline AI coding with no API calls:
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["oh-my-opencode@latest"],
+  "provider": {
+    "anthropic": {}
+  }
+}
+```
+
+### Local Models with Ollama
 
 ```sh
-# Install Ollama separately
-curl https://webi.sh/ollama | sh
-
-# Start server and pull model
+webi ollama
 ollama serve &
 ollama pull qwen2.5-coder:14b
 ```
-
-Configure opencode to use local model:
 
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
   "provider": {
     "ollama": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "http://127.0.0.1:11434/v1"
+      },
       "models": {
-        "qwen-coder": {
-          "id": "qwen2.5-coder:14b",
-          "name": "Qwen 2.5 Coder 14B"
+        "qwen2.5-coder:14b": {
+          "name": "Qwen 2.5 Coder 14B (local)"
         }
       }
     }
-  },
-  "model": {
-    "big": "ollama/qwen-coder",
-    "small": "ollama/qwen-coder"
   }
 }
-```
-
-## Plugin System (oh-my-opencode)
-
-Adds specialized agents, model routing, and skill-based delegation:
-
-```sh
-cd ~/.config/opencode
-npm install oh-my-opencode
-```
-
-Configure agents in `~/.config/opencode/oh-my-opencode.json`:
-
-```json
-{
-  "agents": {
-    "oracle": {
-      "description": "Read-only high-IQ consultant for architecture",
-      "model": "anthropic/claude-sonnet-4-5-20250514",
-      "tools": ["Read", "Grep", "Glob", "WebFetch"]
-    },
-    "reviewer": {
-      "description": "Code review specialist",
-      "model": "anthropic/claude-sonnet-4-5-20250514",
-      "tools": ["Read", "Grep", "Bash"]
-    }
-  }
-}
-```
-
-## Key Features
-
-| Feature | Description |
-|---------|-------------|
-| **Multi-Provider** | Switch between Anthropic, OpenAI, Google, Ollama mid-session |
-| **Full Tool Access** | Read/write files, execute shell commands, search codebase |
-| **Plugin System** | Extend with custom agents and workflows |
-| **Terminal Native** | Runs in any terminal with full keyboard navigation |
-| **Context-Aware** | Maintains conversation context across file edits |
-
-## Common Workflows
-
-### Code Review
-```sh
-opencode
-# In TUI: "Review the changes in src/auth.ts and suggest improvements"
-```
-
-### Implement Feature
-```sh
-opencode
-# In TUI: "Add user authentication with JWT tokens"
-# OpenCode will read files, write code, and execute tests
-```
-
-### Debug Issue
-```sh
-opencode
-# In TUI: "Why is the API returning 500 errors?"
-# OpenCode will read logs, check code, and suggest fixes
-```
-
-### Refactor
-```sh
-opencode
-# In TUI: "Refactor the user service to use async/await instead of promises"
-```
-
-## Integration with Other Tools
-
-### With Ollama (Local Models)
-Requires `ollama` to be running:
-```sh
-ollama serve &  # Keep running in background
-opencode        # Will connect to local Ollama
-```
-
-### With Git
-OpenCode is git-aware and can:
-- Read diffs
-- Suggest commit messages
-- Review changes before commit
-- Create branches
-
-### With Testing Frameworks
-OpenCode can run tests directly:
-```sh
-opencode
-# In TUI: "Run the test suite and fix any failures"
-```
-
-## Files Created
-
-```text
-~/.config/envman/PATH.env           # PATH configuration
-~/.local/bin/opencode               # Symlink to versioned binary
-~/.local/opt/opencode-VERSION/      # Installed binary
-~/.config/opencode/opencode.json    # Configuration
-~/.config/opencode/oh-my-opencode.json  # Plugin config (if installed)
 ```
 
 ## Key Bindings
 
-| Key | Action |
-|-----|--------|
-| `Enter` | Send message |
+| Key      | Action                           |
+| -------- | -------------------------------- |
+| `Enter`  | Send message                     |
 | `Ctrl+E` | Open editor for multi-line input |
-| `Ctrl+C` | Cancel current operation |
-| `Ctrl+L` | Clear screen |
-| `/` | Slash commands |
+| `Ctrl+C` | Cancel current operation         |
+| `Ctrl+L` | Clear screen                     |
+| `/`      | Slash commands                   |
 
-## Comparison with Alternatives
+## Files Created
 
-| Tool | OpenCode | Cursor | GitHub Copilot |
-|------|----------|--------|----------------|
-| **Interface** | Terminal TUI | VS Code fork | IDE extension |
-| **Providers** | Multi (Anthropic, OpenAI, Google, Ollama) | OpenAI only | GitHub's models |
-| **Local Models** | ✅ Via Ollama | ❌ | ❌ |
-| **Plugins** | ✅ oh-my-opencode | Limited | Limited |
-| **Shell Access** | ✅ Full | ✅ Terminal | ❌ |
-| **Offline** | ✅ With Ollama | ❌ | ❌ |
-
-## Best Practices
-
-1. **Start with cloud LLMs** — Test with Anthropic/OpenAI before switching to local models
-2. **Use plugins for complex workflows** — oh-my-opencode adds multi-agent coordination
-3. **Configure model tiers** — Use "big" model for complex tasks, "small" for quick edits
-4. **Keep Ollama running** — If using local models, keep `ollama serve` in background
-5. **Git integration** — Run opencode from git repo root for best context awareness
-
-## Troubleshooting
-
-**OpenCode won't start:**
-```sh
-# Check if binary is in PATH
-which opencode
-
-# Verify configuration
-cat ~/.config/opencode/opencode.json
+```text
+~/.config/envman/PATH.env
+~/.local/bin/opencode
+~/.local/opt/opencode-VERSION/bin/opencode
+~/.config/opencode/opencode.json
 ```
-
-**API key not working:**
-```sh
-# Verify environment variable is set
-echo $ANTHROPIC_API_KEY
-
-# Make sure to export, not just set
-export ANTHROPIC_API_KEY="sk-ant-..."
-```
-
-**Ollama connection failed:**
-```sh
-# Check if Ollama is running
-curl http://localhost:11434/api/version
-
-# Start Ollama if needed
-ollama serve &
-```
-
-## Resources
-
-- GitHub: https://github.com/anomalyco/opencode
-- Plugin System: https://github.com/code-yeongyu/oh-my-opencode
-- Model Options: https://opencode.ai/models
-- Configuration Schema: https://opencode.ai/config.json
 
 ## Related Webi Installers
 
 - `ollama` — Local LLM server for offline AI coding
 - `node` — Required for installing plugins (oh-my-opencode)
-- `git` — Version control integration

--- a/opencode/SKILL.md
+++ b/opencode/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: opencode
+description: Terminal-based AI coding assistant with multi-provider LLM support, file editing, shell access, and plugin system. Use when the user wants AI pair programming in the terminal.
+homepage: https://github.com/anomalyco/opencode
+---
+
+# OpenCode
+
+Terminal-based AI coding assistant that connects to multiple LLM providers (Anthropic, OpenAI, Google, local Ollama) with an interactive TUI for writing, reviewing, and refactoring code.
+
+## When to Use
+
+- User wants AI pair programming directly in the terminal
+- User needs to switch between multiple LLM providers mid-session
+- User wants full tool use (file editing, shell commands, grep, read)
+- User prefers terminal UIs over web-based interfaces
+- User wants plugin-based multi-agent orchestration (oh-my-opencode)
+- User wants local-first AI coding with Ollama (no API costs)
+
+## Installation
+
+```sh
+curl https://webi.sh/opencode | sh
+source ~/.config/envman/PATH.env
+```
+
+## Quick Start
+
+1. **Set API key** (Anthropic, OpenAI, or Google):
+   ```sh
+   export ANTHROPIC_API_KEY="sk-ant-..."
+   # or
+   export OPENAI_API_KEY="sk-..."
+   ```
+
+2. **Launch in project directory**:
+   ```sh
+   cd ~/your-project
+   opencode
+   ```
+
+3. **Start coding** — opencode gives you a TUI where you can chat, edit files, run commands, and navigate your codebase.
+
+## Configuration
+
+### Multi-Provider Setup
+
+Edit `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "anthropic": {},
+    "openai": {},
+    "google": {}
+  },
+  "model": {
+    "big": "anthropic/claude-sonnet-4-5-20250514",
+    "small": "anthropic/claude-haiku-4-5-20250514"
+  }
+}
+```
+
+### Local Models with Ollama (Optional)
+
+For offline AI coding with no API calls:
+
+```sh
+# Install Ollama separately
+curl https://webi.sh/ollama | sh
+
+# Start server and pull model
+ollama serve &
+ollama pull qwen2.5-coder:14b
+```
+
+Configure opencode to use local model:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "ollama": {
+      "models": {
+        "qwen-coder": {
+          "id": "qwen2.5-coder:14b",
+          "name": "Qwen 2.5 Coder 14B"
+        }
+      }
+    }
+  },
+  "model": {
+    "big": "ollama/qwen-coder",
+    "small": "ollama/qwen-coder"
+  }
+}
+```
+
+## Plugin System (oh-my-opencode)
+
+Adds specialized agents, model routing, and skill-based delegation:
+
+```sh
+cd ~/.config/opencode
+npm install oh-my-opencode
+```
+
+Configure agents in `~/.config/opencode/oh-my-opencode.json`:
+
+```json
+{
+  "agents": {
+    "oracle": {
+      "description": "Read-only high-IQ consultant for architecture",
+      "model": "anthropic/claude-sonnet-4-5-20250514",
+      "tools": ["Read", "Grep", "Glob", "WebFetch"]
+    },
+    "reviewer": {
+      "description": "Code review specialist",
+      "model": "anthropic/claude-sonnet-4-5-20250514",
+      "tools": ["Read", "Grep", "Bash"]
+    }
+  }
+}
+```
+
+## Key Features
+
+| Feature | Description |
+|---------|-------------|
+| **Multi-Provider** | Switch between Anthropic, OpenAI, Google, Ollama mid-session |
+| **Full Tool Access** | Read/write files, execute shell commands, search codebase |
+| **Plugin System** | Extend with custom agents and workflows |
+| **Terminal Native** | Runs in any terminal with full keyboard navigation |
+| **Context-Aware** | Maintains conversation context across file edits |
+
+## Common Workflows
+
+### Code Review
+```sh
+opencode
+# In TUI: "Review the changes in src/auth.ts and suggest improvements"
+```
+
+### Implement Feature
+```sh
+opencode
+# In TUI: "Add user authentication with JWT tokens"
+# OpenCode will read files, write code, and execute tests
+```
+
+### Debug Issue
+```sh
+opencode
+# In TUI: "Why is the API returning 500 errors?"
+# OpenCode will read logs, check code, and suggest fixes
+```
+
+### Refactor
+```sh
+opencode
+# In TUI: "Refactor the user service to use async/await instead of promises"
+```
+
+## Integration with Other Tools
+
+### With Ollama (Local Models)
+Requires `ollama` to be running:
+```sh
+ollama serve &  # Keep running in background
+opencode        # Will connect to local Ollama
+```
+
+### With Git
+OpenCode is git-aware and can:
+- Read diffs
+- Suggest commit messages
+- Review changes before commit
+- Create branches
+
+### With Testing Frameworks
+OpenCode can run tests directly:
+```sh
+opencode
+# In TUI: "Run the test suite and fix any failures"
+```
+
+## Files Created
+
+```text
+~/.config/envman/PATH.env           # PATH configuration
+~/.local/bin/opencode               # Symlink to versioned binary
+~/.local/opt/opencode-VERSION/      # Installed binary
+~/.config/opencode/opencode.json    # Configuration
+~/.config/opencode/oh-my-opencode.json  # Plugin config (if installed)
+```
+
+## Key Bindings
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Send message |
+| `Ctrl+E` | Open editor for multi-line input |
+| `Ctrl+C` | Cancel current operation |
+| `Ctrl+L` | Clear screen |
+| `/` | Slash commands |
+
+## Comparison with Alternatives
+
+| Tool | OpenCode | Cursor | GitHub Copilot |
+|------|----------|--------|----------------|
+| **Interface** | Terminal TUI | VS Code fork | IDE extension |
+| **Providers** | Multi (Anthropic, OpenAI, Google, Ollama) | OpenAI only | GitHub's models |
+| **Local Models** | ✅ Via Ollama | ❌ | ❌ |
+| **Plugins** | ✅ oh-my-opencode | Limited | Limited |
+| **Shell Access** | ✅ Full | ✅ Terminal | ❌ |
+| **Offline** | ✅ With Ollama | ❌ | ❌ |
+
+## Best Practices
+
+1. **Start with cloud LLMs** — Test with Anthropic/OpenAI before switching to local models
+2. **Use plugins for complex workflows** — oh-my-opencode adds multi-agent coordination
+3. **Configure model tiers** — Use "big" model for complex tasks, "small" for quick edits
+4. **Keep Ollama running** — If using local models, keep `ollama serve` in background
+5. **Git integration** — Run opencode from git repo root for best context awareness
+
+## Troubleshooting
+
+**OpenCode won't start:**
+```sh
+# Check if binary is in PATH
+which opencode
+
+# Verify configuration
+cat ~/.config/opencode/opencode.json
+```
+
+**API key not working:**
+```sh
+# Verify environment variable is set
+echo $ANTHROPIC_API_KEY
+
+# Make sure to export, not just set
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+**Ollama connection failed:**
+```sh
+# Check if Ollama is running
+curl http://localhost:11434/api/version
+
+# Start Ollama if needed
+ollama serve &
+```
+
+## Resources
+
+- GitHub: https://github.com/anomalyco/opencode
+- Plugin System: https://github.com/code-yeongyu/oh-my-opencode
+- Model Options: https://opencode.ai/models
+- Configuration Schema: https://opencode.ai/config.json
+
+## Related Webi Installers
+
+- `ollama` — Local LLM server for offline AI coding
+- `node` — Required for installing plugins (oh-my-opencode)
+- `git` — Version control integration

--- a/opencode/install.ps1
+++ b/opencode/install.ps1
@@ -1,8 +1,8 @@
 #!/usr/bin/env pwsh
 
-##################
+####################
 # Install opencode #
-##################
+####################
 
 # Every package should define these variables
 $pkg_cmd_name = "opencode"
@@ -19,31 +19,30 @@ New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | Out-Null
 $pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
 
 # Fetch archive
-IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
+if (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
     Write-Output "Downloading opencode from $Env:WEBI_PKG_URL to $pkg_download"
     & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
     & Move-Item "$pkg_download.part" "$pkg_download"
 }
 
-IF (!(Test-Path -Path "$pkg_src_cmd")) {
+if (!(Test-Path -Path "$pkg_src_cmd")) {
     Write-Output "Installing opencode"
 
-    # TODO: create package-specific temp directory
     # Enter tmp
     Push-Location .local\tmp
 
-        # Remove any leftover tmp cruft
-        Remove-Item -Path ".\opencode-v*" -Recurse -ErrorAction Ignore
-        Remove-Item -Path ".\opencode.exe" -Recurse -ErrorAction Ignore
+    # Remove any leftover tmp cruft
+    Remove-Item -Path ".\opencode-v*" -Recurse -ErrorAction Ignore
+    Remove-Item -Path ".\opencode.exe" -Recurse -ErrorAction Ignore
 
-        # Extract to opencode-v$Env:WEBI_VERSION
-        Write-Output "Unpacking $pkg_download"
-        & tar xf "$pkg_download"
+    # Unpack archive
+    Write-Output "Unpacking $pkg_download"
+    & tar xf "$pkg_download"
 
-        # Move into place
-        Write-Output "Install Location: $pkg_src_cmd"
-        New-Item "$pkg_src_bin" -ItemType Directory -Force | Out-Null
-        Move-Item -Path ".\opencode.exe" -Destination "$pkg_src_bin"
+    # Move single binary into place
+    Write-Output "Install Location: $pkg_src_cmd"
+    New-Item "$pkg_src_bin" -ItemType Directory -Force | Out-Null
+    Move-Item -Path ".\opencode.exe" -Destination "$pkg_src_bin"
 
     # Exit tmp
     Pop-Location

--- a/opencode/install.ps1
+++ b/opencode/install.ps1
@@ -1,0 +1,54 @@
+#!/usr/bin/env pwsh
+
+##################
+# Install opencode #
+##################
+
+# Every package should define these variables
+$pkg_cmd_name = "opencode"
+
+$pkg_dst_cmd = "$Env:USERPROFILE\.local\bin\opencode.exe"
+$pkg_dst = "$pkg_dst_cmd"
+
+$pkg_src_cmd = "$Env:USERPROFILE\.local\opt\opencode-v$Env:WEBI_VERSION\bin\opencode.exe"
+$pkg_src_bin = "$Env:USERPROFILE\.local\opt\opencode-v$Env:WEBI_VERSION\bin"
+$pkg_src_dir = "$Env:USERPROFILE\.local\opt\opencode-v$Env:WEBI_VERSION"
+$pkg_src = "$pkg_src_cmd"
+
+New-Item "$Env:USERPROFILE\Downloads\webi" -ItemType Directory -Force | Out-Null
+$pkg_download = "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
+
+# Fetch archive
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE")) {
+    Write-Output "Downloading opencode from $Env:WEBI_PKG_URL to $pkg_download"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
+    & Move-Item "$pkg_download.part" "$pkg_download"
+}
+
+IF (!(Test-Path -Path "$pkg_src_cmd")) {
+    Write-Output "Installing opencode"
+
+    # TODO: create package-specific temp directory
+    # Enter tmp
+    Push-Location .local\tmp
+
+        # Remove any leftover tmp cruft
+        Remove-Item -Path ".\opencode-v*" -Recurse -ErrorAction Ignore
+        Remove-Item -Path ".\opencode.exe" -Recurse -ErrorAction Ignore
+
+        # Extract to opencode-v$Env:WEBI_VERSION
+        Write-Output "Unpacking $pkg_download"
+        & tar xf "$pkg_download"
+
+        # Move into place
+        Write-Output "Install Location: $pkg_src_cmd"
+        New-Item "$pkg_src_bin" -ItemType Directory -Force | Out-Null
+        Move-Item -Path ".\opencode.exe" -Destination "$pkg_src_bin"
+
+    # Exit tmp
+    Pop-Location
+}
+
+Write-Output "Copying into '$pkg_dst_cmd' from '$pkg_src_cmd'"
+Remove-Item -Path "$pkg_dst_cmd" -Recurse -ErrorAction Ignore | Out-Null
+Copy-Item -Path "$pkg_src" -Destination "$pkg_dst" -Recurse

--- a/opencode/install.sh
+++ b/opencode/install.sh
@@ -6,33 +6,33 @@ set -u
 
 __init_opencode() {
 
-	####################
-	# Install opencode #
-	####################
+    ####################
+    # Install opencode #
+    ####################
 
-	pkg_cmd_name="opencode"
+    pkg_cmd_name="opencode"
 
-	pkg_dst_cmd="$HOME/.local/bin/opencode"
-	pkg_dst="$pkg_dst_cmd"
+    pkg_dst_cmd="$HOME/.local/bin/opencode"
+    pkg_dst="$pkg_dst_cmd"
 
-	pkg_src_cmd="$HOME/.local/opt/opencode-v$WEBI_VERSION/bin/opencode"
-	pkg_src_dir="$HOME/.local/opt/opencode-v$WEBI_VERSION"
-	pkg_src="$pkg_src_cmd"
+    pkg_src_cmd="$HOME/.local/opt/opencode-v$WEBI_VERSION/bin/opencode"
+    pkg_src_dir="$HOME/.local/opt/opencode-v$WEBI_VERSION"
+    pkg_src="$pkg_src_cmd"
 
-	pkg_install() {
-		# ~/.local/opt/opencode-v1.2.27/bin/
-		mkdir -p "$(dirname "$pkg_src_cmd")"
+    pkg_install() {
+        # ~/.local/opt/opencode-v1.2.27/bin/
+        mkdir -p "$(dirname "$pkg_src_cmd")"
 
-		# mv ./opencode ~/.local/opt/opencode-v1.2.27/bin/opencode
-		mv ./opencode "$pkg_src_cmd"
-	}
+        # mv ./opencode ~/.local/opt/opencode-v1.2.27/bin/opencode
+        mv ./opencode "$pkg_src_cmd"
+    }
 
-	pkg_get_current_version() {
-		# 'opencode --version' outputs version number
-		opencode --version 2>/dev/null |
-			head -n 1 |
-			cut -d' ' -f1
-	}
+    pkg_get_current_version() {
+        # 'opencode --version' outputs just the version number:
+        #       1.2.27
+        opencode --version 2> /dev/null |
+            head -n 1
+    }
 
 }
 

--- a/opencode/install.sh
+++ b/opencode/install.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# shellcheck disable=SC2034
+
+set -e
+set -u
+
+__init_opencode() {
+
+	####################
+	# Install opencode #
+	####################
+
+	pkg_cmd_name="opencode"
+
+	pkg_dst_cmd="$HOME/.local/bin/opencode"
+	pkg_dst="$pkg_dst_cmd"
+
+	pkg_src_cmd="$HOME/.local/opt/opencode-v$WEBI_VERSION/bin/opencode"
+	pkg_src_dir="$HOME/.local/opt/opencode-v$WEBI_VERSION"
+	pkg_src="$pkg_src_cmd"
+
+	pkg_install() {
+		# ~/.local/opt/opencode-v1.2.27/bin/
+		mkdir -p "$(dirname "$pkg_src_cmd")"
+
+		# mv ./opencode ~/.local/opt/opencode-v1.2.27/bin/opencode
+		mv ./opencode "$pkg_src_cmd"
+	}
+
+	pkg_get_current_version() {
+		# 'opencode --version' outputs version number
+		opencode --version 2>/dev/null |
+			head -n 1 |
+			cut -d' ' -f1
+	}
+
+}
+
+__init_opencode

--- a/opencode/install.sh
+++ b/opencode/install.sh
@@ -25,6 +25,7 @@ __init_opencode() {
 
         # mv ./opencode ~/.local/opt/opencode-v1.2.27/bin/opencode
         mv ./opencode "$pkg_src_cmd"
+        chmod a+x "$pkg_src_cmd"
     }
 
     pkg_get_current_version() {

--- a/opencode/releases.js
+++ b/opencode/releases.js
@@ -12,13 +12,15 @@ Releases.latest = async function () {
   // Keep only CLI binaries: opencode-{os}-{arch}.{tar.gz|zip}
   // Exclude: desktop/electron apps, baseline builds, .yml/.yaml manifests,
   //          .json metadata, .dmg/.deb/.rpm packages, .sig signatures
-  // Include: musl builds (webi handles both gnu and musl)
+  // Exclude musl builds: the normalizer maps both musl and gnu to the same
+  // os/arch key, causing duplicates. Prefer gnu (glibc) as the default.
   all.releases = all.releases.filter(function (rel) {
     let name = rel.name;
     return (
       name.match(/^opencode-(darwin|linux|windows)-/) &&
       !name.includes('desktop') &&
       !name.includes('baseline') &&
+      !name.includes('-musl') &&
       (name.endsWith('.tar.gz') || name.endsWith('.zip'))
     );
   });

--- a/opencode/releases.js
+++ b/opencode/releases.js
@@ -9,28 +9,18 @@ let Releases = module.exports;
 Releases.latest = async function () {
   let all = await github(null, owner, repo);
 
-  // Filter to CLI-only releases (exclude desktop, electron, baseline, musl variants)
+  // Keep only CLI binaries: opencode-{os}-{arch}.{tar.gz|zip}
+  // Exclude: desktop/electron apps, baseline builds, .yml/.yaml manifests,
+  //          .json metadata, .dmg/.deb/.rpm packages, .sig signatures
+  // Include: musl builds (webi handles both gnu and musl)
   all.releases = all.releases.filter(function (rel) {
-    return rel.version && !rel.version.includes('nightly');
-  });
-
-  all.releases.forEach(function (rel) {
-    // Filter assets to CLI binaries only
-    rel.assets = (rel.assets || []).filter(function (asset) {
-      let name = asset.name;
-      // Keep only CLI binaries: opencode-{os}-{arch}.{tar.gz|zip}
-      // Exclude: desktop, electron, baseline, .yml manifests, auto-update files, packages
-      // Include: musl builds (webi handles both gnu and musl)
-      return (
-        name.match(/^opencode-(darwin|linux|windows)-/) &&
-        !name.includes('desktop') &&
-        !name.includes('electron') &&
-        !name.includes('baseline') &&
-        !name.endsWith('.yml') &&
-        !name.endsWith('.yaml') &&
-        (name.endsWith('.tar.gz') || name.endsWith('.zip'))
-      );
-    });
+    let name = rel.name;
+    return (
+      name.match(/^opencode-(darwin|linux|windows)-/) &&
+      !name.includes('desktop') &&
+      !name.includes('baseline') &&
+      (name.endsWith('.tar.gz') || name.endsWith('.zip'))
+    );
   });
 
   return all;

--- a/opencode/releases.js
+++ b/opencode/releases.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var github = require('../_common/github.js');
+var owner = 'anomalyco';
+var repo = 'opencode';
+
+let Releases = module.exports;
+
+Releases.latest = async function () {
+  let all = await github(null, owner, repo);
+
+  // Filter to CLI-only releases (exclude desktop, electron, baseline, musl variants)
+  all.releases = all.releases.filter(function (rel) {
+    return rel.version && !rel.version.includes('nightly');
+  });
+
+  all.releases.forEach(function (rel) {
+    // Filter assets to CLI binaries only
+    rel.assets = (rel.assets || []).filter(function (asset) {
+      let name = asset.name;
+      // Keep only CLI binaries: opencode-{os}-{arch}.{tar.gz|zip}
+      // Exclude: desktop, electron, baseline, musl, auto-update manifests, packages
+      return (
+        name.match(/^opencode-(darwin|linux|windows)-/) &&
+        !name.includes('desktop') &&
+        !name.includes('electron') &&
+        !name.includes('baseline') &&
+        !name.includes('musl') &&
+        (name.endsWith('.tar.gz') || name.endsWith('.zip'))
+      );
+    });
+  });
+
+  return all;
+};
+
+Releases.sample = async function () {
+  let normalize = require('../_webi/normalize.js');
+  let all = await Releases.latest();
+  all = normalize(all);
+  all.releases = all.releases.slice(0, 10);
+  return all;
+};
+
+if (module === require.main) {
+  (async function () {
+    let samples = await Releases.sample();
+    console.info(JSON.stringify(samples, null, 2));
+  })();
+}

--- a/opencode/releases.js
+++ b/opencode/releases.js
@@ -19,13 +19,15 @@ Releases.latest = async function () {
     rel.assets = (rel.assets || []).filter(function (asset) {
       let name = asset.name;
       // Keep only CLI binaries: opencode-{os}-{arch}.{tar.gz|zip}
-      // Exclude: desktop, electron, baseline, musl, auto-update manifests, packages
+      // Exclude: desktop, electron, baseline, .yml manifests, auto-update files, packages
+      // Include: musl builds (webi handles both gnu and musl)
       return (
         name.match(/^opencode-(darwin|linux|windows)-/) &&
         !name.includes('desktop') &&
         !name.includes('electron') &&
         !name.includes('baseline') &&
-        !name.includes('musl') &&
+        !name.endsWith('.yml') &&
+        !name.endsWith('.yaml') &&
         (name.endsWith('.tar.gz') || name.endsWith('.zip'))
       );
     });

--- a/test/install.sh
+++ b/test/install.sh
@@ -55,6 +55,7 @@ __rmrf_local() {
                 nerd-font \
                 nerdfont \
                 node \
+                opencode \
                 ots \
                 pandoc \
                 pathman \
@@ -151,6 +152,7 @@ __rmrf_local() {
                 nerd-font \
                 nerdfont \
                 node \
+                opencode \
                 ots \
                 pandoc \
                 pathman \


### PR DESCRIPTION
## Summary
Add installer for **opencode** - an open-source AI coding assistant with terminal UI.

This PR addresses feedback from #1062 (which was closed) by:
- Using **anomalyco/opencode** (124K stars, actively maintained) as the homepage
- Pointing to the **active fork** instead of archived opencode-ai/opencode repository
- Submitting opencode and crush as **separate PRs** as requested

## Changes
- ✅ `opencode/releases.js` - fetches from **anomalyco/opencode**, filters CLI-only binaries
- ✅ `opencode/install.sh` - POSIX shell installer (bare binary pattern)
- ✅ `opencode/install.ps1` - Windows PowerShell support
- ✅ `opencode/README.md` - comprehensive cheat sheet with **transparent Ollama integration** (clearly marked as optional)

## Testing
- ✅ `node opencode/releases.js` - returns filtered CLI binaries
- ✅ `shellcheck opencode/install.sh` - passes
- ✅ `shfmt` formatting - compliant

## Related
- Closes #1062 (opencode portion)
- Related to webinstall/webi-installer-requests#489
- Maintainer feedback: @David-Bosnic

## Key Features
- Multi-provider LLM support (Anthropic, OpenAI, Google, local Ollama)
- Terminal-based TUI with file editing and shell access
- Plugin system (oh-my-opencode) for multi-agent workflows
- Optional local model support via Ollama (clearly documented)