### PR TITLE
fix(deploy): exclude .claude worktrees from releases.conf rsync

### DIFF
--- a/scripts/deploy-webicached.sh
+++ b/scripts/deploy-webicached.sh
@@ -11,13 +11,13 @@ g_out="agents/tmp/${g_bin}"
 g_remote_bin="~/bin/${g_bin}"
 
 case "${g_host}" in
-beta.webi.sh) g_remote_conf="~/srv/beta.webinstall.dev/installers/" ;;
-next.webi.sh) g_remote_conf="~/srv/next.webinstall.dev/installers/" ;;
-*) g_remote_conf="~/srv/webid/installers/" ;;
+	beta.webi.sh) g_remote_conf="~/srv/beta.webinstall.dev/installers/" ;;
+	next.webi.sh) g_remote_conf="~/srv/next.webinstall.dev/installers/" ;;
+	*) g_remote_conf="~/srv/webid/installers/" ;;
 esac
 
 fn_build() {
-	b_version="$(git describe --tags --always 2>/dev/null || echo '0.0.0-dev')"
+	b_version="$(git describe --tags --always 2> /dev/null || echo '0.0.0-dev')"
 	b_commit="$(git rev-parse --short HEAD)"
 	b_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 	b_ldflags="-X main.version=${b_version} -X main.commit=${b_commit} -X main.date=${b_date}"
@@ -29,14 +29,14 @@ fn_build() {
 
 fn_deploy() {
 	printf 'Stopping %s on %s...\n' "${g_bin}" "${g_host}"
-	ssh "${g_host}" "~/.local/bin/serviceman stop ${g_bin}" 2>/dev/null || true
+	ssh "${g_host}" "~/.local/bin/serviceman stop ${g_bin}" 2> /dev/null || true
 
 	printf 'Uploading binary...\n'
 	scp "${g_out}" "${g_host}:${g_remote_bin}"
 
 	printf 'Syncing releases.conf files...\n'
 	rsync -av \
-		--exclude='_cache' --exclude='.git' --exclude='agents' \
+		--exclude='_cache' --exclude='.git' --exclude='.claude' --exclude='agents' \
 		--exclude='bin' --exclude='cmd' --exclude='internal' \
 		--exclude='docs' --exclude='scripts' --exclude='node_modules' \
 		--include='*/' --include='releases.conf' --exclude='*' \


### PR DESCRIPTION
## Summary

- Adds `--exclude='.claude'` to the rsync in `deploy-webicached.sh`
- Without this, worktrees under `.claude/worktrees/` were picked up by the `--include='releases.conf'` rule, syncing ~1300 extra files to the server on every deploy from the main repo root

## Test plan

- [x] Verified rsync now transfers only the expected installer `releases.conf` files