### PR TITLE
feat(installers): install shell completions and man pages

### DIFF
--- a/bat/install.sh
+++ b/bat/install.sh
@@ -28,6 +28,22 @@ __init_bat() {
         # chmod a+x ~/.local/opt/bat-v0.15.4/bin/bat
         chmod a+x "$pkg_src_cmd"
 
+        # install completions if present (autocomplete/)
+        if test -d ./bat-*/autocomplete; then
+            mkdir -p "$pkg_src_dir/share/bash-completion/completions"
+            mkdir -p "$pkg_src_dir/share/fish/vendor_completions.d"
+            mkdir -p "$pkg_src_dir/share/zsh/site-functions"
+            mv ./bat-*/autocomplete/bat.bash "$pkg_src_dir/share/bash-completion/completions/bat" 2>/dev/null || true
+            mv ./bat-*/autocomplete/bat.fish "$pkg_src_dir/share/fish/vendor_completions.d/bat.fish" 2>/dev/null || true
+            mv ./bat-*/autocomplete/bat.zsh "$pkg_src_dir/share/zsh/site-functions/_bat" 2>/dev/null || true
+        fi
+
+        # install man page if present
+        if test -f ./bat-*/bat.1; then
+            mkdir -p "$pkg_src_dir/share/man/man1"
+            mv ./bat-*/bat.1 "$pkg_src_dir/share/man/man1/bat.1"
+        fi
+
         if ! [ -e ~/.config/bat/config ]; then
             mkdir -p ~/.config/bat/
             touch ~/.config/bat/config

--- a/fd/install.sh
+++ b/fd/install.sh
@@ -27,6 +27,22 @@ __init_fd() {
 
         # chmod a+x "$HOME/.local/opt/fd-v8.1.1/bin/fd"
         chmod a+x "$pkg_src_cmd"
+
+        # install completions if present (autocomplete/{fd.bash,fd.fish,_fd})
+        if test -d ./fd-*/autocomplete; then
+            mkdir -p "$pkg_src_dir/share/bash-completion/completions"
+            mkdir -p "$pkg_src_dir/share/fish/vendor_completions.d"
+            mkdir -p "$pkg_src_dir/share/zsh/site-functions"
+            mv ./fd-*/autocomplete/fd.bash "$pkg_src_dir/share/bash-completion/completions/fd" 2>/dev/null || true
+            mv ./fd-*/autocomplete/fd.fish "$pkg_src_dir/share/fish/vendor_completions.d/fd.fish" 2>/dev/null || true
+            mv ./fd-*/autocomplete/_fd "$pkg_src_dir/share/zsh/site-functions/_fd" 2>/dev/null || true
+        fi
+
+        # install man page if present
+        if test -f ./fd-*/fd.1; then
+            mkdir -p "$pkg_src_dir/share/man/man1"
+            mv ./fd-*/fd.1 "$pkg_src_dir/share/man/man1/fd.1"
+        fi
     }
 }
 

--- a/gh/install.sh
+++ b/gh/install.sh
@@ -25,6 +25,12 @@ __init_gh() {
 
         # mv ./gh-*/gh ~/.local/opt/gh-v0.99.9/bin/gh
         mv ./"$pkg_cmd_name"*/bin/gh "$pkg_src_cmd"
+
+        # install man pages if present
+        if test -d ./"$pkg_cmd_name"*/share/man; then
+            mkdir -p "$pkg_src_dir/share"
+            mv ./"$pkg_cmd_name"*/share/man "$pkg_src_dir/share/man"
+        fi
     }
 
     # pkg_get_current_version is recommended, but (soon) not required

