### PR TITLE
fix: fix an issue with the ps1 version of the fd installer

### DIFF
--- a/fd/install.ps1
+++ b/fd/install.ps1
@@ -24,7 +24,13 @@ if (!(Test-Path -Path "$Env:USERPROFILE\.local\bin\$VERNAME")) {
     Write-Output "Unpacking $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
     & tar xf "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
     # Move single binary into root of temporary folder
-    & Move-Item "$Env:WEBI_PKG_FILE\$EXENAME" "$VERNAME"
+    # Handle both old layout (bare fd.exe) and new layout (fd-v*\fd.exe)
+    if (Test-Path -Path ".\$EXENAME") {
+        & Move-Item "$EXENAME" "$VERNAME"
+    }
+    elseif (Test-Path -Path ".\$Env:PKG_NAME-*\$EXENAME") {
+        & Move-Item ".\$Env:PKG_NAME-*\$EXENAME" "$VERNAME"
+    }
 
 
     # Settle unpacked archive into place

--- a/fd/install.ps1
+++ b/fd/install.ps1
@@ -24,7 +24,7 @@ if (!(Test-Path -Path "$Env:USERPROFILE\.local\bin\$VERNAME")) {
     Write-Output "Unpacking $Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
     & tar xf "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"
     # Move single binary into root of temporary folder
-    & Move-Item "$EXENAME" "$VERNAME"
+    & Move-Item "$Env:WEBI_PKG_FILE\$EXENAME" "$VERNAME"
 
 
     # Settle unpacked archive into place


### PR DESCRIPTION
it tried to move the .exe file but couldn't find it due to not being declared in the script instructions it resolves #1065 