### PR TITLE
feat: prefer specific OS, gate .git on unpacker, probe zst/7z, deploy script

### DIFF
--- a/_webi/builds-cacher.js
+++ b/_webi/builds-cacher.js
@@ -742,19 +742,22 @@ BuildsCacher.create = function ({ ALL_TERMS, installers, caches }) {
       return triplets;
     }
 
+    // Prefer platform-specific matches over ANYOS/ANYARCH fallbacks.
+    // This ensures e.g. darwin-aarch64-none matches before
+    // ANYOS-ANYARCH-none (.git source URLs from old releases).
     let oses = [];
     if (hostTarget.os === 'windows') {
-      oses = ['ANYOS', 'windows'];
+      oses = ['windows', 'ANYOS'];
     } else if (hostTarget.os === 'android') {
-      oses = ['ANYOS', 'posix_2017', 'posix_2024', 'android', 'linux'];
+      oses = ['android', 'linux', 'posix_2017', 'posix_2024', 'ANYOS'];
     } else {
-      oses = ['ANYOS', 'posix_2017', 'posix_2024', hostTarget.os];
+      oses = [hostTarget.os, 'posix_2017', 'posix_2024', 'ANYOS'];
     }
 
     let waterfall = HostTargets.WATERFALL[hostTarget.os] || {};
     let arches = waterfall[hostTarget.arch] ||
       HostTargets.WATERFALL.ANYOS[hostTarget.arch] || [hostTarget.arch];
-    arches = ['ANYARCH'].concat(arches);
+    arches = arches.concat(['ANYARCH']);
     let libcs = waterfall[hostTarget.libc] ||
       HostTargets.WATERFALL.ANYOS[hostTarget.libc] || [hostTarget.libc];
 

--- a/_webi/builds-cacher.js
+++ b/_webi/builds-cacher.js
@@ -557,7 +557,10 @@ BuildsCacher.create = function ({ ALL_TERMS, installers, caches }) {
       exts.push('.gz');
       exts.push('.sh');
     }
-    exts.push('.git');
+    let hasGit = formats.includes('git') || formats.includes('.git');
+    if (hasGit) {
+      exts.push('.git');
+    }
 
     // Fallbacks
     // (we include everything to bubble an extract error over not found)

--- a/webi/webi-pwsh.ps1
+++ b/webi/webi-pwsh.ps1
@@ -194,8 +194,11 @@ Write-Host "${TTask}Installing${TReset} ${TName}${exename}${TReset}"
 Write-Host "    ${TDim}Fetching install script ...${TReset}"
 
 $PKG_URL = "$Env:WEBI_HOST/api/installers/$exename.ps1"
-# TODO detect formats
-$UrlParams = "formats=zip,exe,tar,git&libc=msvc"
+$DetectedFormats = @("zip", "exe", "tar")
+if (Get-Command git -ErrorAction SilentlyContinue) { $DetectedFormats += "git" }
+if (Get-Command zstd -ErrorAction SilentlyContinue) { $DetectedFormats += "zst" }
+if (Get-Command 7z -ErrorAction SilentlyContinue) { $DetectedFormats += "7z" }
+$UrlParams = "formats=$($DetectedFormats -join ',')&libc=msvc"
 $PkgInstallPwsh = "$HOME\.local\tmp\$exename.install.ps1"
 Invoke-DownloadUrl -Force -URL $PKG_URL -Params $UrlParams -Path $PkgInstallPwsh
 