--- a/goreleaser/install.sh
+++ b/goreleaser/install.sh
@@ -25,6 +25,23 @@ __init_goreleaser() {
 
         # mv ./goreleaser-*/goreleaser ~/.local/opt/goreleaser-v1.21.2/bin/goreleaser
         mv ./goreleaser "$pkg_src_cmd"
+
+        # install completions if present (completions/{goreleaser.bash,.fish,.zsh})
+        if test -d ./completions; then
+            mkdir -p "$pkg_src_dir/share/bash-completion/completions"
+            mkdir -p "$pkg_src_dir/share/fish/vendor_completions.d"
+            mkdir -p "$pkg_src_dir/share/zsh/site-functions"
+            mv ./completions/goreleaser.bash "$pkg_src_dir/share/bash-completion/completions/goreleaser" 2>/dev/null || true
+            mv ./completions/goreleaser.fish "$pkg_src_dir/share/fish/vendor_completions.d/goreleaser.fish" 2>/dev/null || true
+            mv ./completions/goreleaser.zsh "$pkg_src_dir/share/zsh/site-functions/_goreleaser" 2>/dev/null || true
+        fi
+
+        # install man page if present (manpages/goreleaser.1.gz)
+        if test -d ./manpages; then
+            mkdir -p "$pkg_src_dir/share/man/man1"
+            mv ./manpages/*.1.gz "$pkg_src_dir/share/man/man1/" 2>/dev/null || true
+            mv ./manpages/*.1 "$pkg_src_dir/share/man/man1/" 2>/dev/null || true
+        fi
     }
 
     # pkg_get_current_version is recommended, but (soon) not required

--- a/lsd/install.sh
+++ b/lsd/install.sh
@@ -25,6 +25,22 @@ __init_lsd() {
 
         # mv ./lsd-*/lsd ~/.local/opt/lsd-v0.17.0/bin/lsd
         mv ./lsd-*/lsd "$pkg_src_cmd"
+
+        # install completions if present (autocomplete/{_lsd,lsd.fish,lsd.bash-completion})
+        if test -d ./lsd-*/autocomplete; then
+            mkdir -p "$pkg_src_dir/share/bash-completion/completions"
+            mkdir -p "$pkg_src_dir/share/fish/vendor_completions.d"
+            mkdir -p "$pkg_src_dir/share/zsh/site-functions"
+            mv ./lsd-*/autocomplete/lsd.bash-completion "$pkg_src_dir/share/bash-completion/completions/lsd" 2>/dev/null || true
+            mv ./lsd-*/autocomplete/lsd.fish "$pkg_src_dir/share/fish/vendor_completions.d/lsd.fish" 2>/dev/null || true
+            mv ./lsd-*/autocomplete/_lsd "$pkg_src_dir/share/zsh/site-functions/_lsd" 2>/dev/null || true
+        fi
+
+        # install man page if present
+        if test -f ./lsd-*/lsd.1; then
+            mkdir -p "$pkg_src_dir/share/man/man1"
+            mv ./lsd-*/lsd.1 "$pkg_src_dir/share/man/man1/lsd.1"
+        fi
     }
 
     # pkg_get_current_version is recommended, but (soon) not required

--- a/pandoc/install.sh
+++ b/pandoc/install.sh
@@ -25,6 +25,12 @@ __init_pandoc() {
 
         # mv ./pandoc-*/pandoc ~/.local/opt/pandoc-v2.10.1/bin/pandoc
         mv ./pandoc-*/bin/pandoc "$pkg_src_cmd"
+
+        # install man pages if present (share/man/man1/pandoc*.1.gz)
+        if test -d ./pandoc-*/share/man; then
+            mkdir -p "$pkg_src_dir/share"
+            mv ./pandoc-*/share/man "$pkg_src_dir/share/man"
+        fi
     }
 
     # pkg_get_current_version is recommended, but (soon) not required

