### PR TITLE
fix(deploy): add webi.sh prod target with correct installers path

### DIFF
--- a/scripts/deploy-webicached.sh
+++ b/scripts/deploy-webicached.sh
@@ -11,13 +11,14 @@ g_out="agents/tmp/${g_bin}"
 g_remote_bin="~/bin/${g_bin}"
 
 case "${g_host}" in
-beta.webi.sh) g_remote_conf="~/srv/beta.webinstall.dev/installers/" ;;
-next.webi.sh) g_remote_conf="~/srv/next.webinstall.dev/installers/" ;;
-*) g_remote_conf="~/srv/webid/installers/" ;;
+	beta.webi.sh) g_remote_conf="~/srv/beta.webinstall.dev/installers/" ;;
+	next.webi.sh) g_remote_conf="~/srv/next.webinstall.dev/installers/" ;;
+	webi.sh) g_remote_conf="~/srv/webinstall.dev/installers/" ;;
+	*) g_remote_conf="~/srv/webinstall.dev/installers/" ;;
 esac
 
 fn_build() {
-	b_version="$(git describe --tags --always 2>/dev/null || echo '0.0.0-dev')"
+	b_version="$(git describe --tags --always 2> /dev/null || echo '0.0.0-dev')"
 	b_commit="$(git rev-parse --short HEAD)"
 	b_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 	b_ldflags="-X main.version=${b_version} -X main.commit=${b_commit} -X main.date=${b_date}"
@@ -29,7 +30,7 @@ fn_build() {
 
 fn_deploy() {
 	printf 'Stopping %s on %s...\n' "${g_bin}" "${g_host}"
-	ssh "${g_host}" "~/.local/bin/serviceman stop ${g_bin}" 2>/dev/null || true
+	ssh "${g_host}" "~/.local/bin/serviceman stop ${g_bin}" 2> /dev/null || true
 
 	printf 'Uploading binary...\n'
 	scp "${g_out}" "${g_host}:${g_remote_bin}"


### PR DESCRIPTION
## Summary
- Adds explicit `webi.sh` case to deploy script with correct `~/srv/webinstall.dev/installers/` path
- Fixes fallback that was incorrectly using `~/srv/webid/installers/` for prod