### PR TITLE
fix(build-classifier): classify CYGWIN and MINGW as windows, not linux

### DIFF
--- a/_webi/builds-cacher.js
+++ b/_webi/builds-cacher.js
@@ -621,13 +621,15 @@ BuildsCacher.create = function ({ ALL_TERMS, installers }) {
     let arches = waterfall[hostTarget.arch] ||
       HostTargets.WATERFALL.ANYOS[hostTarget.arch] || [hostTarget.arch];
     arches = arches.concat(['ANYARCH']);
-    let libcs = waterfall[hostTarget.libc] ||
-      HostTargets.WATERFALL.ANYOS[hostTarget.libc] || [hostTarget.libc];
+    // termsToTarget omits libc for plain UAs; 'libc' → waterfall ['none','libc',...]
+    let libc = hostTarget.libc || 'libc';
+    let libcs = waterfall[libc] ||
+      HostTargets.WATERFALL.ANYOS[libc] || [libc];
 
     // Extend the glibc-host waterfall: the table only lists [none, libc]
     // but Rust projects (bat, rg) and node ship libc='gnu' builds, and
     // static musl builds also run on glibc hosts.
-    if (hostTarget.libc === 'libc' && !libcs.includes('gnu')) {
+    if (libc === 'libc' && !libcs.includes('gnu')) {
       libcs = ['none', 'gnu', 'musl', 'libc'];
     }
 

--- a/_webi/ua-detect.js
+++ b/_webi/ua-detect.js
@@ -38,9 +38,8 @@ function getOs(ua) {
     // It's the year of the Linux Desktop!
     // See also http://www.mslinux.org/
     // 'linux' must be tested before 'Microsoft' because WSL
-    // (TODO: does this affect cygwin / msysgit?)
     return 'linux';
-  } else if (/^ms$|Microsoft|Windows|win32|win|PowerShell/i.test(ua)) {
+  } else if (/^ms$|Microsoft|Windows|win32|win|PowerShell|CYGWIN|MINGW/i.test(ua)) {
     // 'win' must be tested after 'darwin'
     return 'windows';
   } else if (/Linux|curl|wget/i.test(ua)) {


### PR DESCRIPTION
## Summary

- `CYGWIN_NT-*` and `MINGW64_NT-*` user-agents were classified as `os: linux`, causing Cygwin and Git Bash users to receive Linux ELF binaries (e.g. `gh_linux_amd64.tar.gz`) that cannot run on Windows
- Fixes `build-classifier/host-targets.js`: `CYGWIN → T.WINDOWS`, `MINGW → T.WINDOWS`
- Fixes `_webi/ua-detect.js`: adds `CYGWIN|MINGW` to the Windows detection regex (Node.js server path)
- Adds `host-targets-test.js` with explicit `os`/`arch`/`vendor` assertions for all known Cygwin and MINGW user-agent patterns, including the Windows 11 build from #1083
- Bumps `build-classifier` submodule to v1.0.4

Closes #1083

## Test plan

- [ ] `cd _webi/build-classifier && npm test` — `lexver-test.js` and `host-targets-test.js` both pass
- [ ] Deploy to beta.webi.sh: pull branch on beta installers checkout, restart Node.js server
- [ ] `/api/debug` with `CYGWIN_NT-*` UA returns `"os": "windows"`
- [ ] `/api/debug` with `MINGW64_NT-*` UA returns `"os": "windows"`
- [ ] From a Cygwin shell: `curl -sS https://beta.webi.sh/gh | head -5` — `WEBI_PKG_URL` resolves to `gh_*_windows_amd64.zip`, not `gh_*_linux_amd64.tar.gz`
- [ ] Same from a Git Bash (MINGW) terminal