### PR TITLE
fix(webicached): add --tags to git fetch and modernize Go string ops

### DIFF
--- a/internal/releases/gittag/gittag.go
+++ b/internal/releases/gittag/gittag.go
@@ -91,7 +91,7 @@ func Fetch(ctx context.Context, gitURL, repoDir string) iter.Seq2[[]Entry, error
 func ensureRepo(ctx context.Context, repoPath, gitURL string) error {
 	if _, err := os.Stat(repoPath); err == nil {
 		// Exists — fetch updates.
-		cmd := exec.CommandContext(ctx, "git", "--git-dir="+repoPath, "fetch")
+		cmd := exec.CommandContext(ctx, "git", "--git-dir="+repoPath, "fetch", "--tags")
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
 	}


### PR DESCRIPTION
## Summary

**Bug fix:** `gittag.Fetch` runs `git fetch` without `--tags`, which misses tags not reachable from any branch. This causes stale version lists for packages fetched via gittag.

**Modern Go (Go 1.24+):** Replace legacy string patterns with idiomatic modern Go:
- `strings.SplitSeq` instead of `strings.Split` for iteration
- `strings.Cut`/`CutPrefix`/`CutSuffix` instead of `Index`/`HasPrefix`/`TrimSuffix`
- `min()` builtin instead of manual min logic

**Test fix:** `node_test` was calling `nodedist.Fetch(ctx, client)` with 2 args but the function now requires 3 (`ctx, client, baseURL`).

## Files changed

| File | Change |
|------|--------|
| `internal/releases/gittag/gittag.go` | **Bug fix:** add `--tags` to `git fetch` |
| `internal/lexver/lexver.go` | `strings.SplitSeq` |
| `internal/releases/gittag/gittag.go` | `strings.SplitSeq` |
| `internal/releases/git/versions.go` | `strings.Cut` |
| `internal/classifypkg/classifypkg.go` | `strings.CutPrefix` |
| `internal/storage/fsstore/fsstore.go` | `strings.CutSuffix` |
| `internal/httpclient/httpclient.go` | `min()` builtin |
| `internal/releases/node/node_test.go` | Pass required `baseURL` arg |
| 10 other files | Struct field alignment (readability) |
