### PR TITLE
fix(mariadb-galera): remove obsolete package

### DIFF
--- a/mariadb-galera/releases.conf
+++ b/mariadb-galera/releases.conf
@@ -1,2 +1,0 @@
-source = mariadbdist
-asset_filter = galera


### PR DESCRIPTION
## Summary

- Removes `mariadb-galera/releases.conf`
- Galera has been bundled into MariaDB Server since 10.1 — no separate releases exist
- The MariaDB REST API products endpoint confirms this explicitly: _"There are no longer separate MariaDB Galera Cluster releases for MariaDB 10.1 and above. Simply download MariaDB from https://mariadb.org/download/ (10.1 or above) and configure your cluster."_
- The package was producing 0 assets because the API no longer includes galera in its `files[]` arrays

## Test plan

- [x] Verify `mariadb-galera` no longer appears in the webicached package list after deploy — confirmed: not present in logs on beta or next after deploy