### PR TITLE
fix(sshd-prohibit-password): fix garbled sentence in cheat sheet

### DIFF
--- a/ssh-adduser/ssh-adduser
+++ b/ssh-adduser/ssh-adduser
@@ -70,7 +70,7 @@ main() {
         echo ""
         echo "    'ssh-adduser' no longer checks or hardens /etc/ssh/sshd_config"
         echo ""
-        echo "    Run 'sshd-probihit-password' to secure /etc/ssh/sshd_config"
+        echo "    Run 'sshd-prohibit-password' to secure /etc/ssh/sshd_config"
         echo ""
     fi
 

--- a/ssh-harden/README.md
+++ b/ssh-harden/README.md
@@ -1,6 +1,6 @@
 ---
 title: SSH Prohibit Password
-homepage: https://webinstall.dev/ssh-prohibit-password
+homepage: https://webinstall.dev/sshd-prohibit-password
 tagline: |
   SSH Prohibit Password: Because friends don't let friends ssh with passwords
 linux: true
@@ -8,9 +8,8 @@ linux: true
 
 ## Cheat Sheet
 
-> Will check if your system This will check if your Modern SSH deployments are
-> key-only and don't allow root login. However, there's a lot of legacy systems
-> out there.
+> Modern SSH deployments are key-only and don't allow root login. However,
+> there's a lot of legacy systems out there.
 
 `ssh-harden` will
 

--- a/sshd-prohibit-password/README.md
+++ b/sshd-prohibit-password/README.md
@@ -19,9 +19,8 @@ install:
 
 ## Cheat Sheet
 
-> Will check if your system This will check if your Modern SSH deployments are
-> key-only and don't allow root login. However, there's a lot of legacy systems
-> out there.
+> Modern SSH deployments are key-only and don't allow root login. However,
+> there's a lot of legacy systems out there.
 
 `sshd-prohibit-password` will inspect `/etc/ssh/sshd_config` and
 


### PR DESCRIPTION
## Summary

- Fix garbled sentence in `sshd-prohibit-password/README.md` cheat sheet (duplicate fragment from edit)
- Fix `ssh-harden/README.md` homepage URL (`ssh-prohibit-password` → `sshd-prohibit-password`)
- Fix typo in `ssh-adduser/ssh-adduser` script output (`sshd-probihit-password` → `sshd-prohibit-password`)

## Test plan

- [ ] `sshd-prohibit-password/README.md` — cheat sheet description reads cleanly, no duplicate fragment
- [ ] `ssh-harden/README.md` — homepage URL points to `sshd-prohibit-password`
- [ ] `ssh-adduser/ssh-adduser` — run `ssh-adduser` on a system where `/etc/ssh/sshd_config` is not yet hardened; verify the hint message spells `sshd-prohibit-password` correctly