--- a/rg/install.sh
+++ b/rg/install.sh
@@ -26,6 +26,22 @@ __init_rg() {
         # mv ./ripgrep-*/rg ~/.local/opt/rg-v12.1.1/bin/rg
         mv ./ripgrep-*/rg "$pkg_src_cmd"
 
+        # install completions if present (complete/_rg, complete/rg.bash, complete/rg.fish)
+        if test -d ./ripgrep-*/complete; then
+            mkdir -p "$pkg_src_dir/share/bash-completion/completions"
+            mkdir -p "$pkg_src_dir/share/fish/vendor_completions.d"
+            mkdir -p "$pkg_src_dir/share/zsh/site-functions"
+            mv ./ripgrep-*/complete/rg.bash "$pkg_src_dir/share/bash-completion/completions/rg" 2>/dev/null || true
+            mv ./ripgrep-*/complete/rg.fish "$pkg_src_dir/share/fish/vendor_completions.d/rg.fish" 2>/dev/null || true
+            mv ./ripgrep-*/complete/_rg "$pkg_src_dir/share/zsh/site-functions/_rg" 2>/dev/null || true
+        fi
+
+        # install man page if present
+        if test -f ./ripgrep-*/doc/rg.1; then
+            mkdir -p "$pkg_src_dir/share/man/man1"
+            mv ./ripgrep-*/doc/rg.1 "$pkg_src_dir/share/man/man1/rg.1"
+        fi
+
         if ! [ -e ~/.ripgreprc ]; then
             touch ~/.ripgreprc
         fi

--- a/sd/install.sh
+++ b/sd/install.sh
@@ -29,9 +29,21 @@ __init_sd() {
             # ~/.local/opt/sd-v0.99.9/bin
             mkdir -p "$(dirname "$pkg_src_cmd")"
             mv sd-*/sd "$pkg_src_cmd"
+
+            # install completions if present (completions/{sd.bash,sd.fish,_sd})
+            if test -d sd-*/completions; then
+                mkdir -p "$pkg_src_dir/share/bash-completion/completions"
+                mkdir -p "$pkg_src_dir/share/fish/vendor_completions.d"
+                mkdir -p "$pkg_src_dir/share/zsh/site-functions"
+                mv sd-*/completions/sd.bash "$pkg_src_dir/share/bash-completion/completions/sd" 2>/dev/null || true
+                mv sd-*/completions/sd.fish "$pkg_src_dir/share/fish/vendor_completions.d/sd.fish" 2>/dev/null || true
+                mv sd-*/completions/_sd "$pkg_src_dir/share/zsh/site-functions/_sd" 2>/dev/null || true
+            fi
+
+            # install man page if present
             if test -f sd-*/sd.1; then
                 mkdir -p "$pkg_src_dir/share/man/man1"
-                mv sd-*/sd.1 "$pkg_src_dir/share/man/man1"
+                mv sd-*/sd.1 "$pkg_src_dir/share/man/man1/sd.1"
             fi
         elif test -d sd-*/bin; then
             mv sd-* "$pkg_src_dir"

--- a/watchexec/install.sh
+++ b/watchexec/install.sh
@@ -25,6 +25,22 @@ __init_watchexec() {
 
         # mv ./watchexec-*/watchexec ~/.local/opt/watchexec-v0.99.9/bin/watchexec
         mv ./watchexec-*/watchexec "$pkg_src_cmd"
+
+        # install completions if present (completions/{bash,fish,zsh})
+        if test -d ./watchexec-*/completions; then
+            mkdir -p "$pkg_src_dir/share/bash-completion/completions"
+            mkdir -p "$pkg_src_dir/share/fish/vendor_completions.d"
+            mkdir -p "$pkg_src_dir/share/zsh/site-functions"
+            mv ./watchexec-*/completions/bash "$pkg_src_dir/share/bash-completion/completions/watchexec" 2>/dev/null || true
+            mv ./watchexec-*/completions/fish "$pkg_src_dir/share/fish/vendor_completions.d/watchexec.fish" 2>/dev/null || true
+            mv ./watchexec-*/completions/zsh "$pkg_src_dir/share/zsh/site-functions/_watchexec" 2>/dev/null || true
+        fi
+
+        # install man page if present
+        if test -f ./watchexec-*/watchexec.1; then
+            mkdir -p "$pkg_src_dir/share/man/man1"
+            mv ./watchexec-*/watchexec.1 "$pkg_src_dir/share/man/man1/watchexec.1"
+        fi
     }
 
     # pkg_get_current_version is recommended, but (soon) not required

--- a/zoxide/install.sh
+++ b/zoxide/install.sh
@@ -25,6 +25,22 @@ __init_zoxide() {
 
         # mv ./zoxide "~/.local/opt/zoxide-v0.99.9/bin/zoxide"
         mv ./zoxide "$pkg_src_cmd"
+
+        # install completions if present
+        if test -d ./completions; then
+            mkdir -p "$pkg_src_dir/share/bash-completion/completions"
+            mkdir -p "$pkg_src_dir/share/fish/vendor_completions.d"
+            mkdir -p "$pkg_src_dir/share/zsh/site-functions"
+            mv ./completions/zoxide.bash "$pkg_src_dir/share/bash-completion/completions/zoxide" 2>/dev/null || true
+            mv ./completions/zoxide.fish "$pkg_src_dir/share/fish/vendor_completions.d/zoxide.fish" 2>/dev/null || true
+            mv ./completions/_zoxide "$pkg_src_dir/share/zsh/site-functions/_zoxide" 2>/dev/null || true
+        fi
+
+        # install man pages if present
+        if test -d ./man; then
+            mkdir -p "$pkg_src_dir/share"
+            mv ./man "$pkg_src_dir/share/man"
+        fi
     }
 
     # pkg_get_current_version is recommended, but (soon) not required


### PR DESCRIPTION
## Summary

For installers that ship completions/man pages in their release archives, install them into `pkg_src_dir/share/` at install time.

**Shell completions** (bash/fish/zsh) and **man pages** added for:
- `bat`, `fd`, `lsd`, `rg`, `watchexec`, `zoxide` — completions from `autocomplete/` or `completions/`
- `goreleaser` — completions from `completions/`, man pages from `manpages/`
- `gh` — man pages from `share/man/`
- `pandoc` — man pages from `share/man/`
- `sd` — completions from `completions/`, man page `sd.1`

Split out from the same commit as #1085 (releases.conf). Archive format fixes are in #1086.

## Test plan

- [ ] `webi bat` — completions land in `~/.local/opt/bat-*/share/bash-completion/completions/bat`
- [ ] `webi goreleaser` — completions in `share/`, man page in `share/man/man1/`
- [ ] `webi gh` — man pages in `share/man/`
- [ ] `webi pandoc` — man pages in `share/man/`
- [ ] `webi sd` — completions in `share/`, man page `sd.1` in `share/man/man1/`