--- a/webi/webi.sh
+++ b/webi/webi.sh
@@ -40,6 +40,9 @@ __webi_main() {
     if [ -n "$(command -v git)" ]; then
         my_ext="git,$my_ext"
     fi
+    if [ -n "$(command -v unzstd)" ] || [ -n "$(command -v zstd)" ]; then
+        my_ext="zst,$my_ext"
+    fi
     if [ -n "$(command -v unxz)" ]; then
         my_ext="xz,$my_ext"
     fi


### PR DESCRIPTION
## Summary

Five related changes that together make the resolver pick the right binary instead of accidentally installing source archives, git clones, or just dropping versions on the floor:

1. **`_webi/builds-cacher.js` — `_enumerateTriplets`**: prefer specific OS/arch over `ANYOS`/`ANYARCH`.
2. **`_webi/builds-cacher.js` — `getSortedFormats`**: gate `.git` on the caller's `formats` list, mirroring `.tar.xz`, `.tar.zst`, `.zip`, `.7z`.
3. **`webi/webi.sh`**: probe `unzstd`/`zstd` alongside the existing git/unxz/unzip/tar probes.
4. **`webi/webi-pwsh.ps1`**: replace the hardcoded `formats=zip,exe,tar,git` TODO with `Get-Command` probes for git, zstd, 7z.
5. **`_scripts/deploy-webid`**: rsync deploy with submodule precondition, `_cache` symlink restore, anchored worker pkill, smoke tests.
6. **`_webi/build-classifier`**: bump submodule to pull in [webi-build-classifier#21](https://github.com/webinstall/webi-build-classifier/pull/21) — fixes `maybeInstallable` rejecting any package version ending in `.1`.

## ⚠️ Dependency

Commit 6 bumps the submodule to a SHA on `webinstall/webi-build-classifier#21`'s feature branch. **That PR should land first** so the bumped SHA is reachable from `webi-build-classifier`'s `main`. Without #21, `serviceman v1.0.1` (and any other patch.1 version of a source-archive-only package) is still silently dropped by the classifier and the user gets `v1.0.0` instead.

## Motivation

`serviceman` (and any package with a `*/*/git` fallback alongside per-OS binaries) was resolving to `git` instead of the binary, even on hosts with `git` absent:

```
$ curl -A 'aarch64/unknown Darwin/24.2.0 libc' \
       https://next.webi.sh/api/installers/serviceman@stable.sh
WEBI_EXT='git'
```

Two distinct bugs:

**A. Triplet ordering** — `_enumerateTriplets` produced `ANYOS-*` triplets before specific OS triplets:
```
1: ANYOS-ANYARCH-none      ← serviceman's */*/git matches here
...
7: posix_2017-ANYARCH-none ← serviceman's tar.gz/zip is here
```
`findMatchingPackages` returned the git-only triplet first. The `.git`-as-unpacker gate (commit 2) is correct but downstream — by the time `selectPackage` is called the wrong triplet has already been picked.

**B. Classifier silent drop** — `Triplet.maybeInstallable` checked `build.download.endsWith(ext)` against `TERMS_EXTS_NON_BUILD` which contains `.1` (intended for `manpage.1`). GitHub source-archive URLs of the form `.../tarball/v1.0.1` end in `.1`, so the classifier silently rejected the entire v1.0.1 release. Fixed in webi-build-classifier#21 by checking `build.name` instead.

## Behavior

After this PR + the build-classifier PR:

- **`serviceman` macos/linux any host (default formats)**: `v1.0.1/zip` (was `git` → would fail without git).
- **`serviceman` Windows**: still no Windows binary in the cache (Go-cache content gap, not addressed by this PR — needs `therootcompany/serviceman` fetched alongside `bnnanet/serviceman`).
- **`vim-commentary`** (only-git package): unchanged. `selectPackage`'s `packages.length === 1` early return covers single-option triplets.
- **`webi <pkg>` on a host with zstd**: now sends `?formats=...,zst`.
- **`webi-pwsh.ps1` on Windows**: probes git/zstd/7z via `Get-Command`.

## Test plan

- [x] `npm test` passes.
- [x] PR branch deployed to both `beta.webi.sh` and `next.webi.sh`. Verified `/api/installers/serviceman@stable.sh`:
  - macos arm64 → `v1.0.1/zip` (was `v1.0.1/git` pre-PR; would be `v1.0.0/zip` without commit 6).
  - linux amd64/arm64/musl → same (`v1.0.1/zip`).
  - windows amd64 → `v0.9.8/git` (still broken — cache gap, separately tracked).
- [x] `vim-commentary` still resolves to git correctly.
- [ ] Reviewer: check no regression on a binary-package (e.g. node, jq, bat, fd) at the resolved version/ext level.

## Notes

- Companion to #1073 (race-condition fix in the same file).
- `_scripts/deploy-webid` includes a submodule precondition that catches "I forgot to `git submodule update --init`" before the rsync silently pushes an empty `_webi/build-classifier/`. That scenario broke deploys repeatedly during this PR's testing.

## Commits

```
c69359f chore(build-classifier): bump to fix-maybe-installable-version-suffix
d9c315d fix(builds-cacher): enumerate specific OS/arch before ANYOS/ANYARCH
19673d8 feat(scripts): add deploy-webid with submodule precondition
2d1c082 feat(webi): probe zst as unpacker; properly probe formats in webi-pwsh
28cd129 ref(builds-cacher): gate .git on client-provided unpacker
```

Depends on: **webinstall/webi-build-classifier#21**