### PR TITLE
fix(builds-cacher): coalesce concurrent getPackages for same name

### DIFF
--- a/_webi/builds-cacher.js
+++ b/_webi/builds-cacher.js
@@ -198,6 +198,9 @@ BuildsCacher.create = function ({ ALL_TERMS, installers, caches }) {
   bc._staleAge = 15 * 60 * 1000;
   bc._allFormats = {};
   bc._allTriplets = {};
+  // Per-name lock: serializes cold-cache getPackages so concurrent
+  // callers can't corrupt bc._caches[name] via a transformAndUpdate race.
+  bc._inflight = {};
 
   for (let term of TERMS_META) {
     delete bc.orphanTerms[term];
@@ -317,7 +320,24 @@ BuildsCacher.create = function ({ ALL_TERMS, installers, caches }) {
 
   // Typically a package is organized by release (ex: go has 1.20, 1.21, etc),
   // but we will organize by the build (ex: go1.20-darwin-arm64.tar.gz, etc).
-  bc.getPackages = async function ({ Releases, name, date }) {
+  bc.getPackages = async function (args) {
+    let name = args.name;
+    let warm = bc._caches[name];
+    if (warm) {
+      return _doGetPackages(args);
+    }
+    let inflight = bc._inflight[name];
+    if (inflight) {
+      return inflight;
+    }
+    let p = _doGetPackages(args).finally(function () {
+      delete bc._inflight[name];
+    });
+    bc._inflight[name] = p;
+    return p;
+  };
+
+  async function _doGetPackages({ Releases, name, date }) {
     if (!date) {
       date = new Date();
     }
@@ -410,7 +430,7 @@ BuildsCacher.create = function ({ ALL_TERMS, installers, caches }) {
     });
 
     return projInfo;
-  };
+  }
 
   // Makes sure that packages are updated once an hour, on average
   bc._staleNames = [];


### PR DESCRIPTION
## Summary

Fixes a race condition in `_webi/builds-cacher.js` `bc.getPackages` where two concurrent HTTP requests for the same package on a cold in-memory cache could permanently poison `bc._caches[name]`. Affects the `/api/installers/{pkg}` route via `_webi/serve-installer.js` line 121.

## Symptom

After the first concurrent burst of requests for a given package, subsequent requests for that package return `WEBI_VERSION='0.0.0'`, `WEBI_EXT='err'`, and the error placeholder URL. The package stays broken until the server is restarted (or `bc._caches[name]` is cleared by some other path).

## Root cause

`bc.getPackages` does:

1. `let projInfo = bc._caches[name];` — undefined on cold.
2. Initialize `meta` from `projInfo?.oses || []` etc. — empty arrays on cold.
3. `await Fs.readFile(dataFile)` and `JSON.parse` — each concurrent caller gets its own `projInfo` with the file's top-level `oses`/`arches`/`libcs`/`formats` populated.
4. `transformAndUpdate(name, projInfo, meta, ...)` runs `Object.assign(projInfo, { name, updated }, meta)`, which OVERWRITES `projInfo.oses` with `meta.oses` (= `[]`).
5. The classifier loop is supposed to rebuild those tracking arrays. The first call's `_classify` runs the full path and populates `bc._targetsByBuildIdCache`. The second call's `_classify` for the same buildId hits the cache shortcut and **returns early, skipping the projInfo.oses/arches/libcs/formats accumulation block.**
6. The second call's `projInfo` ends up with empty tracking arrays, and since both calls finish with `bc._caches[name] = latestProjInfo`, whichever finishes last wins. If it's the second one, the cache is poisoned.

`serve-installer.js` then checks `projInfo.oses.includes(hostTarget.os)` and returns the error placeholder.

## Fix

A per-name in-flight `Promise` map (`bc._inflight`). Concurrent cold-cache callers for the same name share a single load. Warm-cache callers take the fast path with no synchronization. The fix is local to `bc.getPackages` — no changes to `_classify`, `transformAndUpdate`, or any caller.

## Test plan / what was verified

Verified locally on this PR branch (off `origin/main`, with `_webi/build-classifier` submodule init'd):

- [x] **`npm test` passes** on the patched branch (renders `install-node.sh` and `install-node.ps1` end-to-end via `_webi/test.js`).
- [x] **Race repro before/after** (script: `_webi/test-race-repro.js` — added inline below). Promise.all of 6 cold-cache `serveInstaller` calls for `go` with different UAs:
  - Unpatched `origin/main`: **1/6 succeeded** (5 returned `0.0.0/err`).
  - Patched (this PR): **6/6 succeeded** (all returned `1.26.2/tar.gz` or `/zip`).
- [x] **No regression on warm-path**: subsequent calls for the same package take the fast path (no `_inflight` lookup, no extra await).

```js
// _webi/test-race-repro.js
'use strict';
let Server = require('./serve-installer.js');
async function resolve(label, ua) {
  let s = await Server.serveInstaller('https://test', ua, 'go', 'stable', 'sh',
    ['tar', 'exe', 'zip', 'xz', 'dmg'], '');
  let v = (s.match(/^WEBI_VERSION='([^']*)'/m) || [])[1];
  let e = (s.match(/^WEBI_EXT='([^']*)'/m) || [])[1];
  return `${label}: ${v}/${e}`;
}
(async () => {
  console.log = function () {};
  let r = await Promise.all([
    resolve('a', 'aarch64/unknown Darwin/24.2.0 libc'),
    resolve('b', 'x86_64/unknown Linux/5.15.0 libc'),
    resolve('c', 'x86_64/unknown Windows/10.0.19041 msvc'),
    resolve('d', 'aarch64/unknown Linux/5.15.0 libc'),
    resolve('e', 'x86_64/unknown Linux/5.15.0 musl'),
    resolve('f', 'x86_64/unknown Darwin/23.0.0 libc'),
  ]);
  for (let line of r) console.error(line);
})();
```

Additional validation on a sibling cache-only branch where the fix was originally developed: HTTP fleet-diff against staging at concurrency=12 dropped installer cand-only-errors from 24-229 (cause-dependent) to **0**. Same code change, same fix.

## Suggested reviewer checks

- [ ] Run `_webi/test-race-repro.js` against unpatched main (expect ~1/6) then this PR (expect 6/6).
- [ ] Hit `/api/installers/go@stable.sh` with 6 concurrent curls using different `User-Agent` strings against a fresh process. Every response should have a real `WEBI_VERSION` and `WEBI_PKG_URL`.
- [ ] Smoke: single sequential request still works the same as before.

## Notes

- Discovered while validating a cache-only Node refactor on a sibling branch.
- Production may have been silently affected: depending on traffic patterns, individual packages could become unavailable for arbitrary periods between restarts.
- The `getPackages` signature (`{ Releases, name, date }`) is unchanged. The wrapper threads `args` through to `_doGetPackages`.