### PR TITLE
fix(ua-detect): classify CYGWIN and MINGW user-agents as windows

### DIFF
--- a/_webi/ua-detect.js
+++ b/_webi/ua-detect.js
@@ -38,10 +38,10 @@ function getOs(ua) {
     // It's the year of the Linux Desktop!
     // See also http://www.mslinux.org/
     // 'linux' must be tested before 'Microsoft' because WSL
-    // (TODO: does this affect cygwin / msysgit?)
     return 'linux';
-  } else if (/^ms$|Microsoft|Windows|win32|win|PowerShell/i.test(ua)) {
+  } else if (/^ms$|Microsoft|Windows|win32|win|PowerShell|CYGWIN|MINGW/i.test(ua)) {
     // 'win' must be tested after 'darwin'
+    // CYGWIN_NT-* and MINGW64_NT-* are Windows hosts running Cygwin/Git Bash
     return 'windows';
   } else if (/Linux|curl|wget/i.test(ua)) {
     // test 'linux' again, after 'win'


### PR DESCRIPTION
Replaced by #1088 

## Summary

- CYGWIN_NT-* and MINGW64_NT-* user-agents were falling through to the `curl/wget` fallback in `_webi/ua-detect.js` and returning `os: linux`
- This caused Cygwin and Git Bash users to receive Linux ELF binaries when using the Node.js server path
- Adds `CYGWIN|MINGW` to the Windows detection regex (same fix as #1088 makes in the Go classifier and `build-classifier` submodule)

Companion to #1088.

## Test plan

- [ ] `curl -sS https://beta.webi.sh/gh` from a Cygwin shell — should download `gh_*_windows_amd64.zip`
- [ ] `curl -sS https://beta.webi.sh/gh` from a Git Bash (MINGW) terminal — same
- [ ] `/api/debug` with `CYGWIN_NT-*` UA should return `"os": "windows"`