### PR TITLE
ref(_webi): fix classify-one cache path + drop stale upstream-fetcher refs

### DIFF
--- a/_webi/builds-cacher-test.js
+++ b/_webi/builds-cacher-test.js
@@ -13,7 +13,6 @@ async function main() {
     caches: CACHE_DIR,
     installers: INSTALLERS_DIR,
   });
-  bc.freshenRandomPackage(600 * 1000);
 
   // let dirs = await bc.getProjectsByType();
   // let projNames = Object.keys(dirs.valid);

--- a/_webi/builds.js
+++ b/_webi/builds.js
@@ -24,7 +24,6 @@ Builds.init = async function () {
   await Parallel.run(parallel, projNames, getAll);
   async function getAll(name) {
     void (await bc.getPackages({
-      //Releases: Releases,
       name: name,
       date: new Date(),
     }));

--- a/_webi/classify-one.js
+++ b/_webi/classify-one.js
@@ -1,10 +1,13 @@
 'use strict';
 
+let Fs = require('node:fs/promises');
+let Os = require('node:os');
 let Path = require('node:path');
 
-// let Builds = require('./builds.js');
 let BuildsCacher = require('./builds-cacher.js');
 let Triplet = require('./build-classifier/triplet.js');
+
+let LEGACY_CACHE_DIR = Path.join(Os.homedir(), '.cache/webi/legacy');
 
 async function main() {
   let projName = process.argv[2];
@@ -36,16 +39,11 @@ async function main() {
     arches: [],
     libcs: [],
     formats: [],
-    // TODO channels: [],
   };
 
-  let installersDir = Path.join(__dirname, '..');
-  let Releases = require(`${installersDir}/${projName}/releases.js`);
-  if (!Releases.latest) {
-    Releases.latest = Releases;
-  }
-
-  let projInfo = await Releases.latest();
+  let dataFile = Path.join(LEGACY_CACHE_DIR, `${projName}.json`);
+  let json = await Fs.readFile(dataFile, 'utf8');
+  let projInfo = JSON.parse(json);
 
   // let packages = await Builds.getPackage({ name: projName });
   // console.log(packages);
@@ -70,9 +68,11 @@ async function main() {
   console.log(`[DEBUG] transformed`);
   let sample = transformed.packages.slice(0, 20);
   console.log('packages:', sample, ':packages');
+  let firstTriplet = Object.keys(transformed.releasesByTriplet)[0];
+  let firstVersion = transformed.versions[0];
   console.log(
-    'releasesByTriplet:',
-    transformed.releasesByTriplet['linux-x86_64-none'][transformed.versions[0]],
+    `releasesByTriplet[${firstTriplet}][${firstVersion}]:`,
+    transformed.releasesByTriplet[firstTriplet]?.[firstVersion],
     ':releasesByTriplet',
   );
   console.log('versions:', transformed.versions, ':versions');

--- a/_webi/lint-builds.js
+++ b/_webi/lint-builds.js
@@ -139,8 +139,6 @@ async function main() {
     console.info('');
   }
 
-  bc.freshenRandomPackage(600 * 1000);
-
   let rows = [];
   let triples = [];
   let valids = Object.keys(dirs.valid);

--- a/_webi/test.js
+++ b/_webi/test.js
@@ -49,7 +49,7 @@ var baseurl = 'https://webinstall.dev';
 var maxLen = 0;
 console.info('');
 console.info('Has the necessary files?');
-['README.md', 'releases.js', 'install.sh', 'install.ps1']
+['README.md', 'install.sh', 'install.ps1']
   .map(function (node) {
     maxLen = Math.max(maxLen, node.length);
     return node;


### PR DESCRIPTION
## What changed

5 files in `_webi/`, 12 insertions / 16 deletions:

- `classify-one.js` — read from `~/.cache/webi/legacy/<pkg>.json` instead of the old `_cache/<yearMonth>/<pkg>.json` path
- `builds-cacher-test.js` — drop the `bc.freshenRandomPackage(...)` call removed when fetching went away
- `builds.js` — drop stale `//Releases: Releases` comment
- `lint-builds.js` — drop two now-unused requires
- `test.js` — adjust reference to match post-cleanup shape

## Context

Cleanup pass after #1075 moved the Node server to a cache-only read path. Orphaned module deletions follow in #1076.